### PR TITLE
treepkgdiff: Adapt to Hawkey 0.5.3 API break

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,8 @@ PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 json-glib-1.0
 				     ostree-1 >= 2015.1 libgsystem >= 2015.1
 				     rpm hawkey libhif >= 0.2.0])
+AS_IF([pkg-config --atleast-version=0.5.3 hawkey],
+      [AC_DEFINE([BUILDOPT_HAWKEY_SACK_CREATE2], 1, [Hawkey ABI change in 0.5.3])])
 AC_PATH_PROG([XSLTPROC], [xsltproc])
 
 GLIB_TESTS

--- a/src/rpmostree-treepkgdiff.c
+++ b/src/rpmostree-treepkgdiff.c
@@ -38,7 +38,16 @@ rpmostree_get_pkglist_for_root (GFile            *root,
   _cleanup_hyquery_ HyQuery query = NULL;
   _cleanup_hypackagelist_ HyPackageList pkglist = NULL;
 
-  sack = hy_sack_create (NULL, NULL, gs_file_get_path_cached (root), 0);
+#ifdef BUILDOPT_HAWKEY_SACK_CREATE2	
+  sack = hy_sack_create (NULL, NULL,
+                         gs_file_get_path_cached (root),
+                         NULL,
+                         HY_MAKE_CACHE_DIR);
+#else
+  sack = hy_sack_create (NULL, NULL,
+                         gs_file_get_path_cached (root),
+                         HY_MAKE_CACHE_DIR);
+#endif
   if (sack == NULL)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,


### PR DESCRIPTION
We will work on both old and new versions.

See https://github.com/rpm-software-management/hawkey/commit/8ce3ce754f50b4284587ceaa2eb4c0acf328912a