### PR TITLE
 Add a public shared library, with "rpm -qa" for commit functionality

### DIFF
--- a/Makefile-lib-defines.am
+++ b/Makefile-lib-defines.am
@@ -1,0 +1,24 @@
+# Shared variables between toplevel Makefile.am and doc/Makefile.am
+# ...since gtk-doc forces use of recursive make =(
+#
+# Copyright (C) 2013 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+librpmostree_public_headers = \
+	src/lib/rpmostree.h \
+	src/lib/rpmostree-db.h \
+	$(NULL)

--- a/Makefile-lib.am
+++ b/Makefile-lib.am
@@ -1,0 +1,52 @@
+# Makefile for C source code
+#
+# Copyright (C) 2015 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+include Makefile-lib-defines.am
+
+lib_LTLIBRARIES += librpmostree-1.la
+
+librpmostreeincludedir = $(includedir)/rpm-ostree-1
+librpmostreeinclude_HEADERS = $(librpmostree_public_headers)
+
+librpmostree_1_la_SOURCES = \
+	src/lib/rpmostree-db.c \
+	$(NULL)
+
+librpmostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/src/libpriv -I$(srcdir)/src/lib \
+	$(PKGDEP_RPMOSTREE_CFLAGS)
+librpmostree_1_la_LDFLAGS = -version-number 1:0:0 -Bsymbolic-functions -export-symbols-regex '^rpm_ostree_'
+librpmostree_1_la_LIBADD = libglnx.la $(PKGDEP_RPMOSTREE_LIBS)
+
+if BUILDOPT_INTROSPECTION
+RpmOstree-1.0.gir: librpmostree-1.la Makefile
+RpmOstree_1_0_gir_EXPORT_PACKAGES = rpm-ostree-1
+RpmOstree_1_0_gir_INCLUDES = OSTree-1.0 Gio-2.0
+RpmOstree_1_0_gir_CFLAGS = $(librpmostree_1_la_CFLAGS)
+RpmOstree_1_0_gir_LIBS = librpmostree-1.la
+RpmOstree_1_0_gir_SCANNERFLAGS = --warn-all --identifier-prefix=RpmOstree --symbol-prefix=rpm_ostree
+RpmOstree_1_0_gir_FILES = $(librpmostreeinclude_HEADERS) $(filter-out %-private.h,$(librpmostree_1_la_SOURCES))
+INTROSPECTION_GIRS += RpmOstree-1.0.gir
+gir_DATA += RpmOstree-1.0.gir
+typelib_DATA += RpmOstree-1.0.typelib
+
+CLEANFILES += $(gir_DATA) $(typelib_DATA)
+endif
+
+pkgconfig_DATA += src/lib/rpm-ostree-1.pc
+

--- a/Makefile-libutil.am
+++ b/Makefile-libutil.am
@@ -1,0 +1,50 @@
+# Makefile for C source code
+#
+# Copyright (C) 2015 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+include Makefile-lib-defines.am
+
+privlib_LTLIBRARIES += librpmostreepriv.la
+
+librpmostree_1_la_SOURCES = \
+	librpmostree-priv/rpmostree-cleanup.h \
+	librpmostree-priv/rpmostree-cleanup.c \
+	$(NULL)
+
+librpmostreepriv_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/librpmostree-priv \
+	$(PKGDEP_RPMOSTREE_CFLAGS)
+librpmostreepriv_la_LDFLAGS = -Bsymbolic-functions -export-symbols-regex '^rpmostreepriv_'
+librpmostree_priv_la_LIBADD = libglnx.la $(PKGDEP_RPMOSTREE_LIBS)
+
+if BUILDOPT_INTROSPECTION
+RpmOstree-1.0.gir: libostree-1.la Makefile
+RpmOstree_1_0_gir_EXPORT_PACKAGES = rpm-ostree-1
+RpmOstree_1_0_gir_INCLUDES = OSTree-1 Gio-2.0
+RpmOstree_1_0_gir_CFLAGS = $(librpmostree_1_la_CFLAGS)
+RpmOstree_1_0_gir_LIBS = librpmostree-1.la
+RpmOstree_1_0_gir_SCANNERFLAGS = --warn-all --identifier-prefix=RpmOstree --symbol-prefix=rpmostree
+RpmOstree_1_0_gir_FILES = $(librpmostreeinclude_HEADERS) $(filter-out %-private.h,$(librpmostree_1_la_SOURCES))
+INTROSPECTION_GIRS += RpmOstree-1.0.gir
+gir_DATA += RpmOstree-1.0.gir
+typelib_DATA += RpmOstree-1.0.typelib
+
+CLEANFILES += $(gir_DATA) $(typelib_DATA)
+endif
+
+pkgconfig_DATA += librpmostree/rpm-ostree-1.pc
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,12 @@
 
 include Makefile-decls.am
 
+SUBDIRS += .
+
+if ENABLE_GTK_DOC
+SUBDIRS += doc
+endif
+
 privdatadir=$(pkglibdir)
 
 ACLOCAL_AMFLAGS += -I m4 ${ACLOCAL_FLAGS}

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,8 +33,13 @@ libglnx_srcpath := $(srcdir)/libglnx
 libglnx_cflags := $(PKGDEP_GIO_UNIX_CFLAGS) -I$(libglnx_srcpath)
 libglnx_libs := $(PKGDEP_GIO_UNIX_LIBS)
 
+include $(INTROSPECTION_MAKEFILE)
+GIRS =
+TYPELIBS = $(GIRS:.gir=.typelib)
+
 include libglnx/Makefile-libglnx.am
 noinst_LTLIBRARIES += libglnx.la
+include Makefile-lib.am
 include Makefile-rpm-ostree.am
 include Makefile-tests.am
 include Makefile-man.am

--- a/autogen.sh
+++ b/autogen.sh
@@ -15,6 +15,18 @@ fi
 
 mkdir -p m4
 
+GTKDOCIZE=$(which gtkdocize 2>/dev/null)
+if test -z $GTKDOCIZE; then
+        echo "You don't have gtk-doc installed, and thus won't be able to generate the documentation."
+        rm -f gtk-doc.make
+        cat > gtk-doc.make <<EOF
+EXTRA_DIST =
+CLEANFILES =
+EOF
+else
+        gtkdocize || exit $?
+fi
+
 if ! test -f libglnx/README.md; then
     git submodule update --init
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,8 @@ m4_ifdef([GOBJECT_INTROSPECTION_CHECK], [
 ])
 AM_CONDITIONAL(BUILDOPT_INTROSPECTION, test "x$found_introspection" = xyes)
 
+GTK_DOC_CHECK([1.15], [--flavour no-tmpl])
+
 AC_ARG_ENABLE(installed_tests,
               AS_HELP_STRING([--enable-installed-tests],
                              [Install test programs (default: no)]),,
@@ -94,6 +96,7 @@ if test x$enable_compose_tooling != xno; then RPM_OSTREE_FEATURES="$RPM_OSTREE_F
 
 AC_CONFIG_FILES([
 Makefile
+doc/Makefile
 src/lib/rpm-ostree-1.pc
 ])
 AC_OUTPUT
@@ -103,4 +106,5 @@ echo "
 
     usrbinatomic:	$enable_usrbinatomic
     compose tooling:	$enable_compose_tooling
+    gtk-doc:            $enable_gtk_doc
 "

--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,10 @@ AC_PATH_PROG([XSLTPROC], [xsltproc])
 
 GLIB_TESTS
 
-GOBJECT_INTROSPECTION_REQUIRE([1.34.0])
+m4_ifdef([GOBJECT_INTROSPECTION_CHECK], [
+  GOBJECT_INTROSPECTION_CHECK([1.34.0])
+])
+AM_CONDITIONAL(BUILDOPT_INTROSPECTION, test "x$found_introspection" = xyes)
 
 AC_ARG_ENABLE(installed_tests,
               AS_HELP_STRING([--enable-installed-tests],
@@ -91,6 +94,7 @@ if test x$enable_compose_tooling != xno; then RPM_OSTREE_FEATURES="$RPM_OSTREE_F
 
 AC_CONFIG_FILES([
 Makefile
+src/lib/rpm-ostree-1.pc
 ])
 AC_OUTPUT
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,0 +1,103 @@
+# Copyright (C) 2013 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+abs_top_builddir = @abs_top_builddir@
+
+include ../Makefile-lib-defines.am
+
+NULL =
+
+# We require automake 1.6 at least.
+AUTOMAKE_OPTIONS = 1.6
+
+# The name of the module, e.g. 'glib'.
+DOC_MODULE=rpmostree
+
+# The top-level SGML file. You can change this if you want to.
+DOC_MAIN_SGML_FILE=$(DOC_MODULE)-docs.xml
+
+# The directory containing the source code. Relative to $(srcdir).
+# gtk-doc will search all .c & .h files beneath here for inline comments
+# documenting the functions and macros.
+# e.g. DOC_SOURCE_DIR=../../../gtk
+DOC_SOURCE_DIR=$(top_srcdir)/src/lib
+
+# Extra options to pass to gtkdoc-scangobj. Not normally needed.
+SCANGOBJ_OPTIONS= --version
+
+# Extra options to supply to gtkdoc-scan.
+# e.g. SCAN_OPTIONS=--deprecated-guards="GTK_DISABLE_DEPRECATED"
+SCAN_OPTIONS= --rebuild-types
+
+# Extra options to supply to gtkdoc-mkdb.
+# e.g. MKDB_OPTIONS=--sgml-mode --output-format=xml
+MKDB_OPTIONS=--sgml-mode --output-format=xml
+
+# Extra options to supply to gtkdoc-mktmpl
+# e.g. MKTMPL_OPTIONS=--only-section-tmpl
+MKTMPL_OPTIONS=
+
+# MKHTML_OPTIONS=--path="$(builddir)/html $(srcdir)/html"
+
+# Extra options to supply to gtkdoc-fixref. Not normally needed.
+# e.g. FIXXREF_OPTIONS=--extra-dir=../gdk-pixbuf/html --extra-dir=../gdk/html
+FIXXREF_OPTIONS=
+
+# Used for dependencies. The docs will be rebuilt if any of these change.
+# e.g. HFILE_GLOB=$(top_srcdir)/gtk/*.h
+# e.g. CFILE_GLOB=$(top_srcdir)/gtk/*.c
+HFILE_GLOB=$(addprefix $(top_srcdir)/,$(librpmostree_public_headers))
+CFILE_GLOB=$(top_srcdir)/src/lib/*.c
+
+# Header files to ignore when scanning.
+# e.g. IGNORE_HFILES=gtkdebug.h gtkintl.h
+IGNORE_HFILES= \
+	$(NULL)
+
+# Images to copy into HTML directory.
+# e.g. HTML_IMAGES=$(top_srcdir)/gtk/stock-icons/stock_about_24.png
+HTML_IMAGES=
+
+# Extra SGML files that are included by $(DOC_MAIN_SGML_FILE).
+# e.g. content_files=running.sgml building.sgml changes-2.0.sgml
+content_files= \
+	overview.xml \
+	$(NULL)
+
+# SGML files where gtk-doc abbrevations (#GtkWidget) are expanded
+# These files must be listed here *and* in content_files
+# e.g. expand_content_files=running.sgml
+expand_content_files= \
+	version.xml \
+	$(NULL)
+
+# CFLAGS and LDFLAGS for compiling gtkdoc-scangobj with your library.
+# Only needed if you are using gtkdoc-scangobj to dynamically query widget
+# signals and properties.
+# e.g. INCLUDES=-I$(top_srcdir) -I$(top_builddir) $(GTK_DEBUG_FLAGS)
+# e.g. GTKDOC_LIBS=$(top_builddir)/gtk/$(gtktargetlib)
+GTKDOC_LIBS=
+
+# Hacks around gtk-doc brokenness for out of tree builds
+rpmostree-sections.txt: $(srcdir)/rpmostree-sections.txt
+	cp $< $@
+
+version.xml:
+	echo -n $(VERSION) > "$@"
+
+# This includes the standard gtk-doc make rules, copied by gtkdocize.
+include $(top_srcdir)/gtk-doc.make

--- a/doc/overview.xml
+++ b/doc/overview.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
+"http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
+<!ENTITY version SYSTEM "../version.xml">
+]>
+<part id="overview">
+  <title>rpm-ostree Overview</title>
+  <chapter id="rpmostree-intro">
+    <title>Introduction</title>
+    <para>
+      The project aims to bring together a hybrid of image-like upgrade
+      features (reliable replication, atomicity), with package-like
+      flexibility (seeing package sets inside trees, layering, partial live
+      updates).  For more information, see the <literal>README.md</literal>
+      in the upstream project.  This manual covers the gtk-doc.
+    </para>
+  </chapter>
+</part>

--- a/doc/rpmostree-docs.xml
+++ b/doc/rpmostree-docs.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+               "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd"
+[
+  <!ENTITY % local.common.attrib "xmlns:xi  CDATA  #FIXED 'http://www.w3.org/2003/XInclude'">
+  <!ENTITY version SYSTEM "version.xml">
+]>
+<book id="index">
+	<bookinfo>
+		<title>rpm-ostree Manual</title>
+		<releaseinfo>for &version;</releaseinfo>
+	</bookinfo>
+
+	<chapter xml:id="reference">
+		<title>API Reference</title>
+		<xi:include href="xml/librpmostree-dbquery.xml"/>
+
+		<index id="api-index-full">
+			<title>API Index</title>
+			<xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>
+		</index>
+
+	</chapter>
+</book>

--- a/doc/rpmostree-sections.txt
+++ b/doc/rpmostree-sections.txt
@@ -1,0 +1,9 @@
+<SECTION>
+<FILE>librpmostree-dbquery</FILE>
+RpmOstreeDbQueryResult
+rpm_ostree_db_query_result_get_type
+rpm_ostree_db_query_result_get_packages
+rpm_ostree_db_query_ref
+rpm_ostree_db_query_unref
+rpm_ostree_db_query
+</SECTION>

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -25,16 +25,25 @@ Requires: /usr/bin/yum
 This tool takes a set of packages, and commits them to an OSTree
 repository.  At the moment, it is intended for use on build servers.
 
+%package devel
+Summary: Development headers for %{name}
+Group: Development/Libraries
+Requires: %{name} = %{version}-%{release}
+
+%description devel
+The %{name}-devel package includes the header files for the %{name} library.
+
 %prep
 %setup -q -n %{name}-%{version}
 
 %build
 env NOCONFIGURE=1 ./autogen.sh
-%configure --disable-silent-rules --enable-patched-hawkey-and-libsolv --enable-usrbinatomic
+%configure --disable-silent-rules --enable-gtk-doc --enable-patched-hawkey-and-libsolv --enable-usrbinatomic
 make %{?_smp_mflags}
 
 %install
 make install DESTDIR=$RPM_BUILD_ROOT INSTALL="install -p -c"
+find $RPM_BUILD_ROOT -name '*.la' -delete
 
 %files
 %doc COPYING README.md
@@ -42,6 +51,16 @@ make install DESTDIR=$RPM_BUILD_ROOT INSTALL="install -p -c"
 %{_bindir}/rpm-ostree
 %{_libdir}/%{name}/
 %{_mandir}/man1/*
+%{_libdir}/*.so.1*
+%{_libdir}/girepository-1.0/*.typelib
+
+%files devel
+%{_libdir}/lib*.so
+%{_includedir}/*
+%{_libdir}/pkgconfig/*
+%dir %{_datadir}/gtk-doc/html/*
+%{_datadir}/gtk-doc/html/*
+%{_datadir}/gir-1.0/*-1.0.gir
 
 %changelog
 * Fri Mar 07 2014 Colin Walters <walters@verbum.org> - 2014.5-1

--- a/src/lib/rpm-ostree-1.pc.in
+++ b/src/lib/rpm-ostree-1.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: RpmOstree
+Description: Hybrid package/OSTree system
+Version: @VERSION@
+Requires: ostree-1
+Libs: -L${libdir} -lrpm-ostree-1
+Cflags: -I${includedir}/ostree-1

--- a/src/lib/rpmostree-db.c
+++ b/src/lib/rpmostree-db.c
@@ -25,6 +25,15 @@
 #include "rpmostree-db.h"
 #include "rpmostree-cleanup.h"
 
+/**
+ * SECTION:librpmostree-dbquery
+ * @title: Query RPM database
+ * @short_description: Access the RPM database in commits
+ *
+ * These APIs provide queryable access to the RPM database inside an
+ * OSTree repository.
+ */
+
 struct RpmOstreeDbQueryResult 
 {
   volatile gint refcount;

--- a/src/lib/rpmostree-db.c
+++ b/src/lib/rpmostree-db.c
@@ -1,0 +1,179 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2014 Colin Walters <walters@verbum.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include "string.h"
+
+#include "rpmostree-db.h"
+#include "rpmostree-cleanup.h"
+
+struct RpmOstreeDbQueryResult 
+{
+  volatile gint refcount;
+  GPtrArray *packages;
+};
+
+RpmOstreeDbQueryResult *
+rpm_ostree_db_query_ref (RpmOstreeDbQueryResult *result)
+{
+  g_atomic_int_inc (&result->refcount);
+  return result;
+}
+
+void
+rpm_ostree_db_query_unref (RpmOstreeDbQueryResult *result)
+{
+  if (!g_atomic_int_dec_and_test (&result->refcount))
+    return;
+
+  g_ptr_array_unref (result->packages);
+  g_free (result);
+}
+
+G_DEFINE_BOXED_TYPE(RpmOstreeDbQueryResult, rpm_ostree_db_query_result,
+                    rpm_ostree_db_query_ref,
+                    rpm_ostree_db_query_unref);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeDbQueryResult, rpm_ostree_db_query_unref)
+
+/**
+ * rpm_ostree_db_query_result_get_packages:
+ * @queryresult: Query result
+ *
+ * Returns: (transfer none) (array zero-terminated=1) (element-type utf8): List of packages, %NULL terminated
+ */
+const char *const *
+rpm_ostree_db_query_result_get_packages (RpmOstreeDbQueryResult *queryresult)
+{
+  return (const char * const *)queryresult->packages->pdata;
+}
+
+/**
+ * rpm_ostree_db_query:
+ * @repo: An OSTree repository
+ * @ref: A branch name or commit
+ * @query: (allow-none): Currently, this must be %NULL
+ * @out_result: (out) (transfer full): Query reslut
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Query the RPM packages present in the @ref branch or commit in
+ * @repo. At present, @query must be %NULL; all packages will be
+ * returned.  A future enhancement to this API may allow querying a
+ * subset of packages.
+ */
+gboolean
+rpm_ostree_db_query (OstreeRepo                *repo,
+                     const char                *ref,
+                     GVariant                  *query,
+                     RpmOstreeDbQueryResult   **out_result,
+                     GCancellable              *cancellable,
+                     GError                   **error)
+{
+  gboolean ret = FALSE;
+  int rc;
+  OstreeRepoCheckoutOptions checkout_options = { 0, };
+  g_autofree char *commit = NULL;
+  _cleanup_hysack_ HySack sack = NULL;
+  _cleanup_hyquery_ HyQuery hquery = NULL;
+  _cleanup_hypackagelist_ HyPackageList pkglist = NULL;
+  g_autofree char *tempdir = g_strdup ("/tmp/rpmostree-dbquery-XXXXXXXX");
+  g_autofree char *rpmdb_tempdir = NULL;
+  gs_unref_object GFile* commit_rpmdb = NULL;
+  glnx_fd_close int tempdir_dfd = -1;
+
+  g_return_val_if_fail (query == NULL, FALSE);
+
+  if (!ostree_repo_resolve_rev (repo, ref, FALSE, &commit, error))
+    goto out;
+
+  if (mkdtemp (tempdir) == NULL)
+    {
+      glnx_set_error_from_errno (error);
+      goto out;
+    }
+
+  if (!glnx_opendirat (AT_FDCWD, tempdir, FALSE, &tempdir_dfd, error))
+    goto out;
+
+  /* Create intermediate dirs */ 
+  if (!glnx_shutil_mkdir_p_at (tempdir_dfd, "usr/share", 0777, cancellable, error))
+    goto out;
+
+  checkout_options.mode = OSTREE_REPO_CHECKOUT_MODE_USER;
+  checkout_options.subpath = "usr/share/rpm";
+
+  if (!ostree_repo_checkout_tree_at (repo, &checkout_options,
+                                     tempdir_dfd, "usr/share/rpm",
+                                     commit, 
+                                     cancellable, error))
+    goto out;
+
+#if BUILDOPT_HAWKEY_SACK_CREATE2
+  sack = hy_sack_create (NULL, NULL,
+                         rpmdb_tempdir,
+                         NULL,
+                         0);
+#else
+  sack = hy_sack_create (NULL, NULL,
+                         rpmdb_tempdir,
+                         0);
+#endif
+  if (sack == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Failed to create sack cache");
+      goto out;
+    }
+
+  rc = hy_sack_load_system_repo (sack, NULL, 0);
+  if (!hif_error_set_from_hawkey (rc, error))
+    {
+      g_prefix_error (error, "Failed to load system repo: ");
+      goto out;
+    }
+  hquery = hy_query_create (sack);
+  hy_query_filter (hquery, HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
+  pkglist = hy_query_run (hquery);
+
+  (void) glnx_shutil_rm_rf_at (AT_FDCWD, tempdir, cancellable, NULL);
+
+  ret = TRUE;
+  /* Do output creation now, no errors can be thrown */
+  {
+    RpmOstreeDbQueryResult *result = g_new0 (RpmOstreeDbQueryResult, 1);
+    int i, c;
+
+    result->refcount = 1;
+    result->packages = g_ptr_array_new_with_free_func (free);
+    
+    c = hy_packagelist_count (pkglist);
+    for (i = 0; i < c; i++)
+      {
+        HyPackage pkg = hy_packagelist_get (pkglist, i);
+        g_ptr_array_add (result->packages, hy_package_get_nevra (pkg));
+      }
+    g_ptr_array_add (result->packages, NULL);
+    
+    *out_result = g_steal_pointer (&result);
+  }
+ out:
+  return ret;
+}

--- a/src/lib/rpmostree-db.h
+++ b/src/lib/rpmostree-db.h
@@ -1,0 +1,42 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <ostree.h>
+
+G_BEGIN_DECLS
+
+typedef struct RpmOstreeDbQueryResult RpmOstreeDbQueryResult;
+
+GType rpm_ostree_db_query_result_get_type (void);
+const char *const *rpm_ostree_db_query_result_get_packages (RpmOstreeDbQueryResult *queryresult);
+
+RpmOstreeDbQueryResult *rpm_ostree_db_query_ref (RpmOstreeDbQueryResult *result);
+void rpm_ostree_db_query_unref (RpmOstreeDbQueryResult *result);
+
+gboolean rpm_ostree_db_query (OstreeRepo               *repo,
+                              const char               *ref,
+                              GVariant                 *query,
+                              RpmOstreeDbQueryResult  **out_result,
+                              GCancellable             *cancellable,
+                              GError                  **error);
+
+G_END_DECLS

--- a/src/lib/rpmostree.h
+++ b/src/lib/rpmostree.h
@@ -1,0 +1,23 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Colin Walters <walters@verbum.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <rpmostree-db.h>

--- a/tests/manual/test-dbquery.py
+++ b/tests/manual/test-dbquery.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import sys
+from gi.repository import Gio, OSTree, RpmOstree
+
+repopath, ref = sys.argv[1:3]
+
+r = OSTree.Repo.new(Gio.File.new_for_path(repopath))
+r.open(None)
+_,q = RpmOstree.db_query(r, ref, None, None)
+print "Package list: "
+for p in q.get_packages():
+    print p
+


### PR DESCRIPTION
This will help build release engineering and other types of tools;
for example, rather than parsing the output of `db diff`, one
should be able to call an API.

Initially, this adds the generic infrastructure for a public shared
library, with a new function call to do the equivalent of `rpm -qa` on
a particular OSTree commit.

Closes: #117

