### PR TITLE
Sort subcommands alphabetically

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -36,11 +36,11 @@ static RpmOstreeCommand commands[] = {
 #ifdef HAVE_COMPOSE_TOOLING
   { "compose", rpmostree_builtin_compose },
 #endif
-  { "upgrade", rpmostree_builtin_upgrade },
+  { "db", rpmostree_builtin_db },
   { "rebase", rpmostree_builtin_rebase },
   { "rollback", rpmostree_builtin_rollback },
   { "status", rpmostree_builtin_status },
-  { "db", rpmostree_builtin_db },
+  { "upgrade", rpmostree_builtin_upgrade },
   { NULL }
 };
 


### PR DESCRIPTION
This change causes the subcommands to be sorted alphabetically when
`rpm-ostree` is invoked without an argument or with `--help`.  This
matches the behavior of the `ostree` command.