### PR TITLE
Add rpm_ostree_package_cmp()

### DIFF
--- a/doc/rpmostree-sections.txt
+++ b/doc/rpmostree-sections.txt
@@ -11,4 +11,5 @@ rpm_ostree_package_get_name
 rpm_ostree_package_get_evr
 rpm_ostree_package_get_arch
 rpm_ostree_package_get_nevra
+rpm_ostree_package_cmp
 </SECTION>

--- a/src/lib/rpmostree-package.h
+++ b/src/lib/rpmostree-package.h
@@ -44,3 +44,5 @@ const char *rpm_ostree_package_get_evr (RpmOstreePackage *p);
 _RPMOSTREE_EXTERN
 const char *rpm_ostree_package_get_arch (RpmOstreePackage *p);
 
+_RPMOSTREE_EXTERN
+int rpm_ostree_package_cmp (RpmOstreePackage *p1, RpmOstreePackage *p2);


### PR DESCRIPTION
Equivalent to `hy_package_cmp()`, but works for comparing packages from different memory pools.

This a stop gap measure in light of https://github.com/rpm-software-management/hawkey/pull/90

If and when that pull request gets merged, then this function could at some later point simply call `hy_package_cmp()`.