### PR TITLE
(cleanup): Move the refsack and root loading code into libpriv

### DIFF
--- a/Makefile-lib.am
+++ b/Makefile-lib.am
@@ -27,7 +27,6 @@ librpmostreeinclude_HEADERS = $(librpmostree_public_headers)
 librpmostree_1_la_SOURCES = \
 	src/lib/rpmostree-db.c \
 	src/lib/rpmostree-package.c \
-	src/lib/rpmostree-refsack.c \
 	$(NULL)
 
 librpmostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/src/libpriv -I$(srcdir)/src/lib \

--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -26,6 +26,8 @@ librpmostreepriv_la_SOURCES = \
 	src/libpriv/rpmostree-util.h \
 	src/libpriv/rpmostree-passwd-util.c \
 	src/libpriv/rpmostree-passwd-util.h \
+	src/libpriv/rpmostree-refsack.h \
+	src/libpriv/rpmostree-refsack.c \
 	src/libpriv/rpmostree-cleanup.h \
 	src/libpriv/rpmostree-rpm-util.c \
 	src/libpriv/rpmostree-rpm-util.h \

--- a/src/lib/rpmostree-db.c
+++ b/src/lib/rpmostree-db.c
@@ -23,9 +23,10 @@
 #include "string.h"
 
 #include "rpmostree-db.h"
-#include "rpmostree-priv.h"
 #include "rpmostree-cleanup.h"
 #include "rpmostree-rpm-util.h"
+#include "rpmostree-package-priv.h"
+#include "rpmostree-refsack.h"
 
 /**
  * SECTION:librpmostree-dbquery
@@ -35,56 +36,6 @@
  * These APIs provide queryable access to the RPM database inside an
  * OSTree repository.
  */
-
-static RpmOstreeRefSack *
-get_refsack_for_commit (OstreeRepo                *repo,
-                        const char                *ref,
-                        GCancellable              *cancellable,
-                        GError                   **error)
-{
-  g_autofree char *commit = NULL;
-  g_autofree char *tempdir = g_strdup ("/tmp/rpmostree-dbquery-XXXXXXXX");
-  OstreeRepoCheckoutOptions checkout_options = { 0, };
-  glnx_fd_close int tempdir_dfd = -1;
-
-  if (!ostree_repo_resolve_rev (repo, ref, FALSE, &commit, error))
-    goto out;
-
-  if (mkdtemp (tempdir) == NULL)
-    {
-      glnx_set_error_from_errno (error);
-      goto out;
-    }
-
-  if (!glnx_opendirat (AT_FDCWD, tempdir, FALSE, &tempdir_dfd, error))
-    goto out;
-
-  /* Create intermediate dirs */ 
-  if (!glnx_shutil_mkdir_p_at (tempdir_dfd, "usr/share", 0777, cancellable, error))
-    goto out;
-
-  checkout_options.mode = OSTREE_REPO_CHECKOUT_MODE_USER;
-  checkout_options.subpath = "usr/share/rpm";
-
-  if (!ostree_repo_checkout_tree_at (repo, &checkout_options,
-                                     tempdir_dfd, "usr/share/rpm",
-                                     commit, 
-                                     cancellable, error))
-    goto out;
-
-  {
-    HySack hsack; 
-
-    if (!rpmostree_get_sack_for_root (tempdir_dfd, ".",
-                                      &hsack, cancellable, error))
-      goto out;
-
-    return _rpm_ostree_refsack_new (hsack, AT_FDCWD, tempdir);
-  }
-
- out:
-  return NULL;
-}
 
 static GPtrArray *
 query_all_packages_in_sack (RpmOstreeRefSack *rsack)
@@ -130,7 +81,7 @@ rpm_ostree_db_query_all (OstreeRepo                *repo,
 {
   g_autoptr(RpmOstreeRefSack) rsack = NULL;
 
-  rsack = get_refsack_for_commit (repo, ref, cancellable, error);
+  rsack = _rpm_ostree_get_refsack_for_commit (repo, ref, cancellable, error);
 
   return query_all_packages_in_sack (rsack);
 }
@@ -186,7 +137,7 @@ rpm_ostree_db_diff (OstreeRepo               *repo,
   g_return_val_if_fail (out_removed != NULL && out_added != NULL &&
                         out_modified_old != NULL && out_modified_new != NULL, FALSE);
 
-  orig_sack = get_refsack_for_commit (repo, orig_ref, cancellable, error);
+  orig_sack = _rpm_ostree_get_refsack_for_commit (repo, orig_ref, cancellable, error);
   if (!orig_sack)
     goto out;
 
@@ -195,7 +146,7 @@ rpm_ostree_db_diff (OstreeRepo               *repo,
     orig_pkglist = hy_query_run (query);
   }
 
-  new_sack = get_refsack_for_commit (repo, new_ref, cancellable, error);
+  new_sack = _rpm_ostree_get_refsack_for_commit (repo, new_ref, cancellable, error);
   if (!new_sack)
     goto out;
 

--- a/src/lib/rpmostree-package-priv.h
+++ b/src/lib/rpmostree-package-priv.h
@@ -1,0 +1,28 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2015 Red Hat, In.c
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#pragma once
+
+#include "rpmostree-package.h"
+#include "rpmostree-refsack.h"
+
+RpmOstreePackage * _rpm_ostree_package_new (RpmOstreeRefSack *rsack, HyPackage hypkg);
+

--- a/src/lib/rpmostree-package.c
+++ b/src/lib/rpmostree-package.c
@@ -30,7 +30,7 @@
 
 #include "config.h"
 
-#include "rpmostree-priv.h"
+#include "rpmostree-package-priv.h"
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/libpriv/rpmostree-refsack.h
+++ b/src/libpriv/rpmostree-refsack.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <rpmostree-package.h>
 #include <hawkey/package.h>
 #include <hawkey/sack.h>
 #include "rpmostree-cleanup.h"
@@ -33,9 +32,6 @@ typedef struct {
   char *temp_path;
 } RpmOstreeRefSack;
 
-RpmOstreePackage *
-_rpm_ostree_package_new (RpmOstreeRefSack *rsack, HyPackage hypkg);
-
 RpmOstreeRefSack *
 _rpm_ostree_refsack_new (HySack sack, int temp_base_dfd, const char *temp_path);
 
@@ -44,6 +40,12 @@ _rpm_ostree_refsack_ref (RpmOstreeRefSack *rsack);
 
 void
 _rpm_ostree_refsack_unref (RpmOstreeRefSack *rsack);
+
+RpmOstreeRefSack *
+_rpm_ostree_get_refsack_for_commit (OstreeRepo                *repo,
+                                    const char                *ref,
+                                    GCancellable              *cancellable,
+                                    GError                   **error);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRefSack, _rpm_ostree_refsack_unref);
 


### PR DESCRIPTION
We had `src/lib` having its own little private library; I wanted to
use some of it inside `src/libpriv`, so let's consistently have all
private utility code in `src/libpriv`.