### PR TITLE
passwd-util: Drop unnecessary #include

### DIFF
--- a/src/rpmostree-passwd-util.c
+++ b/src/rpmostree-passwd-util.c
@@ -29,7 +29,6 @@
 #include <pwd.h>
 #include <grp.h>
 
-#include "rpmostree-compose-builtins.h"
 #include "rpmostree-util.h"
 #include "rpmostree-json-parsing.h"
 #include "rpmostree-cleanup.h"


### PR DESCRIPTION
This was breaking the

    make -C packaging -f Makefile.dist-packaging dist-snapshot-without-compose-tooling

build.