### PR TITLE
compose-sign: Note deprecation

### DIFF
--- a/src/app/rpmostree-compose-builtin-sign.c
+++ b/src/app/rpmostree-compose-builtin-sign.c
@@ -68,6 +68,9 @@ rpmostree_compose_builtin_sign (int            argc,
       goto out;
     }
 
+  g_printerr ("This command is deprecated in favor of using `ostree gpg-sign`,\n"
+              "or a custom signing command written with the OSTree API.\n");
+
   repopath = g_file_new_for_path (opt_repo_path);
   repo = ostree_repo_new (repopath);
   if (!ostree_repo_open (repo, cancellable, error))


### PR DESCRIPTION
This binary was hardcoded for a Red Hat internal tool; use the newer
`ostree gpg-sign` or a custom tool.
