### PR TITLE
postprocess: Don't g_critical if previous commit doesn't have version

### DIFF
--- a/src/rpmostree-postprocess.c
+++ b/src/rpmostree-postprocess.c
@@ -1543,13 +1543,13 @@ rpmostree_commit (GFile         *rootfs,
 
   if (metadata && parent_revision)
     {
-      gs_unref_variant GVariant *md_version = g_variant_lookup_value (metadata,
-                                                                      "version",
-                                                                      NULL);
-      const char *version = g_variant_get_string (md_version, NULL);
+      const char *version = NULL;
 
-      if (!metadata_version_unique (repo, parent_revision, version, error))
-        goto out;
+      if (g_variant_lookup (metadata, "version", "&s", &version))
+        {
+          if (!metadata_version_unique (repo, parent_revision, version, error))
+            goto out;
+        }
     }
 
   if (!ostree_repo_write_commit (repo, parent_revision, "", "", metadata,


### PR DESCRIPTION
I sometimes run "rpm-ostree compose tree" directly, mainly so I can
use gdb and/or nonstandard options.  In this case I don't get
version numbers injected.

That happens to trigger a bug in this code.