### PR TITLE
build: replace libhif/hif-context-private.h with libhif/hif-utils.h

### DIFF
--- a/src/rpmostree-compose-builtin-tree.c
+++ b/src/rpmostree-compose-builtin-tree.c
@@ -25,7 +25,7 @@
 #include <json-glib/json-glib.h>
 #include <gio/gunixoutputstream.h>
 #include <libhif.h>
-#include <libhif/hif-context-private.h>
+#include <libhif/hif-utils.h>
 #include <stdio.h>
 #include <rpm/rpmmacro.h>
 


### PR DESCRIPTION
The header was renamed in newer versions of libhif.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>