### PR TITLE
Fix running autogen.sh from outside the source directory

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -15,7 +15,6 @@ fi
 
 mkdir -p m4
 
-cd $olddir
 if ! test -f libglnx/README.md; then
     git submodule update --init
 fi


### PR DESCRIPTION
Otherwise the git submodule invocations produce errors.