### PR TITLE
tests/test-basic.sh: make dots literal

### DIFF
--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -40,7 +40,7 @@ ostree admin --sysroot=sysroot deploy --karg=root=LABEL=MOO --karg=quiet --os=te
 
 rpm-ostree status | tee OUTPUT-status.txt
 
-assert_file_has_content OUTPUT-status.txt '1.0.10'
+assert_file_has_content OUTPUT-status.txt '1\.0\.10'
 
 os_repository_new_commit
 rpm-ostree upgrade --os=testos
@@ -50,6 +50,6 @@ rpm-ostree rebase --os=testos otheros:
 
 rpm-ostree status | tee OUTPUT-status.txt
 
-assert_not_file_has_content OUTPUT-status.txt '1.0.10'
-version=$(date "+%Y%m%d.0")
+assert_not_file_has_content OUTPUT-status.txt '1\.0\.10'
+version=$(date "+%Y%m%d\.0")
 assert_file_has_content OUTPUT-status.txt $version


### PR DESCRIPTION
The assert[_not]_file_has_content functions used grep to check the
pattern against the content. This meant that the '.' characters are
interpreted as "any char". Yesterday, the date was 20150910 and thus the
otheros' tree's version was labelled as such. This date also happens to
match the 1.0.10 pattern, and thus caused the test to fail.

This patch makes sure this doesn't happen again by escaping all the dots
to make them literal.