### PR TITLE
add .ci-test.sh: new script for CI testing

### DIFF
--- a/.ci-test.sh
+++ b/.ci-test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# add testuser if it's not already there
+if ! id -u testuser &>/dev/null; then
+  sudo adduser testuser
+fi
+
+sh autogen.sh --prefix=/usr --enable-installed-tests
+make
+make check
+sudo make install
+sudo gnome-desktop-testing-runner rpm-ostree
+sudo --user=testuser gnome-desktop-testing-runner rpm-ostree


### PR DESCRIPTION
This patch adds a small script that can be integrated into any CI
workflow. The advantages of keeping this upstream include:

1. anyone can use it and integrate it into their own CI
2. represents a publicly-accessible base requirement for patch validity
3. patches which change testing methods can include a patch to this
   script to reflect that