### PR TITLE
compose: Use *at() relative lookups for xattrs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,9 @@ AC_SUBST(CAP_LIBS)
 LIBS="$save_LIBS"
 
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
-PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 json-glib-1.0 ostree-1 >= 2014.13 libgsystem rpm hawkey])
+PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 json-glib-1.0
+				     ostree-1 >= 2014.13 libgsystem >= 2014.3
+				     rpm hawkey])
 AC_PATH_PROG([XSLTPROC], [xsltproc])
 
 GLIB_TESTS


### PR DESCRIPTION
This matches recent work in OSTree to use *at() - it's faster and less
prone to error.  In the case of directories which are mutable by
processes in different security domains, it's more secure too.  (That's
not the case here though).