### PR TITLE
passwd: Use check-* file json config. entries to migrate data across commits

### DIFF
--- a/doc/treefile.md
+++ b/doc/treefile.md
@@ -66,11 +66,12 @@ Treefile
    Note this does not alter the RPM database, so `rpm -V` will complain.
 
  * `preserve-passwd`: boolean, optional: Defaults to `true`.  If enabled,
-   copy the `/etc/passwd` (and `/usr/lib/passwd`) files from the previous commit
-   if they exist.  This helps ensure consistent uid/gid allocations across
-   builds.  However, it does mean that removed users will exist in the `passwd`
-   database forever.  It also does not help clients switch between unrelated
-   trees.
+   and `check-passwd` has a type other than file, copy the `/etc/passwd` (and
+   `/usr/lib/passwd`) files from the previous commit if they exist. If
+   check-passwd has the file type, then the data is preserved from that file to
+   `/usr/lib/passwd`.
+   This helps ensure consistent uid/gid allocations across builds.  However, it
+   does mean that removed users will exist in the `passwd` database forever.
 
  * `check-passwd`: Object, optional: Checks to run against the new passwd file
    before accepting the tree. All the entries specified should exist (unless
@@ -78,6 +79,8 @@ Treefile
    types: none (for no checking), previous (to check against the passwd file in
    the previous commit), file (to check against another passwd file), and data
    to specify the relevant passwd data in the json itself.
+   Note that if you choose file, and preserve-passwd is true then the data will
+   be copied from the referenced file and not the previous commit.
 
    Example: `check-passwd: { "type": "none" }`
    Example: `check-passwd: { "type": "previous" }`
@@ -91,6 +94,8 @@ Treefile
    types: none (for no checking), previous (to check against the group file in
    the previous commit), file (to check against another group file), and data
    to specify the relevant group data in the json itself.
+   Note that if you choose file, and preserve-passwd is true then the data will
+   be copied from the referenced file and not the previous commit.
 
    Example: `check-groups: { "type": "none" }`
    Example: `check-groups: { "type": "previous" }`

--- a/src/rpmostree-compose-builtin-tree.c
+++ b/src/rpmostree-compose-builtin-tree.c
@@ -786,6 +786,7 @@ rpmostree_compose_builtin_tree (int             argc,
   gs_unref_ptrarray GPtrArray *bootstrap_packages = NULL;
   gs_unref_ptrarray GPtrArray *packages = NULL;
   gs_unref_object GFile *treefile_path = NULL;
+  gs_unref_object GFile *treefile_dirpath = NULL;
   gs_unref_object GFile *repo_path = NULL;
   gs_unref_object JsonParser *treefile_parser = NULL;
   gs_unref_variant_builder GVariantBuilder *metadata_builder = 
@@ -1022,7 +1023,8 @@ rpmostree_compose_builtin_tree (int             argc,
     self->serialized_treefile = g_bytes_new_take (treefile_buf, len);
   }
 
-  if (previous_root != NULL)
+  treefile_dirpath = g_file_get_parent (treefile_path);
+  if (TRUE)
     {
       gboolean generate_from_previous = TRUE;
 
@@ -1034,7 +1036,9 @@ rpmostree_compose_builtin_tree (int             argc,
 
       if (generate_from_previous)
         {
-          if (!rpmostree_generate_passwd_from_previous (repo, yumroot, previous_root,
+          if (!rpmostree_generate_passwd_from_previous (repo, yumroot,
+                                                        treefile_dirpath,
+                                                        previous_root, treefile,
                                                         cancellable, error))
             goto out;
         }
@@ -1076,11 +1080,11 @@ rpmostree_compose_builtin_tree (int             argc,
   if (!rpmostree_prepare_rootfs_for_commit (yumroot, treefile, cancellable, error))
     goto out;
 
-  if (!rpmostree_check_passwd (repo, yumroot, treefile_path, treefile,
+  if (!rpmostree_check_passwd (repo, yumroot, treefile_dirpath, treefile,
                                cancellable, error))
     goto out;
 
-  if (!rpmostree_check_groups (repo, yumroot, treefile_path, treefile,
+  if (!rpmostree_check_groups (repo, yumroot, treefile_dirpath, treefile,
                                cancellable, error))
     goto out;
 

--- a/src/rpmostree-passwd-util.h
+++ b/src/rpmostree-passwd-util.h
@@ -55,6 +55,8 @@ rpmostree_passwd_migrate_except_root (GFile         *rootfs,
 gboolean
 rpmostree_generate_passwd_from_previous (OstreeRepo      *repo,
                                          GFile           *yumroot,
+                                         GFile           *treefile_dirpath,
                                          GFile           *previous_root,
+                                         JsonObject      *treedata,
                                          GCancellable    *cancellable,
                                          GError         **error);


### PR DESCRIPTION
Needs some docs. also a bit more testing before merging, as a bunch of code got moved about and reused.

Basically the migrate code will now look at the files pointed to by check-passwd/check-group so that they can be migrated across branches.