### PR TITLE
Show GPG signatures for "status" and "upgrade"

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -99,6 +99,32 @@ rpmostree_option_context_parse (GOptionContext *context,
   return TRUE;
 }
 
+void
+rpmostree_print_gpg_verify_result (OstreeRepo *repo,
+                                   const char *checksum,
+                                   OstreeGpgVerifyResult *result)
+{
+  GString *buffer;
+  guint n_sigs, ii;
+
+  n_sigs = ostree_gpg_verify_result_count_all (result);
+
+  /* XXX If we ever add internationalization, use ngettext() here. */
+  g_print ("\nFound %u signature%s:\n", n_sigs, n_sigs == 1 ? "" : "s");
+
+  buffer = g_string_sized_new (256);
+
+  for (ii = 0; ii < n_sigs; ii++)
+    {
+      g_string_append_c (buffer, '\n');
+      ostree_gpg_verify_result_describe (result, ii, buffer, "  ",
+                                         OSTREE_GPG_SIGNATURE_FORMAT_DEFAULT);
+    }
+
+  g_print ("%s\n", buffer->str);
+  g_string_free (buffer, TRUE);
+}
+
 int
 main (int    argc,
       char **argv)

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -100,9 +100,7 @@ rpmostree_option_context_parse (GOptionContext *context,
 }
 
 void
-rpmostree_print_gpg_verify_result (OstreeRepo *repo,
-                                   const char *checksum,
-                                   OstreeGpgVerifyResult *result)
+rpmostree_print_gpg_verify_result (OstreeGpgVerifyResult *result)
 {
   GString *buffer;
   guint n_sigs, ii;

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -108,7 +108,8 @@ rpmostree_print_gpg_verify_result (OstreeGpgVerifyResult *result)
   n_sigs = ostree_gpg_verify_result_count_all (result);
 
   /* XXX If we ever add internationalization, use ngettext() here. */
-  g_print ("\nFound %u signature%s:\n", n_sigs, n_sigs == 1 ? "" : "s");
+  g_print ("GPG: Verification enabled, found %u signature%s:\n",
+           n_sigs, n_sigs == 1 ? "" : "s");
 
   buffer = g_string_sized_new (256);
 

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -45,6 +45,20 @@ static GOptionEntry option_entries[] = {
   { NULL }
 };
 
+static void
+gpg_verify_result_cb (OstreeRepo *repo,
+                      const char *checksum,
+                      OstreeGpgVerifyResult *result,
+                      GSConsole *console)
+{
+  /* Temporarily place the GSConsole stream (which is just stdout)
+   * back in normal mode before printing GPG verification results. */
+  gs_console_end_status_line (console, NULL, NULL);
+
+  g_print ("\n");
+  rpmostree_print_gpg_verify_result (result);
+}
+
 gboolean
 rpmostree_builtin_upgrade (int             argc,
                            char          **argv,
@@ -63,6 +77,7 @@ rpmostree_builtin_upgrade (int             argc,
 
   gs_free char *origin_description = NULL;
   gs_unref_object OstreeRepo *repo = NULL; 
+  gulong signal_handler_id = 0;
 
   if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv, error))
     goto out;
@@ -89,6 +104,10 @@ rpmostree_builtin_upgrade (int             argc,
     {
       gs_console_begin_status_line (console, "", NULL, NULL);
       progress = ostree_async_progress_new_and_connect (ostree_repo_pull_default_console_progress_changed, console);
+      signal_handler_id = g_signal_connect (repo, "gpg-verify-result",
+                                            G_CALLBACK (gpg_verify_result_cb),
+                                            console);
+
     }
 
   if (opt_allow_downgrade)  
@@ -124,6 +143,12 @@ rpmostree_builtin_upgrade (int             argc,
     }
   else
     {
+      gs_free char *ref = NULL; // location of this rev
+      gs_free char *remote = NULL;
+
+      if (!ostree_parse_refspec (origin_description, &remote, &ref, error))
+        goto out;
+
       if (!opt_check_diff)
         {
           if (!ostree_sysroot_upgrader_deploy (upgrader, cancellable, error))
@@ -150,12 +175,6 @@ rpmostree_builtin_upgrade (int             argc,
           _cleanup_rpmrev_ struct RpmRevisionData *rpmrev2 = NULL;
 
           gs_free char *tmpd = g_mkdtemp (g_strdup ("/tmp/rpm-ostree.XXXXXX"));
-
-          gs_free char *ref = NULL; // location of this rev
-          gs_free char *remote = NULL;
-
-          if (!ostree_parse_refspec (origin_description, &remote, &ref, error))
-             goto out;
 
           if (rpmReadConfigFiles (NULL, NULL))
             {
@@ -184,6 +203,9 @@ rpmostree_builtin_upgrade (int             argc,
  out:
   if (console)
     (void) gs_console_end_status_line (console, NULL, NULL);
+
+  if (signal_handler_id > 0)
+    g_signal_handler_disconnect (repo, signal_handler_id);
 
   return ret;
 }

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -46,5 +46,9 @@ gboolean rpmostree_option_context_parse (GOptionContext *context,
                                          char ***argv,
                                          GError **error);
 
+void rpmostree_print_gpg_verify_result (OstreeRepo *repo,
+                                        const char *checksum,
+                                        OstreeGpgVerifyResult *result);
+
 G_END_DECLS
 

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -46,9 +46,7 @@ gboolean rpmostree_option_context_parse (GOptionContext *context,
                                          char ***argv,
                                          GError **error);
 
-void rpmostree_print_gpg_verify_result (OstreeRepo *repo,
-                                        const char *checksum,
-                                        OstreeGpgVerifyResult *result);
+void rpmostree_print_gpg_verify_result (OstreeGpgVerifyResult *result);
 
 G_END_DECLS
 


### PR DESCRIPTION
This implements the follow up suggestions from https://github.com/GNOME/ostree/pull/77, and is blocked on https://github.com/GNOME/ostree/pull/80 for `ostree_gpg_verify_result_describe()`.

The `rpm-ostree upgrade` command lists any GPG signatures on the newly-deployed commit similarly to `ostree show`.

The `rpm-ostree status` command was a little more tricky.  If `--pretty` is given, it lists GPG signatures on each deployment.  But for the more terse, one-line-per-deployment format, it only lists GPG signatures on the currently booted deployment, and does so *after* the tabular output to maintain readability.

This is of course all subject to tweaking.

Some examples:
```
# atomic host upgrade
Updating from: local:fedora-atomic/f23/x86_64/local-testing

24 metadata, 22 content objects fetched; 87892 KiB transferred in 3 seconds
Copying /etc changes: 27 modified, 4 removed, 58 added
Transaction complete; bootconfig swap: yes deployment count change: 0
Freed objects: 104.8 MB
Changed:
  ...
  rpm-ostree-2015.3.44.g9d59912-5.fc21.test.20150407.4.x86_64
  rpm-ostree-debuginfo-2015.3.44.g9d59912-5.fc21.test.20150407.4.x86_64

Found 1 signature:

  Signature made Tue 07 Apr 2015 10:11:27 PM UTC using RSA key ID 7572B288944E4891
  Good signature from "Matthew Barnes <mbarnes@redhat.com>"

Upgrade prepared for next boot; run "systemctl reboot" to start a reboot
```
(after reboot)
```
$ rpm-ostree status --pretty
============================================================
  * DEFAULT ON BOOT
----------------------------------------
  version    0.1.5      
  timestamp  2015-04-07 21:49:45
  id         0fb0bd3b310ec157fe3d3b7d21956ef966705af07ab8ce03f510e33edbe1d9f5.1
  osname     fedora-atomic
  refspec    local:fedora-atomic/f23/x86_64/local-testing

  Signature made Tue 07 Apr 2015 10:11:27 PM UTC using RSA key ID 7572B288944E4891
  Good signature from "Matthew Barnes <mbarnes@redhat.com>"
============================================================
    NON-DEFAULT ROLLBACK TARGET
----------------------------------------
  version    0.1.4      
  timestamp  2015-04-07 20:17:13
  id         e529b361ba7fbf19e3dda2e4ea77215f70b9f52c54bcba2814bb066d8bd0d44e.0
  osname     fedora-atomic
  refspec    local:fedora-atomic/f23/x86_64/local-testing
============================================================

$ rpm-ostree status
  TIMESTAMP (UTC)         VERSION   ID             OSNAME            REFSPEC                                          
* 2015-04-07 21:49:45     0.1.5     0fb0bd3b31     fedora-atomic     local:fedora-atomic/f23/x86_64/local-testing     
  2015-04-07 20:17:13     0.1.4     e529b361ba     fedora-atomic     local:fedora-atomic/f23/x86_64/local-testing     

Found 1 signature on the booted deployment (*):

  Signature made Tue 07 Apr 2015 10:11:27 PM UTC using RSA key ID 7572B288944E4891
  Good signature from "Matthew Barnes <mbarnes@redhat.com>"
```