### PR TITLE
passwd: Avoid EINVAL if previous passwd data is empty somehow

### DIFF
--- a/src/rpmostree-passwd-util.c
+++ b/src/rpmostree-passwd-util.c
@@ -893,6 +893,9 @@ concat_passwd_file (GFile           *yumroot,
       if (!g_file_load_contents (source, cancellable,
                                  &contents, &len, NULL, error))
         goto out;
+
+      if (len == 0)
+        continue;
       
       if (src_stream) (void) fclose (src_stream);
       src_stream = fmemopen (contents, len, "r");


### PR DESCRIPTION
Maybe we should make this into an explicit error, but anyways
I somehow ended up with an empty /usr/etc/passwd in the tree
contents, I think due to bugs in earlier work there.

This causes fmemopen to return EINVAL, which errors out the
compose.  Let's stumble forwards here.

Now that I think about it, it might be a valid case to have an
existant but empty /usr/etc/passwd in the tree - when we migrate to
systemd-sysusers, I think we'll want an empty file there by default.