### PR TITLE
daemon: Add info dictionary to cached results

### DIFF
--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -128,7 +128,9 @@ rpmostree_builtin_upgrade (int             argc,
       gs_unref_object GFile *rpmdbdir = NULL;
       gs_unref_object GFile *sysroot_file = NULL;
       g_autofree char *origin_description = NULL;
+      g_autoptr(GVariant) cached_update = NULL;
       const char *sysroot_path;
+      GVariantDict upgrade_dict;
 
       _cleanup_rpmrev_ struct RpmRevisionData *rpmrev1 = NULL;
       _cleanup_rpmrev_ struct RpmRevisionData *rpmrev2 = NULL;
@@ -149,7 +151,11 @@ rpmostree_builtin_upgrade (int             argc,
       if (!ostree_sysroot_get_repo (sysroot, &repo, cancellable, error))
         goto out;
 
-      origin_description = rpmostree_os_dup_upgrade_origin (os_proxy);
+      cached_update = rpmostree_os_dup_cached_update(os_proxy);
+      g_variant_dict_init (&upgrade_dict, cached_update);
+      if (!g_variant_dict_lookup (&upgrade_dict, "origin", "s", &origin_description))
+        goto out;
+
       if (!ostree_parse_refspec (origin_description, &remote, &ref, error))
          goto out;
 

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -64,9 +64,18 @@
       <arg type="a(sua{sv})" name="result" direction="out"/>
     </method>
 
+    <!-- details dictionary keys:
+       'osname' (type 's')
+       'checksum' (type 's')
+       'version' (type 's')
+       'timestamp' (type 't')
+       'origin' (type 's')
+       'signatures' (type 'av')
+    -->
     <method name="GetCachedUpdateRpmDiff">
       <arg type="s" name="deployid"/>
       <arg type="a(sua{sv})" name="result" direction="out"/>
+      <arg type="a{sv}" name="details" direction="out"/>
     </method>
 
     <method name="DownloadUpdateRpmDiff">
@@ -99,10 +108,19 @@
       <arg type="s" name="transaction_address" direction="out"/>
     </method>
 
+    <!-- details dictionary keys:
+       'osname' (type 's')
+       'checksum' (type 's')
+       'version' (type 's')
+       'timestamp' (type 't')
+       'origin' (type 's')
+       'signatures' (type 'av')
+    -->
     <method name="GetCachedRebaseRpmDiff">
       <arg type="s" name="refspec"/>
       <arg type="as" name="packages"/>
       <arg type="a(sua{sv})" name="result" direction="out"/>
+      <arg type="a{sv}" name="details" direction="out"/>
     </method>
 
     <method name="DownloadRebaseRpmDiff">

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -42,7 +42,16 @@
     <property name="BootedDeployment" type="a{sv}" access="read"/>
     <property name="DefaultDeployment" type="a{sv}" access="read"/>
     <property name="RollbackDeployment" type="a{sv}" access="read"/>
-    <property name="UpgradeOrigin" type="s" access="read"/>
+
+    <!-- CachedUpdate dictionary keys:
+       'osname' (type 's')
+       'checksum' (type 's')
+       'version' (type 's')
+       'timestamp' (type 't')
+       'origin' (type 's')
+       'signatures' (type 'av')
+    -->
+    <property name="CachedUpdate" type="a{sv}" access="read"/>
     <property name="HasCachedUpdateRpmDiff" type="b" access="read"/>
 
     <!-- NONE, DIFF, PREPARE, REBOOT -->

--- a/src/daemon/rpmostreed-deployment-utils.h
+++ b/src/daemon/rpmostreed-deployment-utils.h
@@ -35,6 +35,10 @@ GVariant *      rpmostreed_deployment_generate_blank_variant (void);
 GVariant *      rpmostreed_deployment_generate_variant (OstreeDeployment *deployment,
                                                         OstreeRepo *repo);
 
+GVariant *      rpmostreed_commit_generate_cached_details_variant (OstreeDeployment *deployment,
+                                                                   OstreeRepo *repo,
+                                                                   const gchar *refspec);
+
 gint            rpmostreed_rollback_deployment_index (const gchar *name,
                                                       OstreeSysroot *ot_sysroot,
                                                       GError **error);


### PR DESCRIPTION
I'd like to propose returning a info dictionary from the methods that return cached rpm diffs. This commit right now just changes the xml to the proposed api. If you like the idea then I can fill in the code.