### PR TITLE
Rewrite rpm-ostree compose sign

### DIFF
--- a/src/app/rpmostree-compose-builtin-sign.c
+++ b/src/app/rpmostree-compose-builtin-sign.c
@@ -45,18 +45,10 @@ rpmostree_compose_builtin_sign (int            argc,
                                 GError       **error)
 {
   gboolean ret = FALSE;
-  GOptionContext *context = g_option_context_new ("- Use rpm-sign to sign an OSTree commit");
+  GOptionContext *context = g_option_context_new ("- Sign an OSTree commit");
   gs_unref_object GFile *repopath = NULL;
   gs_unref_object OstreeRepo *repo = NULL;
-  gs_unref_object GFile *tmp_commitdata_file = NULL;
-  gs_unref_object GFileIOStream *tmp_sig_stream = NULL;
-  gs_unref_object GFile *tmp_sig_file = NULL;
-  gs_unref_object GFileIOStream *tmp_commitdata_stream = NULL;
-  GOutputStream *tmp_commitdata_output = NULL;
-  gs_unref_object GInputStream *commit_data = NULL;
   gs_free char *checksum = NULL;
-  gs_unref_variant GVariant *commit_variant = NULL;
-  gs_unref_bytes GBytes *commit_bytes = NULL;
   
   if (!rpmostree_option_context_parse (context, option_entries, &argc, &argv, error))
     goto out;
@@ -76,65 +68,14 @@ rpmostree_compose_builtin_sign (int            argc,
   if (!ostree_repo_resolve_rev (repo, opt_rev, FALSE, &checksum, error))
     goto out;
 
-  if (!ostree_repo_load_variant (repo, OSTREE_OBJECT_TYPE_COMMIT,
-                                 checksum, &commit_variant, error))
+  if (!ostree_repo_sign_commit (repo, checksum, opt_key_id,
+                                NULL, cancellable, error))
     goto out;
-
-  commit_bytes = g_variant_get_data_as_bytes (commit_variant);
-  commit_data = (GInputStream*)g_memory_input_stream_new_from_bytes (commit_bytes);
-  
-  tmp_commitdata_file = g_file_new_tmp ("tmpsigXXXXXX", &tmp_commitdata_stream,
-                                       error);
-  if (!tmp_commitdata_file)
-    goto out;
-
-  tmp_commitdata_output = (GOutputStream*)g_io_stream_get_output_stream ((GIOStream*)tmp_commitdata_stream);
-  if (g_output_stream_splice ((GOutputStream*)tmp_commitdata_output,
-                              commit_data,
-                              G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE |
-                              G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET,
-                              cancellable, error) < 0)
-    goto out;
-
-  tmp_sig_file = g_file_new_tmp ("tmpsigoutXXXXXX", &tmp_sig_stream, error);
-  if (!tmp_sig_file)
-    goto out;
-
-  (void) g_io_stream_close ((GIOStream*)tmp_sig_stream, NULL, NULL);
-                                  
-  if (!gs_subprocess_simple_run_sync (NULL, GS_SUBPROCESS_STREAM_DISPOSITION_NULL,
-                                      cancellable, error,
-                                      "rpm-sign",
-                                      "--key", opt_key_id,
-                                      "--detachsign", gs_file_get_path_cached (tmp_commitdata_file),
-                                      "--output", gs_file_get_path_cached (tmp_sig_file),
-                                      NULL))
-    goto out;
-
-  {
-    char *sigcontent = NULL;
-    gsize len;
-    gs_unref_bytes GBytes *sigbytes = NULL;
-
-    if (!g_file_load_contents (tmp_sig_file, cancellable, &sigcontent, &len, NULL,
-                               error))
-      goto out;
-
-    sigbytes = g_bytes_new_take (sigcontent, len);
-
-    if (!ostree_repo_append_gpg_signature (repo, checksum, sigbytes,
-                                           cancellable, error))
-      goto out;
-  }
 
   g_print ("Successfully signed OSTree commit=%s with key=%s\n",
            checksum, opt_key_id);
   
   ret = TRUE;
  out:
-  if (tmp_commitdata_file)
-    (void) gs_file_unlink (tmp_commitdata_file, NULL, NULL);
-  if (tmp_sig_file)
-    (void) gs_file_unlink (tmp_sig_file, NULL, NULL);
   return ret;
 }


### PR DESCRIPTION
Just to finish off https://github.com/projectatomic/rpm-ostree/issues/111...

Now that we have `ostree gpg-sign`, I assume we don't want to be invoking `rpm-sign` anymore.  On the other hand we can't just up and rip out `rpm-ostree compose sign`.  So I rewrote the command to just be a simplified (and deprecated) version of `ostree gpg-sign`.