### PR TITLE
compose: Fix lookup of previous /etc/passwd

### DIFF
--- a/src/rpmostree-passwd-util.c
+++ b/src/rpmostree-passwd-util.c
@@ -677,10 +677,11 @@ concat_passwd_file (GFile           *yumroot,
 {
   gboolean ret = FALSE;
   gs_free char *etc_subpath = g_strconcat ("etc/", filename, NULL);
+  gs_free char *usretc_subpath = g_strconcat ("usr/etc/", filename, NULL);
   gs_free char *usrlib_subpath = g_strconcat ("usr/lib/", filename, NULL);
   gs_unref_object GFile *yumroot_etc = g_file_resolve_relative_path (yumroot, "etc");
   gs_unref_object GFile *yumroot_dest = g_file_resolve_relative_path (yumroot, etc_subpath);
-  gs_unref_object GFile *orig_etc_content = g_file_resolve_relative_path (previous_commit, etc_subpath);
+  gs_unref_object GFile *orig_etc_content = g_file_resolve_relative_path (previous_commit, usretc_subpath);
   gs_unref_object GFile *orig_usrlib_content = g_file_resolve_relative_path (previous_commit, usrlib_subpath);
   gs_unref_object GFileOutputStream *out = NULL;
   gboolean have_etc, have_usr;


### PR DESCRIPTION
I swear I tested this, but anyways
https://github.com/projectatomic/rpm-ostree/pull/79
wasn't quite right.  We need to look at /usr/etc/{passwd,group}
for previous data.

We happily noticed there was no /etc/passwd in the tree, then
proceeded to do the merge and split again, with the result
of an empty /usr/etc/passwd in the new tree.

That in turn resulted in an empty /etc/passwd in an installed system,
i.e. with no "root" user, with obvious bad consequences, namely in my
case crashing Anaconda.

(Yes, I will write a testsuite for this)