### PR TITLE
build: Use -fvisibility=hidden and explicit exports

### DIFF
--- a/Makefile-lib.am
+++ b/Makefile-lib.am
@@ -29,8 +29,9 @@ librpmostree_1_la_SOURCES = \
 	$(NULL)
 
 librpmostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/src/libpriv -I$(srcdir)/src/lib \
+	-fvisibility=hidden '-D_RPMOSTREE_EXTERN=__attribute((visibility("default"))) extern' \
 	$(PKGDEP_RPMOSTREE_CFLAGS)
-librpmostree_1_la_LDFLAGS = -version-number 1:0:0 -Bsymbolic-functions -export-symbols-regex '^rpm_ostree_'
+librpmostree_1_la_LDFLAGS = -version-number 1:0:0 -Bsymbolic-functions
 librpmostree_1_la_LIBADD = libglnx.la $(PKGDEP_RPMOSTREE_LIBS)
 
 if BUILDOPT_INTROSPECTION

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,8 @@ AM_CFLAGS += $(WARN_CFLAGS)
 EXTRA_DIST += autogen.sh COPYING
 
 libglnx_srcpath := $(srcdir)/libglnx
-libglnx_cflags := $(PKGDEP_GIO_UNIX_CFLAGS) -I$(libglnx_srcpath)
+libglnx_cflags := $(PKGDEP_GIO_UNIX_CFLAGS) -I$(libglnx_srcpath) -fvisibility=hidden
+libglnx_ldflags := 
 libglnx_libs := $(PKGDEP_GIO_UNIX_LIBS)
 
 include $(INTROSPECTION_MAKEFILE)

--- a/src/lib/rpmostree-db.h
+++ b/src/lib/rpmostree-db.h
@@ -26,16 +26,16 @@ G_BEGIN_DECLS
 
 typedef struct RpmOstreeDbQueryResult RpmOstreeDbQueryResult;
 
-GType rpm_ostree_db_query_result_get_type (void);
-const char *const *rpm_ostree_db_query_result_get_packages (RpmOstreeDbQueryResult *queryresult);
+_RPMOSTREE_EXTERN GType rpm_ostree_db_query_result_get_type (void);
+_RPMOSTREE_EXTERN const char *const *rpm_ostree_db_query_result_get_packages (RpmOstreeDbQueryResult *queryresult);
 
-RpmOstreeDbQueryResult *rpm_ostree_db_query_ref (RpmOstreeDbQueryResult *result);
-void rpm_ostree_db_query_unref (RpmOstreeDbQueryResult *result);
+_RPMOSTREE_EXTERN RpmOstreeDbQueryResult *rpm_ostree_db_query_ref (RpmOstreeDbQueryResult *result);
+_RPMOSTREE_EXTERN void rpm_ostree_db_query_unref (RpmOstreeDbQueryResult *result);
 
-RpmOstreeDbQueryResult *rpm_ostree_db_query (OstreeRepo               *repo,
-                                             const char               *ref,
-                                             GVariant                 *query,
-                                             GCancellable             *cancellable,
-                                             GError                  **error);
+_RPMOSTREE_EXTERN RpmOstreeDbQueryResult *rpm_ostree_db_query (OstreeRepo               *repo,
+                                                               const char               *ref,
+                                                               GVariant                 *query,
+                                                               GCancellable             *cancellable,
+                                                               GError                  **error);
 
 G_END_DECLS

--- a/src/lib/rpmostree.h
+++ b/src/lib/rpmostree.h
@@ -20,4 +20,8 @@
 
 #pragma once
 
+#ifndef _RPMOSTREE_EXTERN
+#define _RPMOSTREE_EXTERN extern
+#endif
+
 #include <rpmostree-db.h>


### PR DESCRIPTION
This avoids symbol leakage.  Previously we were at risk of exporting
other random API from libpriv, as well as libglnx.