### PR TITLE
postprocess: provide --gzip and --reproducible to dracut

### DIFF
--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -345,6 +345,8 @@ do_kernel_prep (GFile         *yumroot,
     g_ptr_array_add (dracut_argv, "dracut");
     g_ptr_array_add (dracut_argv, "-v");
     g_ptr_array_add (dracut_argv, "--tmpdir=/tmp");
+    g_ptr_array_add (dracut_argv, "--reproducible");
+    g_ptr_array_add (dracut_argv, "--gzip");
     g_ptr_array_add (dracut_argv, "-f");
     g_ptr_array_add (dracut_argv, "/var/tmp/initramfs.img");
     g_ptr_array_add (dracut_argv, (char*)kver);


### PR DESCRIPTION
This should help to generate the same initrd when the files didn't
change.

Newer versions of gzip (or pigz when available) can generate rsync
friendly files and if present, Dracut already takes advantage of it.

Also use --reproducible, to instruct Dracut to generate CPIO
reproducible files.  It is required a version of GNU CPIO that
has support for it.

Dracut has --reproducible for almost a year, so use it inconditionally.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>