### PR TITLE
[WIP] Add a package object cache

### DIFF
--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -26,6 +26,8 @@ librpmostreepriv_la_SOURCES = \
 	src/libpriv/rpmostree-util.h \
 	src/libpriv/rpmostree-passwd-util.c \
 	src/libpriv/rpmostree-passwd-util.h \
+	src/libpriv/rpmostree-refts.h \
+	src/libpriv/rpmostree-refts.c \
 	src/libpriv/rpmostree-refsack.h \
 	src/libpriv/rpmostree-refsack.c \
 	src/libpriv/rpmostree-cleanup.h \

--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -31,6 +31,8 @@ librpmostreepriv_la_SOURCES = \
 	src/libpriv/rpmostree-refsack.h \
 	src/libpriv/rpmostree-refsack.c \
 	src/libpriv/rpmostree-cleanup.h \
+	src/libpriv/rpmostree-pkgobject-cache.h \
+	src/libpriv/rpmostree-pkgobject-cache.c \
 	src/libpriv/rpmostree-rpm-util.c \
 	src/libpriv/rpmostree-rpm-util.h \
 	$(NULL)

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -190,7 +190,8 @@ rpmostree_builtin_upgrade (int             argc,
                                       NULL, cancellable, error)))
             goto out;
 
-          rpmhdrs_diff_prnt_diff (rpmhdrs_diff (rpmrev1->rpmdb, rpmrev2->rpmdb));
+          rpmhdrs_diff_prnt_diff (rpmhdrs_diff (rpmrev_get_headers (rpmrev1),
+                                                rpmrev_get_headers (rpmrev2)));
         }
     }
   

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -194,8 +194,7 @@ rpmostree_builtin_upgrade (int             argc,
                                       NULL, cancellable, error)))
             goto out;
 
-          rpmhdrs_diff_prnt_diff (rpmrev1->root, rpmrev2->root,
-                                  rpmhdrs_diff (rpmrev1->rpmdb, rpmrev2->rpmdb));
+          rpmhdrs_diff_prnt_diff (rpmhdrs_diff (rpmrev1->rpmdb, rpmrev2->rpmdb));
         }
     }
   

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -168,8 +168,6 @@ rpmostree_builtin_upgrade (int             argc,
           _cleanup_rpmrev_ struct RpmRevisionData *rpmrev1 = NULL;
           _cleanup_rpmrev_ struct RpmRevisionData *rpmrev2 = NULL;
 
-          gs_free char *tmpd = g_mkdtemp (g_strdup ("/tmp/rpm-ostree.XXXXXX"));
-
           gs_free char *ref = NULL; // location of this rev
           gs_free char *remote = NULL;
 
@@ -183,14 +181,12 @@ rpmostree_builtin_upgrade (int             argc,
               goto out;
             }
 
-          rpmdbdir = g_file_new_for_path (tmpd);
-
-          if (!(rpmrev1 = rpmrev_new (repo, rpmdbdir, 
+          if (!(rpmrev1 = rpmrev_new (repo, 
                                       ostree_deployment_get_csum (ostree_sysroot_get_booted_deployment (sysroot)),
                                       NULL, cancellable, error)))
             goto out;
 
-          if (!(rpmrev2 = rpmrev_new (repo, rpmdbdir, ref,
+          if (!(rpmrev2 = rpmrev_new (repo, ref,
                                       NULL, cancellable, error)))
             goto out;
 

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -876,6 +876,7 @@ rpmostree_compose_builtin_tree (int             argc,
       goto out;
 
     if (!rpmostree_commit (yumroot, repo, ref, metadata, gpgkey, selinux,
+                           previous_checksum,
                            cancellable, error))
       goto out;
   }

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -35,8 +35,6 @@ rpmostree_db_builtin_diff (int argc, char **argv, GCancellable *cancellable, GEr
 {
   GOptionContext *context;
   gs_unref_object OstreeRepo *repo = NULL;
-  gs_unref_object GFile *rpmdbdir = NULL;
-  gboolean rpmdbdir_is_tmp = FALSE;
   struct RpmRevisionData *rpmrev1 = NULL;
   struct RpmRevisionData *rpmrev2 = NULL;
   gboolean success = FALSE;
@@ -44,7 +42,7 @@ rpmostree_db_builtin_diff (int argc, char **argv, GCancellable *cancellable, GEr
   context = g_option_context_new ("COMMIT COMMIT - Show package changes between two commits");
 
   if (!rpmostree_db_option_context_parse (context, option_entries, &argc, &argv, &repo,
-                                          &rpmdbdir, &rpmdbdir_is_tmp, cancellable, error))
+                                          cancellable, error))
     goto out;
 
   if (argc != 3)
@@ -60,10 +58,10 @@ rpmostree_db_builtin_diff (int argc, char **argv, GCancellable *cancellable, GEr
       goto out;
     }
 
-  if (!(rpmrev1 = rpmrev_new (repo, rpmdbdir, argv[1], NULL, cancellable, error)))
+  if (!(rpmrev1 = rpmrev_new (repo, argv[1], NULL, cancellable, error)))
     goto out;
 
-  if (!(rpmrev2 = rpmrev_new (repo, rpmdbdir, argv[2], NULL, cancellable, error)))
+  if (!(rpmrev2 = rpmrev_new (repo, argv[2], NULL, cancellable, error)))
     goto out;
 
   if (!g_str_equal (argv[1], rpmrev1->commit))
@@ -102,9 +100,6 @@ out:
    * being there. */
   rpmrev_free (rpmrev1);
   rpmrev_free (rpmrev2);
-
-  if (rpmdbdir_is_tmp)
-    (void) gs_shutil_rm_rf (rpmdbdir, NULL, NULL);
 
   g_option_context_free (context);
 

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -81,13 +81,11 @@ rpmostree_db_builtin_diff (int argc, char **argv, GCancellable *cancellable, GEr
 
   if (g_str_equal (opt_format, "diff"))
     {
-      rpmhdrs_diff_prnt_diff (rpmrev1->root, rpmrev2->root,
-                              rpmhdrs_diff (rpmrev1->rpmdb, rpmrev2->rpmdb));
+      rpmhdrs_diff_prnt_diff (rpmhdrs_diff (rpmrev1->rpmdb, rpmrev2->rpmdb));
     }
   else if (g_str_equal (opt_format, "block"))
     {
-      rpmhdrs_diff_prnt_block (rpmrev1->root, rpmrev2->root,
-                               rpmhdrs_diff (rpmrev1->rpmdb, rpmrev2->rpmdb));
+      rpmhdrs_diff_prnt_block (rpmhdrs_diff (rpmrev1->rpmdb, rpmrev2->rpmdb));
     }
   else
     {

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -64,13 +64,13 @@ rpmostree_db_builtin_diff (int argc, char **argv, GCancellable *cancellable, GEr
   if (!(rpmrev2 = rpmrev_new (repo, argv[2], NULL, cancellable, error)))
     goto out;
 
-  if (!g_str_equal (argv[1], rpmrev1->commit))
-    printf ("ostree diff commit old: %s (%s)\n", argv[1], rpmrev1->commit);
+  if (!g_str_equal (argv[1], rpmrev_get_commit (rpmrev1)))
+    printf ("ostree diff commit old: %s (%s)\n", argv[1], rpmrev_get_commit (rpmrev1));
   else
     printf ("ostree diff commit old: %s\n", argv[1]);
 
-  if (!g_str_equal (argv[2], rpmrev2->commit))
-    printf ("ostree diff commit new: %s (%s)\n", argv[2], rpmrev2->commit);
+  if (!g_str_equal (argv[2], rpmrev_get_commit (rpmrev2)))
+    printf ("ostree diff commit new: %s (%s)\n", argv[2], rpmrev_get_commit (rpmrev2));
   else
     printf ("ostree diff commit new: %s\n", argv[2]);
 
@@ -79,11 +79,13 @@ rpmostree_db_builtin_diff (int argc, char **argv, GCancellable *cancellable, GEr
 
   if (g_str_equal (opt_format, "diff"))
     {
-      rpmhdrs_diff_prnt_diff (rpmhdrs_diff (rpmrev1->rpmdb, rpmrev2->rpmdb));
+      rpmhdrs_diff_prnt_diff (rpmhdrs_diff (rpmrev_get_headers (rpmrev1),
+                                            rpmrev_get_headers (rpmrev2)));
     }
   else if (g_str_equal (opt_format, "block"))
     {
-      rpmhdrs_diff_prnt_block (rpmhdrs_diff (rpmrev1->rpmdb, rpmrev2->rpmdb));
+      rpmhdrs_diff_prnt_block (rpmhdrs_diff (rpmrev_get_headers (rpmrev1),
+                                             rpmrev_get_headers (rpmrev2)));
     }
   else
     {

--- a/src/app/rpmostree-db-builtin-list.c
+++ b/src/app/rpmostree-db-builtin-list.c
@@ -70,12 +70,12 @@ _builtin_db_list (OstreeRepo *repo,
       if (!rpmrev)
         goto out;
 
-      if (!g_str_equal (rev, rpmrev->commit))
-        printf ("ostree commit: %s (%s)\n", rev, rpmrev->commit);
+      if (!g_str_equal (rev, rpmrev_get_commit (rpmrev)))
+        printf ("ostree commit: %s (%s)\n", rev, rpmrev_get_commit (rpmrev));
       else
         printf ("ostree commit: %s\n", rev);
 
-      rpmhdrs_list (rpmrev->rpmdb);
+      rpmhdrs_list (rpmrev_get_headers (rpmrev));
     }
 
   ret = TRUE;

--- a/src/app/rpmostree-db-builtin-list.c
+++ b/src/app/rpmostree-db-builtin-list.c
@@ -75,7 +75,7 @@ _builtin_db_list (OstreeRepo *repo, GFile *rpmdbdir,
       else
         printf ("ostree commit: %s\n", rev);
 
-      rpmhdrs_list (rpmrev->root, rpmrev->rpmdb);
+      rpmhdrs_list (rpmrev->rpmdb);
     }
 
   ret = TRUE;

--- a/src/app/rpmostree-db-builtin-list.c
+++ b/src/app/rpmostree-db-builtin-list.c
@@ -28,7 +28,7 @@ static GOptionEntry option_entries[] = {
 };
 
 static gboolean
-_builtin_db_list (OstreeRepo *repo, GFile *rpmdbdir,
+_builtin_db_list (OstreeRepo *repo,
                   GPtrArray *revs, const GPtrArray *patterns,
                   GCancellable   *cancellable,
                   GError        **error)
@@ -58,14 +58,14 @@ _builtin_db_list (OstreeRepo *repo, GFile *rpmdbdir,
           if (!range_revs)
             goto out;
 
-          if (!_builtin_db_list (repo, rpmdbdir, range_revs, patterns,
+          if (!_builtin_db_list (repo, range_revs, patterns,
                                  cancellable, error))
             goto out;
 
           continue;
         }
 
-      rpmrev = rpmrev_new (repo, rpmdbdir, rev, patterns,
+      rpmrev = rpmrev_new (repo, rev, patterns,
                            cancellable, error);
       if (!rpmrev)
         goto out;
@@ -89,8 +89,6 @@ rpmostree_db_builtin_list (int argc, char **argv, GCancellable *cancellable, GEr
 {
   GOptionContext *context;
   gs_unref_object OstreeRepo *repo = NULL;
-  gs_unref_object GFile *rpmdbdir = NULL;
-  gboolean rpmdbdir_is_tmp = FALSE;
   gs_unref_ptrarray GPtrArray *patterns = NULL;
   gs_unref_ptrarray GPtrArray *revs = NULL;
   gboolean success = FALSE;
@@ -99,7 +97,7 @@ rpmostree_db_builtin_list (int argc, char **argv, GCancellable *cancellable, GEr
   context = g_option_context_new ("[PREFIX-PKGNAME...] COMMIT... - List packages within commits");
 
   if (!rpmostree_db_option_context_parse (context, option_entries, &argc, &argv, &repo,
-                                          &rpmdbdir, &rpmdbdir_is_tmp, cancellable, error))
+                                          cancellable, error))
     goto out;
 
   /* Iterate over all arguments. When we see the first argument which
@@ -128,15 +126,12 @@ rpmostree_db_builtin_list (int argc, char **argv, GCancellable *cancellable, GEr
         }
     }
 
-  if (!_builtin_db_list (repo, rpmdbdir, revs, patterns, cancellable, error))
+  if (!_builtin_db_list (repo, revs, patterns, cancellable, error))
     goto out;
 
   success = TRUE;
 
 out:
-  if (rpmdbdir_is_tmp)
-    (void) gs_shutil_rm_rf (rpmdbdir, NULL, NULL);
-
   g_option_context_free (context);
 
   return success;

--- a/src/app/rpmostree-db-builtin-version.c
+++ b/src/app/rpmostree-db-builtin-version.c
@@ -69,7 +69,7 @@ _builtin_db_version (OstreeRepo *repo, GFile *rpmdbdir, GPtrArray *revs,
         if (!rpmrev)
           goto out;
 
-        rpmdbv = rpmhdrs_rpmdbv (rpmrev->root, rpmrev->rpmdb,
+        rpmdbv = rpmhdrs_rpmdbv (rpmrev->rpmdb,
                                  cancellable, error);
         if (rpmdbv == NULL)
           goto out;

--- a/src/app/rpmostree-db-builtin-version.c
+++ b/src/app/rpmostree-db-builtin-version.c
@@ -69,14 +69,14 @@ _builtin_db_version (OstreeRepo *repo, GPtrArray *revs,
         if (!rpmrev)
           goto out;
 
-        rpmdbv = rpmhdrs_rpmdbv (rpmrev->rpmdb,
+        rpmdbv = rpmhdrs_rpmdbv (rpmrev_get_headers (rpmrev),
                                  cancellable, error);
         if (rpmdbv == NULL)
           goto out;
 
         // FIXME: g_console?
-        if (!g_str_equal (rev, rpmrev->commit))
-          printf ("ostree commit: %s (%s)\n", rev, rpmrev->commit);
+        if (!g_str_equal (rev, rpmrev_get_commit (rpmrev)))
+          printf ("ostree commit: %s (%s)\n", rev, rpmrev_get_commit (rpmrev));
         else
           printf ("ostree commit: %s\n", rev);
 

--- a/src/app/rpmostree-db-builtins.h
+++ b/src/app/rpmostree-db-builtins.h
@@ -34,8 +34,6 @@ gboolean rpmostree_db_option_context_parse (GOptionContext *context,
                                             const GOptionEntry *main_entries,
                                             int *argc, char ***argv,
                                             OstreeRepo **out_repo,
-                                            GFile **out_rpmdbdir,
-                                            gboolean *out_rpmdbdir_is_tmp,
                                             GCancellable *cancellable,
                                             GError **error);
 

--- a/src/lib/rpmostree-db.c
+++ b/src/lib/rpmostree-db.c
@@ -81,7 +81,7 @@ rpm_ostree_db_query_all (OstreeRepo                *repo,
 {
   g_autoptr(RpmOstreeRefSack) rsack = NULL;
 
-  rsack = _rpm_ostree_get_refsack_for_commit (repo, ref, cancellable, error);
+  rsack = rpmostree_get_refsack_for_commit (repo, ref, cancellable, error);
 
   return query_all_packages_in_sack (rsack);
 }
@@ -137,7 +137,7 @@ rpm_ostree_db_diff (OstreeRepo               *repo,
   g_return_val_if_fail (out_removed != NULL && out_added != NULL &&
                         out_modified_old != NULL && out_modified_new != NULL, FALSE);
 
-  orig_sack = _rpm_ostree_get_refsack_for_commit (repo, orig_ref, cancellable, error);
+  orig_sack = rpmostree_get_refsack_for_commit (repo, orig_ref, cancellable, error);
   if (!orig_sack)
     goto out;
 
@@ -146,7 +146,7 @@ rpm_ostree_db_diff (OstreeRepo               *repo,
     orig_pkglist = hy_query_run (query);
   }
 
-  new_sack = _rpm_ostree_get_refsack_for_commit (repo, new_ref, cancellable, error);
+  new_sack = rpmostree_get_refsack_for_commit (repo, new_ref, cancellable, error);
   if (!new_sack)
     goto out;
 

--- a/src/lib/rpmostree-package.c
+++ b/src/lib/rpmostree-package.c
@@ -55,7 +55,7 @@ rpm_ostree_package_finalize (GObject *object)
   hy_package_free (pkg->hypkg);
   
   /* We do internal refcounting of the sack because hawkey doesn't */
-  _rpm_ostree_refsack_unref (pkg->sack);
+  rpmostree_refsack_unref (pkg->sack);
 
   G_OBJECT_CLASS (rpm_ostree_package_parent_class)->finalize (object);
 }
@@ -174,7 +174,7 @@ RpmOstreePackage *
 _rpm_ostree_package_new (RpmOstreeRefSack *rsack, HyPackage hypkg)
 {
   RpmOstreePackage *p = g_object_new (RPM_OSTREE_TYPE_PACKAGE, NULL);
-  p->sack = _rpm_ostree_refsack_ref (rsack);
+  p->sack = rpmostree_refsack_ref (rsack);
   p->hypkg = hy_package_link (hypkg);
   return p;
 }

--- a/src/libpriv/rpmostree-pkgobject-cache.c
+++ b/src/libpriv/rpmostree-pkgobject-cache.c
@@ -1,0 +1,270 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Colin Walters <walters@verbum.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include "rpmostree-rpm-util.h"
+#include "rpmostree-refsack.h"
+#include "rpmostree-pkgobject-cache.h"
+
+#include <fnmatch.h>
+#include <sys/ioctl.h>
+#include <hawkey/packageset.h>
+#include <rpm/rpmts.h>
+#include <rpm/rpmdb.h>
+#include <rpm/rpmmacro.h>
+#include <libglnx.h>
+
+/**
+ * SECTION:rpmostree-pkgobject-cache
+ * @title: Cache a mapping from previous tree objects
+ *
+ * This class is intended to speed up commits for subsequent commits,
+ * given a previous commit.  By default, we'll zlib compress + checksum
+ * each file which can be slow.  Particularly the zlib compression.
+ *
+ * This class implements a potential optimization by building up a mapping from
+ * `(package version, filename) -> checksum` for the previous commit, then looking
+ * in that cache for the new commit.  Thus if a package hasn't changed, we simply
+ * return the cached checksum.
+ */
+
+static char *
+ptrarray_path_join (GPtrArray  *path)
+{
+  GString *path_buf;
+
+  path_buf = g_string_new ("");
+
+  if (path->len == 0)
+    g_string_append_c (path_buf, '/');
+  else
+    {
+      guint i;
+      for (i = 0; i < path->len; i++)
+        {
+          const char *elt = path->pdata[i];
+
+          g_string_append_c (path_buf, '/');
+          g_string_append (path_buf, elt);
+        }
+    }
+
+  return g_string_free (path_buf, FALSE);
+}
+
+struct RpmOstreePkgObjectCache {
+  RpmOstreeRefTs *source_refts;
+  RpmOstreeRefTs *target_refts;
+  GHashTable *sourcemap;  /* file path -> checksum */
+};
+
+RpmOstreePkgObjectCache *
+_rpmostree_pkg_object_cache_new (void)
+{
+  RpmOstreePkgObjectCache *cache = g_new0 (RpmOstreePkgObjectCache, 1);
+  cache->sourcemap = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+  return cache;
+}
+
+static char *
+cache_key_for_path (const char *path,
+                    RpmOstreeRefTs  *refts)
+{
+  rpmdbMatchIterator mi = NULL;
+  char *ret = NULL;
+  
+  mi = rpmtsInitIterator (refts->ts, RPMDBI_INSTFILENAMES, path, 0);
+  if (mi == NULL)
+    mi = rpmtsInitIterator (refts->ts, RPMDBI_PROVIDENAME, path, 0);
+  
+  if (mi != NULL)
+    {
+      Header h;
+      const char *sha1;
+
+      h = rpmdbNextIterator (mi);
+      g_assert (h);
+
+      sha1 = headerGetString (h, RPMTAG_SHA1HEADER);
+      if (sha1)
+        {
+          /* RHEL7 RPMs are SHA1...in the future we should handle
+           * others, but the md5 -> sha1 transition was *really*
+           * painful and I doubt anyone's going to jump to do
+           * another.
+           */
+          ret = g_strconcat (sha1, "-", path, NULL);
+        }
+    }
+  else
+    {
+      /* Hack to deal with kernel/rpm not handling UsrMove */
+      if (g_str_has_prefix (path, "/usr/lib"))
+        ret = cache_key_for_path (path + 4, refts);
+    }
+
+  rpmdbFreeIterator (mi);
+  return ret;
+}
+
+static gboolean
+pkg_object_cache_load_source (RpmOstreePkgObjectCache *cache,
+                              GPtrArray               *path_parts,
+                              OstreeRepo              *repo,
+                              GFile                   *dirpath,
+                              GCancellable            *cancellable,
+                              GError                 **error)
+{
+  gboolean ret = FALSE;
+  gs_unref_object GFileEnumerator *direnum = NULL;
+
+  direnum = g_file_enumerate_children (dirpath, "standard::name,standard::type",
+                                       G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
+                                       cancellable, error);
+  if (!direnum)
+    goto out;
+
+  while (TRUE)
+    {
+      GFileInfo *file_info;
+      GFile *child;
+      GFileType ftype;
+
+      if (!gs_file_enumerator_iterate (direnum, &file_info, &child,
+                                       cancellable, error))
+        goto out;
+      if (file_info == NULL)
+        break;
+
+      g_ptr_array_add (path_parts, (char*)g_file_info_get_name (file_info));
+
+      ftype = g_file_info_get_file_type (file_info);
+      if (ftype == G_FILE_TYPE_DIRECTORY)
+        {
+
+          if (!pkg_object_cache_load_source (cache, path_parts, repo,
+                                             child, cancellable, error))
+            goto out;
+
+        }
+      else if (ftype == G_FILE_TYPE_REGULAR)
+        {
+          g_autofree char *relpath = ptrarray_path_join (path_parts);
+          char *cachekey = cache_key_for_path (relpath, cache->source_refts);
+
+          if (cachekey)
+            {
+              /* Transfer ownership of cachekey into the cache */
+              g_hash_table_insert (cache->sourcemap, cachekey,
+                                   g_strdup (ostree_repo_file_get_checksum ((OstreeRepoFile*)child)));
+            }
+        }
+
+      g_ptr_array_remove_index (path_parts, path_parts->len - 1);
+    }
+
+  ret = TRUE;
+ out:
+  return ret;
+}
+
+gboolean
+_rpmostree_pkg_object_cache_load_source (RpmOstreePkgObjectCache *cache,
+                                         OstreeRepo              *repo,
+                                         const char              *commit,
+                                         GCancellable            *cancellable,
+                                         GError                 **error)
+{
+  gboolean ret = FALSE;
+  glnx_unref_object GFile *root = NULL;
+  g_autoptr(GPtrArray) path_parts = g_ptr_array_new ();
+  
+  if (!ostree_repo_read_commit (repo, commit, &root, NULL, cancellable, error))
+    goto out;
+
+  if (!rpmostree_get_refts_for_commit (repo, commit, &cache->source_refts,
+                                       cancellable, error))
+    goto out;
+
+  if (!pkg_object_cache_load_source (cache, path_parts, repo, root, cancellable, error))
+    goto out;
+
+  ret = TRUE;
+ out:
+  return ret;
+}
+
+gboolean
+_rpmostree_pkg_object_cache_load_target (RpmOstreePkgObjectCache *cache,
+                                         int                      dfd,
+                                         GCancellable            *cancellable,
+                                         GError                 **error)
+{
+  gboolean ret = FALSE;
+  rpmts ts;
+  int r;
+  g_autofree char *rootpath = NULL;
+
+  /* FIXME - this macro expansion affects all use of librpm in this process.
+   * We need an API for this.
+   */
+  rpmExpand ("%define _dbpath /usr/share/rpm", NULL);
+
+  ts = rpmtsCreate ();
+  rpmtsSetVSFlags (ts, _RPMVSF_NODIGESTS | _RPMVSF_NOSIGNATURES);
+
+  rootpath = glnx_fdrel_abspath (dfd, ".");
+
+  r = rpmtsSetRootDir (ts, rootpath);
+  g_assert_cmpint (r, ==, 0);
+
+  r = rpmtsOpenDB (ts, O_RDONLY);
+  if (r == -1)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Failed to open rpmdb");
+      goto out;
+    }
+  
+  cache->target_refts = rpmostree_refts_new (ts, AT_FDCWD, NULL);
+
+  ret = TRUE;
+ out:
+  return ret;
+}
+
+const char *
+_rpmostree_pkg_object_cache_query (RpmOstreePkgObjectCache *cache,
+                                   const char              *filename)
+{
+  g_autofree char *cachekey = cache_key_for_path (filename, cache->target_refts);
+  if (cachekey)
+    return g_hash_table_lookup (cache->sourcemap, cachekey);
+
+  return NULL;
+}
+
+void
+_rpmostree_pkg_object_cache_free (RpmOstreePkgObjectCache *cache)
+{
+  g_hash_table_unref (cache->sourcemap);
+  g_free (cache);
+}

--- a/src/libpriv/rpmostree-pkgobject-cache.h
+++ b/src/libpriv/rpmostree-pkgobject-cache.h
@@ -1,0 +1,48 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Colin Walters <walters@verbum.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <ostree.h>
+
+typedef struct RpmOstreePkgObjectCache RpmOstreePkgObjectCache;
+
+RpmOstreePkgObjectCache * _rpmostree_pkg_object_cache_new (void);
+
+gboolean
+_rpmostree_pkg_object_cache_load_source (RpmOstreePkgObjectCache *cache,
+                                         OstreeRepo              *repo,
+                                         const char              *commit,
+                                         GCancellable            *cancellable,
+                                         GError                 **error);
+
+gboolean
+_rpmostree_pkg_object_cache_load_target (RpmOstreePkgObjectCache *cache,
+                                         int                      dfd,
+                                         GCancellable            *cancellable,
+                                         GError                 **error);
+
+const char *
+_rpmostree_pkg_object_cache_query (RpmOstreePkgObjectCache *cache,
+                                   const char              *filename);
+
+void
+_rpmostree_pkg_object_cache_free (RpmOstreePkgObjectCache *cache);
+

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -36,6 +36,7 @@
 
 #include "rpmostree-postprocess.h"
 #include "rpmostree-passwd-util.h"
+#include "rpmostree-pkgobject-cache.h"
 #include "rpmostree-rpm-util.h"
 #include "rpmostree-cleanup.h"
 #include "rpmostree-json-parsing.h"
@@ -1371,6 +1372,26 @@ read_xattrs_cb (OstreeRepo     *repo,
   return g_variant_ref_sink (g_variant_builder_end (&builder));
 }
 
+typedef struct {
+  RpmOstreePkgObjectCache *cache;
+  guint hits;
+  guint total;
+} CacheState;
+
+static char *
+file_cache_callback (OstreeRepo           *self,
+                     const char           *path,
+                     gpointer              user_data)
+{
+  CacheState *state = user_data;
+  char *ret = g_strdup (_rpmostree_pkg_object_cache_query (state->cache, path));
+
+  if (ret)
+    state->hits++;
+  state->total++;
+  return ret;
+}
+
 gboolean
 rpmostree_commit (GFile         *rootfs,
                   OstreeRepo    *repo,
@@ -1378,12 +1399,14 @@ rpmostree_commit (GFile         *rootfs,
                   GVariant      *metadata,
                   const char    *gpg_keyid,
                   gboolean       enable_selinux,
+                  const char    *previous_checksum,
                   GCancellable  *cancellable,
                   GError       **error)
 {
   gboolean ret = FALSE;
   gs_unref_object OstreeMutableTree *mtree = NULL;
   OstreeRepoCommitModifier *commit_modifier = NULL;
+  CacheState cachestate = { NULL, };
   gs_free char *parent_revision = NULL;
   gs_free char *new_revision = NULL;
   gs_unref_object GFile *root_tree = NULL;
@@ -1408,8 +1431,25 @@ rpmostree_commit (GFile         *rootfs,
   if (!gs_file_open_dir_fd (rootfs, &rootfs_fd, cancellable, error))
     goto out;
 
-  mtree = ostree_mutable_tree_new ();
   commit_modifier = ostree_repo_commit_modifier_new (0, NULL, NULL, NULL);
+
+  if (previous_checksum)
+    {
+      cachestate.cache = _rpmostree_pkg_object_cache_new ();
+      
+      if (!_rpmostree_pkg_object_cache_load_source (cachestate.cache, repo, previous_checksum,
+                                                    cancellable, error))
+        goto out;
+
+      if (!_rpmostree_pkg_object_cache_load_target (cachestate.cache, rootfs_fd, cancellable, error))
+        goto out;
+
+      ostree_repo_commit_modifier_set_file_cache_callback (commit_modifier,
+                                                           file_cache_callback, NULL,
+                                                           &cachestate);
+    }
+
+  mtree = ostree_mutable_tree_new ();
   ostree_repo_commit_modifier_set_xattr_callback (commit_modifier,
                                                   read_xattrs_cb, NULL,
                                                   GINT_TO_POINTER (rootfs_fd));
@@ -1433,6 +1473,9 @@ rpmostree_commit (GFile         *rootfs,
                                  cancellable, error))
     goto out;
 
+  if (cachestate.cache)
+    g_print ("Cache hits: %u/%u\n", cachestate.hits, cachestate.total);
+
   if (gpg_keyid)
     {
       g_print ("Signing commit %s with key %s\n", new_revision, gpg_keyid);
@@ -1455,5 +1498,7 @@ rpmostree_commit (GFile         *rootfs,
 
   ret = TRUE;
  out:
+  if (cachestate.cache)
+    _rpmostree_pkg_object_cache_free (cachestate.cache);
   return ret;
 }

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -43,5 +43,6 @@ rpmostree_commit (GFile         *rootfs,
                   GVariant      *metadata,
                   const char    *gpg_keyid,
                   gboolean       enable_selinux,
+                  const char    *previous_commit,
                   GCancellable  *cancellable,
                   GError       **error);

--- a/src/libpriv/rpmostree-refsack.c
+++ b/src/libpriv/rpmostree-refsack.c
@@ -65,47 +65,24 @@ _rpm_ostree_get_refsack_for_commit (OstreeRepo                *repo,
                                     GCancellable              *cancellable,
                                     GError                   **error)
 {
-  g_autofree char *commit = NULL;
-  g_autofree char *tempdir = g_strdup ("/tmp/rpmostree-dbquery-XXXXXXXX");
-  OstreeRepoCheckoutOptions checkout_options = { 0, };
+  RpmOstreeRefSack *ret = NULL;
+  g_autofree char *tempdir = NULL;
   glnx_fd_close int tempdir_dfd = -1;
-
-  if (!ostree_repo_resolve_rev (repo, ref, FALSE, &commit, error))
+  HySack hsack; 
+  
+  if (!rpmostree_checkout_only_rpmdb_tempdir (repo, ref, &tempdir, &tempdir_dfd,
+                                              cancellable, error))
+    goto out;
+  
+  if (!rpmostree_get_sack_for_root (tempdir_dfd, ".",
+                                    &hsack, cancellable, error))
     goto out;
 
-  if (mkdtemp (tempdir) == NULL)
-    {
-      glnx_set_error_from_errno (error);
-      goto out;
-    }
-
-  if (!glnx_opendirat (AT_FDCWD, tempdir, FALSE, &tempdir_dfd, error))
-    goto out;
-
-  /* Create intermediate dirs */ 
-  if (!glnx_shutil_mkdir_p_at (tempdir_dfd, "usr/share", 0777, cancellable, error))
-    goto out;
-
-  checkout_options.mode = OSTREE_REPO_CHECKOUT_MODE_USER;
-  checkout_options.subpath = "usr/share/rpm";
-
-  if (!ostree_repo_checkout_tree_at (repo, &checkout_options,
-                                     tempdir_dfd, "usr/share/rpm",
-                                     commit, 
-                                     cancellable, error))
-    goto out;
-
-  {
-    HySack hsack; 
-
-    if (!rpmostree_get_sack_for_root (tempdir_dfd, ".",
-                                      &hsack, cancellable, error))
-      goto out;
-
-    return _rpm_ostree_refsack_new (hsack, AT_FDCWD, tempdir);
-  }
-
+  ret = _rpm_ostree_refsack_new (hsack, AT_FDCWD, tempdir);
+  tempdir = NULL; /* Transfer ownership */
  out:
-  return NULL;
+  if (tempdir)
+    (void) glnx_shutil_rm_rf_at (AT_FDCWD, tempdir, NULL, NULL);
+  return ret;
 }
 

--- a/src/libpriv/rpmostree-refsack.c
+++ b/src/libpriv/rpmostree-refsack.c
@@ -25,7 +25,7 @@
 #include "rpmostree-rpm-util.h"
 
 RpmOstreeRefSack *
-_rpm_ostree_refsack_new (HySack sack, int temp_base_dfd, const char *temp_path)
+rpmostree_refsack_new (HySack sack, int temp_base_dfd, const char *temp_path)
 {
   RpmOstreeRefSack *rsack = g_new0 (RpmOstreeRefSack, 1);
   rsack->sack = sack;
@@ -36,14 +36,14 @@ _rpm_ostree_refsack_new (HySack sack, int temp_base_dfd, const char *temp_path)
 }
 
 RpmOstreeRefSack *
-_rpm_ostree_refsack_ref (RpmOstreeRefSack *rsack)
+rpmostree_refsack_ref (RpmOstreeRefSack *rsack)
 {
   g_atomic_int_inc (&rsack->refcount);
   return rsack;
 }
 
 void
-_rpm_ostree_refsack_unref (RpmOstreeRefSack *rsack)
+rpmostree_refsack_unref (RpmOstreeRefSack *rsack)
 {
   if (!g_atomic_int_dec_and_test (&rsack->refcount))
     return;

--- a/src/libpriv/rpmostree-refsack.c
+++ b/src/libpriv/rpmostree-refsack.c
@@ -58,31 +58,3 @@ _rpm_ostree_refsack_unref (RpmOstreeRefSack *rsack)
   g_free (rsack->temp_path);
   g_free (rsack);
 }
-
-RpmOstreeRefSack *
-_rpm_ostree_get_refsack_for_commit (OstreeRepo                *repo,
-                                    const char                *ref,
-                                    GCancellable              *cancellable,
-                                    GError                   **error)
-{
-  RpmOstreeRefSack *ret = NULL;
-  g_autofree char *tempdir = NULL;
-  glnx_fd_close int tempdir_dfd = -1;
-  HySack hsack; 
-  
-  if (!rpmostree_checkout_only_rpmdb_tempdir (repo, ref, &tempdir, &tempdir_dfd,
-                                              cancellable, error))
-    goto out;
-  
-  if (!rpmostree_get_sack_for_root (tempdir_dfd, ".",
-                                    &hsack, cancellable, error))
-    goto out;
-
-  ret = _rpm_ostree_refsack_new (hsack, AT_FDCWD, tempdir);
-  tempdir = NULL; /* Transfer ownership */
- out:
-  if (tempdir)
-    (void) glnx_shutil_rm_rf_at (AT_FDCWD, tempdir, NULL, NULL);
-  return ret;
-}
-

--- a/src/libpriv/rpmostree-refsack.h
+++ b/src/libpriv/rpmostree-refsack.h
@@ -33,13 +33,13 @@ typedef struct {
 } RpmOstreeRefSack;
 
 RpmOstreeRefSack *
-_rpm_ostree_refsack_new (HySack sack, int temp_base_dfd, const char *temp_path);
+rpmostree_refsack_new (HySack sack, int temp_base_dfd, const char *temp_path);
 
 RpmOstreeRefSack *
-_rpm_ostree_refsack_ref (RpmOstreeRefSack *rsack);
+rpmostree_refsack_ref (RpmOstreeRefSack *rsack);
 
 void
-_rpm_ostree_refsack_unref (RpmOstreeRefSack *rsack);
+rpmostree_refsack_unref (RpmOstreeRefSack *rsack);
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRefSack, _rpm_ostree_refsack_unref);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRefSack, rpmostree_refsack_unref);
 

--- a/src/libpriv/rpmostree-refsack.h
+++ b/src/libpriv/rpmostree-refsack.h
@@ -41,11 +41,5 @@ _rpm_ostree_refsack_ref (RpmOstreeRefSack *rsack);
 void
 _rpm_ostree_refsack_unref (RpmOstreeRefSack *rsack);
 
-RpmOstreeRefSack *
-_rpm_ostree_get_refsack_for_commit (OstreeRepo                *repo,
-                                    const char                *ref,
-                                    GCancellable              *cancellable,
-                                    GError                   **error);
-
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRefSack, _rpm_ostree_refsack_unref);
 

--- a/src/libpriv/rpmostree-refts.c
+++ b/src/libpriv/rpmostree-refts.c
@@ -1,0 +1,64 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Colin Walters <walters@verbum.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include "rpmostree-refts.h"
+#include "rpmostree-rpm-util.h"
+
+/*
+ * A wrapper for an `rpmts` that supports:
+ *
+ *  - Reference counting
+ *  - Possibly holding a pointer to a tempdir, and cleaning it when unref'd
+ */
+
+RpmOstreeRefTs *
+rpmostree_refts_new (rpmts ts, int temp_base_dfd, const char *temp_path)
+{
+  RpmOstreeRefTs *rts = g_new0 (RpmOstreeRefTs, 1);
+  rts->ts = ts;
+  rts->refcount = 1;
+  rts->temp_base_dfd = temp_base_dfd;
+  rts->temp_path = g_strdup (temp_path);
+  return rts;
+}
+
+RpmOstreeRefTs *
+rpmostree_refts_ref (RpmOstreeRefTs *rts)
+{
+  g_atomic_int_inc (&rts->refcount);
+  return rts;
+}
+
+void
+rpmostree_refts_unref (RpmOstreeRefTs *rts)
+{
+  if (!g_atomic_int_dec_and_test (&rts->refcount))
+    return;
+  rpmtsFree (rts->ts);
+  
+  if (rts->temp_path)
+    (void) glnx_shutil_rm_rf_at (rts->temp_base_dfd, rts->temp_path, NULL, NULL);
+
+  g_free (rts->temp_path);
+  g_free (rts);
+}

--- a/src/libpriv/rpmostree-refts.h
+++ b/src/libpriv/rpmostree-refts.h
@@ -1,0 +1,45 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Red Hat, In.c
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#pragma once
+
+#include <hawkey/package.h>
+#include <hawkey/sack.h>
+#include "rpmostree-cleanup.h"
+
+typedef struct {
+  volatile gint refcount;
+  rpmts ts;
+  int temp_base_dfd;
+  char *temp_path;
+} RpmOstreeRefTs;
+
+RpmOstreeRefTs *
+rpmostree_refts_new (rpmts ts, int temp_base_dfd, const char *temp_path);
+
+RpmOstreeRefTs *
+rpmostree_refts_ref (RpmOstreeRefTs *rts);
+
+void
+rpmostree_refts_unref (RpmOstreeRefTs *rts);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRefTs, rpmostree_refts_unref);
+

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -836,17 +836,17 @@ rpmostree_get_refsack_for_root (int              dfd,
                           &sack, cancellable, error))
     goto out;
 
-  ret = _rpm_ostree_refsack_new (sack, AT_FDCWD, NULL);
+  ret = rpmostree_refsack_new (sack, AT_FDCWD, NULL);
  out:
   return ret;
 }
 
 
 RpmOstreeRefSack *
-_rpm_ostree_get_refsack_for_commit (OstreeRepo                *repo,
-                                    const char                *ref,
-                                    GCancellable              *cancellable,
-                                    GError                   **error)
+rpmostree_get_refsack_for_commit (OstreeRepo                *repo,
+                                  const char                *ref,
+                                  GCancellable              *cancellable,
+                                  GError                   **error)
 {
   RpmOstreeRefSack *ret = NULL;
   g_autofree char *tempdir = NULL;
@@ -861,7 +861,7 @@ _rpm_ostree_get_refsack_for_commit (OstreeRepo                *repo,
                           &hsack, cancellable, error))
     goto out;
 
-  ret = _rpm_ostree_refsack_new (hsack, AT_FDCWD, tempdir);
+  ret = rpmostree_refsack_new (hsack, AT_FDCWD, tempdir);
   tempdir = NULL; /* Transfer ownership */
  out:
   if (tempdir)

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -36,6 +36,14 @@
 GS_DEFINE_CLEANUP_FUNCTION0(rpmtd, _cleanup_rpmtdFreeData, rpmtdFreeData);
 #define _cleanup_rpmtddata_ __attribute__((cleanup(_cleanup_rpmtdFreeData)))
 
+struct RpmRevisionData
+{
+  struct RpmHeaders *rpmdb;
+  GFile *root;
+  char *tempdir;
+  char *commit;
+};
+
 static int
 header_name_cmp (Header h1, Header h2)
 {
@@ -726,6 +734,18 @@ rpmrev_new (OstreeRepo *repo, const char *rev,
   if (created_tmpdir && tempdir)
     (void) glnx_shutil_rm_rf_at (AT_FDCWD, tempdir, NULL, NULL);
   return rpmrev;
+}
+
+struct RpmHeaders *
+rpmrev_get_headers (struct RpmRevisionData *self)
+{
+  return self->rpmdb;
+}
+
+const char *
+rpmrev_get_commit (struct RpmRevisionData *self)
+{
+  return self->commit;
 }
 
 void

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -39,7 +39,7 @@ GS_DEFINE_CLEANUP_FUNCTION0(rpmtd, _cleanup_rpmtdFreeData, rpmtdFreeData);
 struct RpmRevisionData
 {
   struct RpmHeaders *rpmdb;
-  char *tempdir;
+  RpmOstreeRefTs *refts;
   char *commit;
 };
 
@@ -224,27 +224,16 @@ header_cmp_p (gconstpointer gph1, gconstpointer gph2)
 }
 
 static struct RpmHeaders *
-rpmhdrs_new (const char *root, const GPtrArray *patterns)
+rpmhdrs_new (RpmOstreeRefTs *refts, const GPtrArray *patterns)
 {
-  rpmts ts = rpmtsCreate();
-  int status = -1;
   rpmdbMatchIterator iter;
   Header h1;
   GPtrArray *hs = NULL;
   struct RpmHeaders *ret = NULL;
   gsize patprefixlen = pat_fnmatch_prefix (patterns);
 
-  // rpm also aborts on mem errors, so this is fine.
-  g_assert (ts);
-  rpmtsSetVSFlags (ts, _RPMVSF_NODIGESTS | _RPMVSF_NOSIGNATURES);
-
-  // This only fails if root isn't absolute.
-  g_assert (root && root[0] == '/');
-  status = rpmtsSetRootDir (ts, root);
-  g_assert (status == 0);
-
   /* iter = rpmtsInitIterator (ts, RPMTAG_NAME, "yum", 0); */
-  iter = rpmtsInitIterator (ts, RPMDBI_PACKAGES, NULL, 0);
+  iter = rpmtsInitIterator (refts->ts, RPMDBI_PACKAGES, NULL, 0);
 
   hs = g_ptr_array_new_with_free_func (header_free_p);
   while ((h1 = rpmdbNextIterator (iter)))
@@ -265,7 +254,7 @@ rpmhdrs_new (const char *root, const GPtrArray *patterns)
 
   ret = g_malloc0 (sizeof (struct RpmHeaders));
 
-  ret->ts = ts;
+  ret->refts = rpmostree_refts_ref (refts);
   ret->hs = hs;
 
   return ret;
@@ -276,7 +265,7 @@ rpmhdrs_free (struct RpmHeaders *l1)
 {
   g_ptr_array_free (l1->hs, TRUE);
   l1->hs = NULL;
-  l1->ts = rpmtsFree (l1->ts);
+  rpmostree_refts_unref (l1->refts);
 
   g_free (l1);
 }
@@ -665,16 +654,21 @@ rpmrev_new (OstreeRepo *repo, const char *rev,
             GError        **error)
 {
   struct RpmRevisionData *rpmrev = NULL;
-  g_autofree char *tempdir = NULL;
+  g_autofree char *commit = NULL;
+  g_autoptr(RpmOstreeRefTs) refts = NULL;
 
-  if (!rpmostree_checkout_only_rpmdb_tempdir (repo, rev, &tempdir, NULL,
-                                              cancellable, error))
+  if (!ostree_repo_resolve_rev (repo, rev, FALSE, &commit, error))
+    goto out;
+
+  if (!rpmostree_get_refts_for_commit (repo, commit, &refts, cancellable, error))
     goto out;
 
   rpmrev = g_malloc0 (sizeof(struct RpmRevisionData));
-  rpmrev->tempdir = tempdir;  tempdir = NULL;
-  rpmrev->commit = g_strdup (rev);
-  rpmrev->rpmdb = rpmhdrs_new (rpmrev->tempdir, patterns);
+  rpmrev->refts = refts;
+  refts = NULL;
+  rpmrev->commit = commit;
+  commit = NULL;
+  rpmrev->rpmdb = rpmhdrs_new (rpmrev->refts, patterns);
 
  out:
   return rpmrev;
@@ -701,11 +695,7 @@ rpmrev_free (struct RpmRevisionData *ptr)
   rpmhdrs_free (ptr->rpmdb);
   ptr->rpmdb = NULL;
 
-  if (ptr->tempdir)
-    {
-      (void) glnx_shutil_rm_rf_at (AT_FDCWD, ptr->tempdir, NULL, NULL);
-      g_clear_pointer (&ptr->tempdir, g_free);
-    }
+  rpmostree_refts_unref (ptr->refts);
 
   g_clear_pointer (&ptr->commit, g_free);
 

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -813,6 +813,16 @@ rpmostree_checkout_only_rpmdb_tempdir (OstreeRepo       *repo,
                                      cancellable, error))
     goto out;
 
+  /* And make a compat symlink to keep rpm happy */ 
+  if (!glnx_shutil_mkdir_p_at (tempdir_dfd, "var/lib", 0777, cancellable, error))
+    goto out;
+
+  if (symlinkat ("../../usr/share/rpm", tempdir_dfd, "var/lib/rpm") == -1)
+    {
+      glnx_set_error_from_errno (error);
+      goto out;
+    }
+
   *out_tempdir = tempdir;
   tempdir = NULL;
   if (out_tempdir_dfd)

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -870,6 +870,38 @@ rpmostree_get_refsack_for_commit (OstreeRepo                *repo,
 }
 
 gboolean
+rpmostree_get_refts_for_commit (OstreeRepo                *repo,
+                                const char                *ref,
+                                RpmOstreeRefTs           **out_ts,
+                                GCancellable              *cancellable,
+                                GError                   **error)
+{
+  gboolean ret = FALSE;
+  g_autofree char *tempdir = NULL;
+  rpmts ts;
+  int r;
+  
+  if (!rpmostree_checkout_only_rpmdb_tempdir (repo, ref, &tempdir, NULL,
+                                              cancellable, error))
+    goto out;
+
+  ts = rpmtsCreate ();
+  /* This actually makes sense because we know we've verified it at build time */
+  rpmtsSetVSFlags (ts, _RPMVSF_NODIGESTS | _RPMVSF_NOSIGNATURES);
+
+  r = rpmtsSetRootDir (ts, tempdir);
+  g_assert_cmpint (r, ==, 0);
+  
+  ret = TRUE;
+  *out_ts = rpmostree_refts_new (ts, AT_FDCWD, tempdir);
+  tempdir = NULL; /* Transfer ownership */
+ out:
+  if (tempdir)
+    (void) glnx_shutil_rm_rf_at (AT_FDCWD, tempdir, NULL, NULL);
+  return ret;
+}
+
+gboolean
 rpmostree_get_pkglist_for_root (int               dfd,
                                 const char       *path,
                                 RpmOstreeRefSack **out_refsack,

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -89,6 +89,14 @@ GS_DEFINE_CLEANUP_FUNCTION0(struct RpmRevisionData *, _cleanup_rpmrev_free, rpmr
 #define _cleanup_rpmrev_ __attribute__((cleanup(_cleanup_rpmrev_free)))
 
 gboolean
+rpmostree_checkout_only_rpmdb_tempdir (OstreeRepo       *repo,
+                                       const char       *ref,
+                                       char            **out_tempdir,
+                                       int              *out_tempdir_dfd,
+                                       GCancellable     *cancellable,
+                                       GError          **error);
+
+gboolean
 rpmostree_get_sack_for_root (int               dfd,
                              const char       *path,
                              HySack           *out_sack,

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -55,24 +55,18 @@ rpmhdrs_diff (struct RpmHeaders *l1,
               struct RpmHeaders *l2);
 
 void
-rpmhdrs_list (GFile *root,
-              struct RpmHeaders *l1);
+rpmhdrs_list (struct RpmHeaders *l1);
 
 char *
-rpmhdrs_rpmdbv (GFile *root,
-                struct RpmHeaders *l1,
+rpmhdrs_rpmdbv (struct RpmHeaders *l1,
                 GCancellable *cancellable,
                 GError **error);
 
 void
-rpmhdrs_diff_prnt_block (GFile *root1,
-                         GFile *root2,
-                         struct RpmHeadersDiff *diff);
+rpmhdrs_diff_prnt_block (struct RpmHeadersDiff *diff);
 
 void
-rpmhdrs_diff_prnt_diff (GFile *root1,
-                        GFile *root2,
-                        struct RpmHeadersDiff *diff);
+rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff);
 
 struct RpmRevisionData *
 rpmrev_new (OstreeRepo *repo,

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -43,13 +43,7 @@ struct RpmHeadersDiff
   GPtrArray *hs_mod_new; /* list of rpm header objects from <rpm.h> = Header */
 };
 
-struct RpmRevisionData
-{
-  struct RpmHeaders *rpmdb;
-  GFile *root;
-  char *tempdir;
-  char *commit;
-};
+struct RpmRevisionData;
 
 struct RpmHeadersDiff *
 rpmhdrs_diff (struct RpmHeaders *l1,
@@ -75,6 +69,10 @@ rpmrev_new (OstreeRepo *repo,
             const GPtrArray *patterns,
             GCancellable *cancellable,
             GError **error);
+
+struct RpmHeaders *rpmrev_get_headers (struct RpmRevisionData *self);
+
+const char *rpmrev_get_commit (struct RpmRevisionData *self);
 
 void
 rpmrev_free (struct RpmRevisionData *ptr);

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -26,6 +26,7 @@
 #include <rpm/rpmlog.h>
 #include "rpmostree-util.h"
 #include "rpmostree-refsack.h"
+#include "rpmostree-refts.h"
 #include "rpmostree-cleanup.h"
 
 #include "libglnx.h"
@@ -100,6 +101,13 @@ rpmostree_get_refsack_for_root (int              dfd,
                                 const char      *path,
                                 GCancellable    *cancellable,
                                 GError         **error);
+
+gboolean
+rpmostree_get_refts_for_commit (OstreeRepo                *repo,
+                                const char                *ref,
+                                RpmOstreeRefTs           **out_ts,
+                                GCancellable              *cancellable,
+                                GError                   **error);
 
 gboolean
 rpmostree_get_pkglist_for_root (int               dfd,

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -25,6 +25,7 @@
 #include <rpm/rpmlib.h>
 #include <rpm/rpmlog.h>
 #include "rpmostree-util.h"
+#include "rpmostree-refsack.h"
 #include "rpmostree-cleanup.h"
 
 #include "libglnx.h"
@@ -88,17 +89,22 @@ rpmostree_checkout_only_rpmdb_tempdir (OstreeRepo       *repo,
                                        GCancellable     *cancellable,
                                        GError          **error);
 
-gboolean
-rpmostree_get_sack_for_root (int               dfd,
-                             const char       *path,
-                             HySack           *out_sack,
-                             GCancellable     *cancellable,
-                             GError          **error);
+RpmOstreeRefSack *
+_rpm_ostree_get_refsack_for_commit (OstreeRepo                *repo,
+                                    const char                *ref,
+                                    GCancellable              *cancellable,
+                                    GError                   **error);
+
+RpmOstreeRefSack *
+rpmostree_get_refsack_for_root (int              dfd,
+                                const char      *path,
+                                GCancellable    *cancellable,
+                                GError         **error);
 
 gboolean
 rpmostree_get_pkglist_for_root (int               dfd,
                                 const char       *path,
-                                HySack           *out_sack,
+                                RpmOstreeRefSack **out_refsack,
                                 HyPackageList    *out_pkglist,
                                 GCancellable     *cancellable,
                                 GError          **error);

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -47,6 +47,7 @@ struct RpmRevisionData
 {
   struct RpmHeaders *rpmdb;
   GFile *root;
+  char *tempdir;
   char *commit;
 };
 
@@ -70,7 +71,6 @@ rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff);
 
 struct RpmRevisionData *
 rpmrev_new (OstreeRepo *repo,
-            GFile *rpmdbdir,
             const char *rev,
             const GPtrArray *patterns,
             GCancellable *cancellable,

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -90,10 +90,10 @@ rpmostree_checkout_only_rpmdb_tempdir (OstreeRepo       *repo,
                                        GError          **error);
 
 RpmOstreeRefSack *
-_rpm_ostree_get_refsack_for_commit (OstreeRepo                *repo,
-                                    const char                *ref,
-                                    GCancellable              *cancellable,
-                                    GError                   **error);
+rpmostree_get_refsack_for_commit (OstreeRepo                *repo,
+                                  const char                *ref,
+                                  GCancellable              *cancellable,
+                                  GError                   **error);
 
 RpmOstreeRefSack *
 rpmostree_get_refsack_for_root (int              dfd,

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -33,7 +33,7 @@
 
 struct RpmHeaders
 {
-  rpmts ts; /* rpm transaction set the headers belong to */
+  RpmOstreeRefTs *refts; /* rpm transaction set the headers belong to */
   GPtrArray *hs; /* list of rpm header objects from <rpm.h> = Header */
 };
 


### PR DESCRIPTION
This commit implements https://github.com/projectatomic/rpm-ostree/issues/24

Needs to be cleaned up, and isn't quite as much of a speedup as I
thought, because unfortunately the "lookup package owner of file" is
actually a non-indexed (i.e. loop over all pkgs) operation in libsolv
=( =( =(

We might be able to fix this by using librpm directly which from my
current reading of the source code has some caching for this.