### PR TITLE
compose: Fix "too old" error for "old" file:/// repos

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -206,6 +206,7 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
   hif_context_set_install_root (hifctx, gs_file_get_path_cached (yumroot));
 
   hif_context_set_cache_dir (hifctx, cachedir);
+  hif_context_set_cache_age (hifctx, G_MAXUINT);
   hif_context_set_solv_dir (hifctx, solvdir);
   hif_context_set_lock_dir (hifctx, lockdir);
   hif_context_set_check_disk_space (hifctx, FALSE);


### PR DESCRIPTION
Bodhi points rpm-ostree at the "gold" Fedora repo via `file:///`, and
libhif is brokenly checking the mtime on `file://` repos.

Work around that here by just ignoring cache ages, because at present
we don't actually cache really - we drop the RPMs in the tempdir.

(Long term having actual caching of the RPMs would be nice, but
 we can revisit this when we get there)

Closes #156