### PR TITLE
Deploy any version

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -25,6 +25,7 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-compose-builtins.h \
 	src/app/rpmostree-builtin-upgrade.c \
 	src/app/rpmostree-builtin-rollback.c \
+	src/app/rpmostree-builtin-deploy.c \
 	src/app/rpmostree-builtin-rebase.c \
 	src/app/rpmostree-builtin-status.c \
 	src/app/rpmostree-builtin-db.c \

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -104,6 +104,12 @@ Boston, MA 02111-1307, USA.
         effect.</para>
 
         <para>
+          In addition to exit status 0 for success and 1 for error, this
+          command also uses exit status 77 to indicate that no upgrade is
+          available.
+        </para>
+
+        <para>
           <command>--reboot</command> or <command>-r </command> to initiate a reboot after upgrade is prepared.
         </para>
 
@@ -160,6 +166,12 @@ Boston, MA 02111-1307, USA.
             version of the current tree which may be newer or older than your
             running filesystem tree.  The tree to download can be specified by
             its SHA256 checksum, or by its "version" metadata value.
+          </para>
+
+          <para>
+            In addition to exit status 0 for success and 1 for error, this
+            command also uses exit status 77 to indicate that no deployment
+            change occurred.
           </para>
 
           <para>

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -152,6 +152,29 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
+        <term><command>deploy</command></term>
+
+        <listitem>
+          <para>
+            Similar to <literal>upgrade</literal>, but download a specific
+            version of the current tree which may be newer or older than your
+            running filesystem tree.  The tree to download can be specified by
+            its SHA256 checksum, or by its "version" metadata value.
+          </para>
+
+          <para>
+            <option>--reboot</option> or <option>-r</option> to initiate a
+            reboot after the downloaded tree is prepared.
+          </para>
+
+          <para>
+            <option>--preview</option> to download only /usr/share/rpm in
+            order to preview the package changes with the current tree.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><command>compose</command></term>
 	
 	<listitem><para>Entrypoint for tree composition; most

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -115,7 +115,9 @@ Boston, MA 02111-1307, USA.
 
           <para><command>--allow-downgrade</command> to permit deployment of chronologically older trees.</para>
 
-          <para><option>--check-diff</option> to download only /usr/share/rpm in order to do a package-level diff between the two versions.</para>
+          <para><option>--preview</option> to download only /usr/share/rpm in order to do a package-level diff between the two versions.</para>
+
+          <para><option>--check</option> to just check if an upgrade is available, without downloading it or performing a package-level diff.</para>
       </listitem>
       </varlistentry>
 

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -38,6 +38,7 @@ static RpmOstreeCommand commands[] = {
   { "compose", rpmostree_builtin_compose },
 #endif
   { "db", rpmostree_builtin_db },
+  { "deploy", rpmostree_builtin_deploy },
   { "rebase", rpmostree_builtin_rebase },
   { "rollback", rpmostree_builtin_rollback },
   { "status", rpmostree_builtin_status },

--- a/src/app/rpmostree-builtin-db.c
+++ b/src/app/rpmostree-builtin-db.c
@@ -25,7 +25,7 @@
 
 typedef struct {
   const char *name;
-  gboolean (*fn) (int argc, char **argv, GCancellable *cancellable, GError **error);
+  int (*fn) (int argc, char **argv, GCancellable *cancellable, GError **error);
 } RpmOstreeDbCommand;
 
 static RpmOstreeDbCommand rpm_subcommands[] = {
@@ -124,13 +124,13 @@ out:
   return success;
 }
 
-gboolean
+int
 rpmostree_builtin_db (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
   RpmOstreeDbCommand *subcommand;
   const char *subcommand_name = NULL;
   gs_free char *prgname = NULL;
-  gboolean ret = FALSE;
+  int exit_status = EXIT_SUCCESS;
   int in, out;
 
   for (in = 1, out = 1; in < argc; in++, out++)
@@ -189,6 +189,7 @@ rpmostree_builtin_db (int argc, char **argv, GCancellable *cancellable, GError *
               g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                            "Unknown \"db\" subcommand '%s'", subcommand_name);
             }
+          exit_status = EXIT_FAILURE;
         }
 
       help = g_option_context_get_help (context, FALSE, NULL);
@@ -202,11 +203,9 @@ rpmostree_builtin_db (int argc, char **argv, GCancellable *cancellable, GError *
   prgname = g_strdup_printf ("%s %s", g_get_prgname (), subcommand_name);
   g_set_prgname (prgname);
 
-  if (!subcommand->fn (argc, argv, cancellable, error))
-    goto out;
+  exit_status = subcommand->fn (argc, argv, cancellable, error);
 
-  ret = TRUE;
  out:
-  return ret;
+  return exit_status;
 }
 

--- a/src/app/rpmostree-builtin-deploy.c
+++ b/src/app/rpmostree-builtin-deploy.c
@@ -145,11 +145,23 @@ rpmostree_builtin_deploy (int            argc,
                                                               error))
         goto out;
 
+      if (g_variant_n_children (result) == 0)
+        {
+          exit_status = RPM_OSTREE_EXIT_UNCHANGED;
+          goto out;
+        }
+
       rpmostree_print_package_diffs (result);
     }
-  else if (!opt_reboot && default_deployment != NULL)
+  else if (!opt_reboot)
     {
       const char *sysroot_path;
+
+      if (default_deployment == NULL)
+        {
+          exit_status = RPM_OSTREE_EXIT_UNCHANGED;
+          goto out;
+        }
 
       sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
 

--- a/src/app/rpmostree-builtin-deploy.c
+++ b/src/app/rpmostree-builtin-deploy.c
@@ -1,0 +1,171 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include "rpmostree-builtins.h"
+#include "rpmostree-libbuiltin.h"
+#include "rpmostree-rpm-util.h"
+#include "rpmostree-dbus-helpers.h"
+
+#include <libglnx.h>
+
+static char *opt_osname;
+static gboolean opt_reboot;
+static gboolean opt_preview;
+
+static GOptionEntry option_entries[] = {
+  { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+  { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after upgrade is prepared", NULL },
+  /* XXX As much as I dislike the inconsistency with "rpm-ostree upgrade",
+   *     calling this option --check-diff doesn't really make sense here.
+   *     A --preview option would work for both commands if we wanted to
+   *     deprecate --check-diff. */
+  { "preview", 0, 0, G_OPTION_ARG_NONE, &opt_preview, "Just preview package differences", NULL },
+  { NULL }
+};
+
+static GVariant *
+get_args_variant (void)
+{
+  GVariantDict dict;
+
+  g_variant_dict_init (&dict, NULL);
+  g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
+
+  return g_variant_dict_end (&dict);
+}
+
+static void
+default_deployment_changed_cb (GObject *object,
+                               GParamSpec *pspec,
+                               GVariant **value)
+{
+  g_object_get (object, pspec->name, value, NULL);
+}
+
+int
+rpmostree_builtin_deploy (int            argc,
+                          char         **argv,
+                          GCancellable  *cancellable,
+                          GError       **error)
+{
+  int exit_status = EXIT_FAILURE;
+  GOptionContext *context;
+  glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
+  glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
+  g_autoptr(GVariant) default_deployment = NULL;
+  g_autofree char *transaction_address = NULL;
+  const char * const packages[] = { NULL };
+  const char *revision;
+
+  context = g_option_context_new ("REVISION - Deploy a specific commit");
+
+  if (!rpmostree_option_context_parse (context,
+                                       option_entries,
+                                       &argc, &argv,
+                                       RPM_OSTREE_BUILTIN_FLAG_NONE,
+                                       cancellable,
+                                       &sysroot_proxy,
+                                       error))
+    goto out;
+
+  if (argc < 2)
+    {
+      rpmostree_usage_error (context, "REVISION must be specified", error);
+      goto out;
+    }
+
+  revision = argv[1];
+
+  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
+                                cancellable, &os_proxy, error))
+    goto out;
+
+  if (opt_preview)
+    {
+      if (!rpmostree_os_call_download_deploy_rpm_diff_sync (os_proxy,
+                                                            revision,
+                                                            packages,
+                                                            &transaction_address,
+                                                            cancellable,
+                                                            error))
+        goto out;
+    }
+  else
+    {
+      /* This will set the GVariant if the default deployment changes. */
+      g_signal_connect (os_proxy, "notify::default-deployment",
+                        G_CALLBACK (default_deployment_changed_cb),
+                        &default_deployment);
+
+      if (!rpmostree_os_call_deploy_sync (os_proxy,
+                                          revision,
+                                          get_args_variant (),
+                                          &transaction_address,
+                                          cancellable,
+                                          error))
+        goto out;
+    }
+
+  if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
+                                                transaction_address,
+                                                cancellable,
+                                                error))
+    goto out;
+
+  if (opt_preview)
+    {
+      g_autoptr(GVariant) result = NULL;
+      g_autoptr(GVariant) details = NULL;
+
+      if (!rpmostree_os_call_get_cached_deploy_rpm_diff_sync (os_proxy,
+                                                              revision,
+                                                              packages,
+                                                              &result,
+                                                              &details,
+                                                              cancellable,
+                                                              error))
+        goto out;
+
+      rpmostree_print_package_diffs (result);
+    }
+  else if (!opt_reboot && default_deployment != NULL)
+    {
+      const char *sysroot_path;
+
+      sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
+
+      if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
+                                                           cancellable,
+                                                           error))
+        goto out;
+
+      g_print ("Run \"systemctl reboot\" to start a reboot\n");
+    }
+
+  exit_status = EXIT_SUCCESS;
+
+out:
+  /* Does nothing if using the message bus. */
+  rpmostree_cleanup_peer ();
+
+  return exit_status;
+}

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -80,11 +80,17 @@ rpmostree_builtin_rebase (int             argc,
                                        error))
     goto out;
 
+  if (argc < 2)
+    {
+      rpmostree_usage_error (context, "REFSPEC must be specified", error);
+      goto out;
+    }
+
+  new_provided_refspec = argv[1];
+
   if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
                                 cancellable, &os_proxy, error))
     goto out;
-
-  new_provided_refspec = argv[1];
 
   if (!rpmostree_os_call_rebase_sync (os_proxy,
                                       get_args_variant (),

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -54,13 +54,13 @@ get_args_variant (void)
   return g_variant_dict_end (&dict);
 }
 
-gboolean
+int
 rpmostree_builtin_rebase (int             argc,
                           char          **argv,
                           GCancellable   *cancellable,
                           GError        **error)
 {
-  gboolean ret = FALSE;
+  int exit_status = EXIT_FAILURE;
   const char *new_provided_refspec;
 
   /* forced blank for now */
@@ -122,11 +122,11 @@ rpmostree_builtin_rebase (int             argc,
       g_print ("Run \"systemctl reboot\" to start a reboot\n");
     }
 
-  ret = TRUE;
+  exit_status = EXIT_SUCCESS;
 
 out:
   /* Does nothing if using the message bus. */
   rpmostree_cleanup_peer ();
 
-  return ret;
+  return exit_status;
 }

--- a/src/app/rpmostree-builtin-rollback.c
+++ b/src/app/rpmostree-builtin-rollback.c
@@ -48,13 +48,13 @@ get_args_variant (void)
   return g_variant_dict_end (&dict);
 }
 
-gboolean
+int
 rpmostree_builtin_rollback (int             argc,
                             char          **argv,
                             GCancellable   *cancellable,
                             GError        **error)
 {
-  gboolean ret = FALSE;
+  int exit_status = EXIT_FAILURE;
 
   GOptionContext *context = g_option_context_new ("- Revert to the previously booted tree");
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
@@ -102,11 +102,11 @@ rpmostree_builtin_rollback (int             argc,
       g_print ("Run \"systemctl reboot\" to start a reboot\n");
     }
 
-  ret = TRUE;
+  exit_status = EXIT_SUCCESS;
 
 out:
   /* Does nothing if using the message bus. */
   rpmostree_cleanup_peer ();
 
-  return ret;
+  return exit_status;
 }

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -44,13 +44,13 @@ printchar (char *s, int n)
   g_print ("\n");
 }
 
-gboolean
+int
 rpmostree_builtin_status (int             argc,
                           char          **argv,
                           GCancellable   *cancellable,
                           GError        **error)
 {
-  gboolean ret = FALSE;
+  int exit_status = EXIT_FAILURE;
   GOptionContext *context = g_option_context_new ("- Get the version of the booted system");
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
@@ -259,11 +259,11 @@ rpmostree_builtin_status (int             argc,
         }
     }
 
-  ret = TRUE;
+  exit_status = EXIT_SUCCESS;
 
 out:
   /* Does nothing if using the message bus. */
   rpmostree_cleanup_peer ();
 
-	return ret;
+  return exit_status;
 }

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -141,28 +141,32 @@ rpmostree_builtin_upgrade (int             argc,
                                                               error))
         goto out;
 
-      rpmostree_print_package_diffs (result);
-    }
-  else
-    {
-      /* nothing changed */
-      if (default_deployment == NULL)
+      if (g_variant_n_children (result) == 0)
         {
+          exit_status = RPM_OSTREE_EXIT_UNCHANGED;
           goto out;
         }
-      if (!opt_reboot)
+
+      rpmostree_print_package_diffs (result);
+    }
+  else if (!opt_reboot)
+    {
+      const char *sysroot_path;
+
+      if (default_deployment == NULL)
         {
-          const char *sysroot_path;
-
-          sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-
-          if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
-                                                               cancellable,
-                                                               error))
-            goto out;
-
-          g_print ("Run \"systemctl reboot\" to start a reboot\n");
+          exit_status = RPM_OSTREE_EXIT_UNCHANGED;
+          goto out;
         }
+
+      sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
+
+      if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
+                                                           cancellable,
+                                                           error))
+        goto out;
+
+      g_print ("Run \"systemctl reboot\" to start a reboot\n");
     }
 
   exit_status = EXIT_SUCCESS;

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -66,13 +66,13 @@ default_changed_callback (GObject *object,
   g_object_get (object, pspec->name, value, NULL);
 }
 
-gboolean
+int
 rpmostree_builtin_upgrade (int             argc,
                            char          **argv,
                            GCancellable   *cancellable,
                            GError        **error)
 {
-  gboolean ret = FALSE;
+  int exit_status = EXIT_FAILURE;
 
   GOptionContext *context = g_option_context_new ("- Perform a system upgrade");
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
@@ -208,11 +208,11 @@ rpmostree_builtin_upgrade (int             argc,
         }
     }
 
-  ret = TRUE;
+  exit_status = EXIT_SUCCESS;
 
 out:
   /* Does nothing if using the message bus. */
   rpmostree_cleanup_peer ();
 
-  return ret;
+  return exit_status;
 }

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -39,6 +39,7 @@ typedef struct {
 
 BUILTINPROTO(compose);
 BUILTINPROTO(upgrade);
+BUILTINPROTO(deploy);
 BUILTINPROTO(rebase);
 BUILTINPROTO(rollback);
 BUILTINPROTO(status);

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -25,6 +25,10 @@
 
 G_BEGIN_DECLS
 
+/* Exit code for no change after pulling commits.
+ * Use alongside EXIT_SUCCESS and EXIT_FAILURE. */
+#define RPM_OSTREE_EXIT_UNCHANGED  (77)
+
 typedef enum {
   RPM_OSTREE_BUILTIN_FLAG_NONE = 0,
   RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD = 1 << 0

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -32,7 +32,7 @@ typedef enum {
 
 typedef struct {
   const char *name;
-  gboolean (*fn) (int argc, char **argv, GCancellable *cancellable, GError **error);
+  int (*fn) (int argc, char **argv, GCancellable *cancellable, GError **error);
 } RpmOstreeCommand;
 
 #define BUILTINPROTO(name) gboolean rpmostree_builtin_ ## name (int argc, char **argv, GCancellable *cancellable, GError **error)

--- a/src/app/rpmostree-compose-builtin-sign.c
+++ b/src/app/rpmostree-compose-builtin-sign.c
@@ -39,13 +39,13 @@ static GOptionEntry option_entries[] = {
   { NULL }
 };
 
-gboolean
+int
 rpmostree_compose_builtin_sign (int            argc,
                                 char         **argv,
                                 GCancellable  *cancellable,
                                 GError       **error)
 {
-  gboolean ret = FALSE;
+  int exit_status = EXIT_FAILURE;
   GOptionContext *context = g_option_context_new ("- Use rpm-sign to sign an OSTree commit");
   gs_unref_object GFile *repopath = NULL;
   gs_unref_object OstreeRepo *repo = NULL;
@@ -136,11 +136,13 @@ rpmostree_compose_builtin_sign (int            argc,
   g_print ("Successfully signed OSTree commit=%s with key=%s\n",
            checksum, opt_key_id);
   
-  ret = TRUE;
+  exit_status = EXIT_SUCCESS;
+
  out:
   if (tmp_commitdata_file)
     (void) gs_file_unlink (tmp_commitdata_file, NULL, NULL);
   if (tmp_sig_file)
     (void) gs_file_unlink (tmp_sig_file, NULL, NULL);
-  return ret;
+
+  return exit_status;
 }

--- a/src/app/rpmostree-compose-builtin-sign.c
+++ b/src/app/rpmostree-compose-builtin-sign.c
@@ -24,6 +24,7 @@
 #include <glib-unix.h>
 
 #include "rpmostree-compose-builtins.h"
+#include "rpmostree-libbuiltin.h"
 
 #include "libgsystem.h"
 
@@ -69,8 +70,7 @@ rpmostree_compose_builtin_sign (int            argc,
 
   if (!(opt_repo_path && opt_key_id && opt_rev))
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Missing required argument");
+      rpmostree_usage_error (context, "Missing required argument", error);
       goto out;
     }
 

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -615,13 +615,13 @@ compose_strv_contains_prefix (gchar **strv,
 }
 
 
-gboolean
+int
 rpmostree_compose_builtin_tree (int             argc,
                                 char          **argv,
                                 GCancellable   *cancellable,
                                 GError        **error)
 {
-  gboolean ret = FALSE;
+  int exit_status = EXIT_FAILURE;
   GError *temp_error = NULL;
   GOptionContext *context = g_option_context_new ("TREEFILE - Run yum and commit the result to an OSTree repository");
   const char *ref;
@@ -760,8 +760,8 @@ rpmostree_compose_builtin_tree (int             argc,
       json_generator_set_pretty (generator, TRUE);
       json_generator_set_root (generator, treefile_rootval);
       (void) json_generator_to_stream (generator, stdout, NULL, NULL);
-      
-      ret = TRUE;
+
+      exit_status = EXIT_SUCCESS;
       goto out;
     }
 
@@ -877,7 +877,7 @@ rpmostree_compose_builtin_tree (int             argc,
     if (unmodified)
       {
         g_print ("No apparent changes since previous commit; use --force-nocache to override\n");
-        ret = TRUE;
+        exit_status = EXIT_SUCCESS;
         goto out;
       }
   }
@@ -942,6 +942,8 @@ rpmostree_compose_builtin_tree (int             argc,
         }
     }
 
+  exit_status = EXIT_SUCCESS;
+
  out:
   /* Move back out of the workding directory to ensure unmount works */
   (void )chdir ("/");
@@ -964,5 +966,6 @@ rpmostree_compose_builtin_tree (int             argc,
       g_clear_pointer (&self->serialized_treefile, g_bytes_unref);
       g_ptr_array_unref (self->treefile_context_dirs);
     }
-  return ret;
+
+  return exit_status;
 }

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -37,6 +37,7 @@
 #include "rpmostree-cleanup.h"
 #include "rpmostree-postprocess.h"
 #include "rpmostree-passwd-util.h"
+#include "rpmostree-libbuiltin.h"
 #include "rpmostree-rpm-util.h"
 
 #include "libgsystem.h"
@@ -622,7 +623,7 @@ rpmostree_compose_builtin_tree (int             argc,
 {
   gboolean ret = FALSE;
   GError *temp_error = NULL;
-  GOptionContext *context = g_option_context_new ("- Run yum and commit the result to an OSTree repository");
+  GOptionContext *context = g_option_context_new ("TREEFILE - Run yum and commit the result to an OSTree repository");
   const char *ref;
   RpmOstreeTreeComposeContext selfdata = { NULL, };
   RpmOstreeTreeComposeContext *self = &selfdata;
@@ -659,16 +660,13 @@ rpmostree_compose_builtin_tree (int             argc,
 
   if (argc < 2)
     {
-      g_printerr ("usage: rpm-ostree compose tree TREEFILE\n");
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Option processing failed");
+      rpmostree_usage_error (context, "TREEFILE must be specified", error);
       goto out;
     }
   
   if (!opt_repo)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "--repo must be specified");
+      rpmostree_usage_error (context, "--repo must be specified", error);
       goto out;
     }
 

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -31,14 +31,14 @@ static GOptionEntry option_entries[] = {
   { NULL }
 };
 
-gboolean
+int
 rpmostree_db_builtin_diff (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
+  int exit_status = EXIT_FAILURE;
   GOptionContext *context;
   gs_unref_object OstreeRepo *repo = NULL;
   struct RpmRevisionData *rpmrev1 = NULL;
   struct RpmRevisionData *rpmrev2 = NULL;
-  gboolean success = FALSE;
 
   context = g_option_context_new ("COMMIT COMMIT - Show package changes between two commits");
 
@@ -92,7 +92,7 @@ rpmostree_db_builtin_diff (int argc, char **argv, GCancellable *cancellable, GEr
       goto out;
     }
 
-  success = TRUE;
+  exit_status = EXIT_SUCCESS;
 
 out:
   /* Free the RpmRevisionData structs explicitly *before* possibly removing
@@ -103,6 +103,6 @@ out:
 
   g_option_context_free (context);
 
-  return success;
+  return exit_status;
 }
 

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include "rpmostree-db-builtins.h"
+#include "rpmostree-libbuiltin.h"
 #include "rpmostree-rpm-util.h"
 
 static char *opt_format;
@@ -47,14 +48,11 @@ rpmostree_db_builtin_diff (int argc, char **argv, GCancellable *cancellable, GEr
 
   if (argc != 3)
     {
-      gs_free char *help;
+      g_autofree char *message = NULL;
 
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "\"%s\" takes exactly 2 arguments", g_get_prgname ());
-
-      help = g_option_context_get_help (context, FALSE, NULL);
-      g_printerr ("%s", help);
-
+      message = g_strdup_printf ("\"%s\" takes exactly 2 arguments",
+                                 g_get_prgname ());
+      rpmostree_usage_error (context, message, error);
       goto out;
     }
 

--- a/src/app/rpmostree-db-builtin-list.c
+++ b/src/app/rpmostree-db-builtin-list.c
@@ -84,14 +84,14 @@ _builtin_db_list (OstreeRepo *repo,
   return ret;
 }
 
-gboolean
+int
 rpmostree_db_builtin_list (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
+  int exit_status = EXIT_FAILURE;
   GOptionContext *context;
   gs_unref_object OstreeRepo *repo = NULL;
   gs_unref_ptrarray GPtrArray *patterns = NULL;
   gs_unref_ptrarray GPtrArray *revs = NULL;
-  gboolean success = FALSE;
   int ii;
 
   context = g_option_context_new ("[PREFIX-PKGNAME...] COMMIT... - List packages within commits");
@@ -129,11 +129,11 @@ rpmostree_db_builtin_list (int argc, char **argv, GCancellable *cancellable, GEr
   if (!_builtin_db_list (repo, revs, patterns, cancellable, error))
     goto out;
 
-  success = TRUE;
+  exit_status = EXIT_SUCCESS;
 
 out:
   g_option_context_free (context);
 
-  return success;
+  return exit_status;
 }
 

--- a/src/app/rpmostree-db-builtin-version.c
+++ b/src/app/rpmostree-db-builtin-version.c
@@ -89,13 +89,13 @@ _builtin_db_version (OstreeRepo *repo, GPtrArray *revs,
   return ret;
 }
 
-gboolean
+int
 rpmostree_db_builtin_version (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
+  int exit_status = EXIT_FAILURE;
   GOptionContext *context;
   gs_unref_object OstreeRepo *repo = NULL;
   gs_unref_ptrarray GPtrArray *revs = NULL;
-  gboolean success = FALSE;
   gint ii;
 
   context = g_option_context_new ("COMMIT... - Show rpmdb version of packages within the commits");
@@ -112,11 +112,11 @@ rpmostree_db_builtin_version (int argc, char **argv, GCancellable *cancellable, 
   if (!_builtin_db_version (repo, revs, cancellable, error))
     goto out;
 
-  success = TRUE;
+  exit_status = EXIT_SUCCESS;
 
 out:
   g_option_context_free (context);
 
-  return success;
+  return exit_status;
 }
 

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -55,3 +55,6 @@ rpmostree_transaction_get_response_sync      (RPMOSTreeSysroot *sysroot_proxy,
 void
 rpmostree_print_signatures                   (GVariant *variant,
                                               const gchar *sep);
+
+void
+rpmostree_print_package_diffs                (GVariant *variant);

--- a/src/app/rpmostree-libbuiltin.c
+++ b/src/app/rpmostree-libbuiltin.c
@@ -26,6 +26,22 @@
 #include "rpmostree.h"
 #include "rpmostree-cleanup.h"
 
+void
+rpmostree_usage_error (GOptionContext  *context,
+                       const char      *message,
+                       GError         **error)
+{
+  g_autofree char *help = NULL;
+
+  g_return_if_fail (context != NULL);
+  g_return_if_fail (message != NULL);
+
+  help = g_option_context_get_help (context, TRUE, NULL);
+  g_printerr ("%s\n", help);
+
+  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, message);
+}
+
 gboolean
 rpmostree_print_treepkg_diff_from_sysroot_path (const gchar *sysroot_path,
                                                 GCancellable *cancellable,

--- a/src/app/rpmostree-libbuiltin.h
+++ b/src/app/rpmostree-libbuiltin.h
@@ -24,6 +24,11 @@
 
 G_BEGIN_DECLS
 
+void
+rpmostree_usage_error (GOptionContext  *context,
+                       const char      *message,
+                       GError         **error);
+
 gboolean
 rpmostree_print_treepkg_diff (OstreeSysroot    *sysroot,
                               GCancellable     *cancellable,

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -64,6 +64,26 @@
       <arg type="a(sua{sv})" name="result" direction="out"/>
     </method>
 
+    <!-- Revision may be a full checksum or version string.
+
+         Available options:
+         "reboot" (type 'b')
+    -->
+    <method name="Deploy">
+      <arg type="s" name="revision" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="s" name="transaction_address" direction="out"/>
+    </method>
+
+    <!-- Available options:
+         "allow-downgrade" (type 'b')
+         "reboot" (type 'b')
+    -->
+    <method name="Upgrade">
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="s" name="transaction_address" direction="out"/>
+    </method>
+
     <!-- details dictionary keys:
        'osname' (type 's')
        'checksum' (type 's')
@@ -79,15 +99,6 @@
     </method>
 
     <method name="DownloadUpdateRpmDiff">
-      <arg type="s" name="transaction_address" direction="out"/>
-    </method>
-
-    <!-- Available options:
-         "allow-downgrade" (type 'b')
-         "reboot" (type 'b')
-    -->
-    <method name="Upgrade">
-      <arg type="a{sv}" name="options" direction="in"/>
       <arg type="s" name="transaction_address" direction="out"/>
     </method>
 

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -75,6 +75,27 @@
       <arg type="s" name="transaction_address" direction="out"/>
     </method>
 
+    <!-- details dictionary keys:
+       'osname' (type 's')
+       'checksum' (type 's')
+       'version' (type 's')
+       'timestamp' (type 't')
+       'origin' (type 's')
+       'signatures' (type 'av')
+    -->
+    <method name="GetCachedDeployRpmDiff">
+      <arg type="s" name="revision"/>
+      <arg type="as" name="packages"/>
+      <arg type="a(sua{sv})" name="result" direction="out"/>
+      <arg type="a{sv}" name="details" direction="out"/>
+    </method>
+
+    <method name="DownloadDeployRpmDiff">
+      <arg type="s" name="revision"/>
+      <arg type="as" name="packages"/>
+      <arg type="s" name="transaction_address" direction="out"/>
+    </method>
+
     <!-- Available options:
          "allow-downgrade" (type 'b')
          "reboot" (type 'b')

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -225,7 +225,6 @@ rpmostreed_commit_generate_cached_details_variant (OstreeDeployment *deployment,
   g_autofree gchar *origin_refspec = NULL;
   g_autofree gchar *head = NULL;
   const gchar *osname;
-  const gchar *csum;
 
   GVariant *sigs = NULL; /* floating variant */
   GVariant *ret = NULL; /* floating variant */
@@ -234,7 +233,6 @@ rpmostreed_commit_generate_cached_details_variant (OstreeDeployment *deployment,
   GVariantDict dict;
 
   osname = ostree_deployment_get_osname (deployment);
-  csum = ostree_deployment_get_csum (deployment);
 
   if (refspec)
     origin_refspec = g_strdup (refspec);
@@ -250,9 +248,6 @@ rpmostreed_commit_generate_cached_details_variant (OstreeDeployment *deployment,
       g_warning ("Error loading resolving revision: %s", error->message);
       goto out;
     }
-
-  if (g_strcmp0 (csum, head) == 0)
-    goto out;
 
   sigs = rpmostreed_deployment_gpg_results (repo, origin_refspec, head);
 

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -341,6 +341,7 @@ get_deploy_diff_variant_in_thread (GTask *task,
   glnx_unref_object OstreeDeployment *base_deployment = NULL;
   g_autofree char *base_refspec = NULL;
   g_autofree char *checksum = NULL;
+  g_autofree char *version = NULL;
 
   GVariant *value = NULL;
   GVariant *details = NULL;
@@ -369,16 +370,17 @@ get_deploy_diff_variant_in_thread (GTask *task,
   base_checksum = ostree_deployment_get_csum (base_deployment);
   base_refspec = rpmostreed_deployment_get_refspec (base_deployment);
 
-  /* If revision string is not a SHA256 checksum, assume it's a version. */
-  if (ostree_validate_checksum_string (revision, NULL))
-    {
-      checksum = g_strdup (revision);
-    }
-  else
+  if (!rpmostreed_parse_revision (revision,
+                                  &checksum,
+                                  &version,
+                                  &local_error))
+    goto out;
+
+  if (version != NULL)
     {
       if (!rpmostreed_repo_lookup_cached_version (ot_repo,
                                                   base_refspec,
-                                                  revision,
+                                                  version,
                                                   cancellable,
                                                   &checksum,
                                                   &local_error))

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -62,3 +62,12 @@ RpmostreedTransaction *
                                                             gboolean reboot,
                                                             GCancellable *cancellable,
                                                             GError **error);
+
+RpmostreedTransaction *
+               rpmostreed_transaction_new_deploy           (GDBusMethodInvocation *invocation,
+                                                            OstreeSysroot *sysroot,
+                                                            const char *osname,
+                                                            const char *revision,
+                                                            gboolean reboot,
+                                                            GCancellable *cancellable,
+                                                            GError **error);

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -25,6 +25,7 @@ RpmostreedTransaction *
                                                             OstreeSysroot *sysroot,
                                                             const char *osname,
                                                             const char *refspec,
+                                                            const char *revision,
                                                             GCancellable *cancellable,
                                                             GError **error);
 

--- a/src/daemon/rpmostreed-utils.c
+++ b/src/daemon/rpmostreed-utils.c
@@ -489,3 +489,72 @@ rpmostreed_repo_lookup_cached_version (OstreeRepo    *repo,
 out:
   return ret;
 }
+
+/**
+ * rpmostreed_parse_revision:
+ * @revision: Revision string
+ * @out_checksum: (out) (allow-none): Commit checksum, or %NULL
+ * @out_version: (out) (allow-none): Version value, or %NULL
+ * @error: Error
+ *
+ * Determines @revision to either be a SHA256 checksum or a version metadata
+ * value, sets one of @out_checksum or @out_version appropriately, and then
+ * returns %TRUE.
+ *
+ * The @revision string may have a "revision=" prefix to denote a SHA256
+ * checksum, or a "version=" prefix to denote a version metadata value.  If
+ * the @revision string lacks either prefix, the function attempts to infer
+ * the type of revision.  The prefixes are case-insensitive.
+ *
+ * The only possible error is if a "revision=" prefix is given, but the
+ * rest of the string is not a valid SHA256 checksum.  In that case the
+ * function sets @error and returns %FALSE.
+ *
+ * Returns: %TRUE on success, %FALSE of failure
+ */
+gboolean
+rpmostreed_parse_revision (const char  *revision,
+                           char       **out_checksum,
+                           char       **out_version,
+                           GError     **error)
+{
+  const char *checksum = NULL;
+  const char *version = NULL;
+  gboolean ret = FALSE;
+
+  g_return_val_if_fail (revision != NULL, FALSE);
+
+  if (g_ascii_strncasecmp (revision, "revision=", 9) == 0)
+    {
+      checksum = revision + 9;
+
+      /* Since this claims to be a checksum, fail if it isn't. */
+      if (!ostree_validate_checksum_string (checksum, error))
+        goto out;
+    }
+  else if (g_ascii_strncasecmp (revision, "version=", 8) == 0)
+    {
+      version = revision + 8;
+    }
+  else if (ostree_validate_checksum_string (revision, NULL))
+    {
+      /* If it looks like a checksum, assume it is. */
+      checksum = revision;
+    }
+  else
+    {
+      /* Treat anything else as a version metadata value. */
+      version = revision;
+    }
+
+  if (out_checksum != NULL)
+    *out_checksum = g_strdup (checksum);
+
+  if (out_version != NULL)
+    *out_version = g_strdup (version);
+
+  ret = TRUE;
+
+out:
+  return ret;
+}

--- a/src/daemon/rpmostreed-utils.h
+++ b/src/daemon/rpmostreed-utils.h
@@ -36,3 +36,30 @@ gboolean   rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
                                              GError **error);
 void
 rpmostreed_reboot (GCancellable *cancellable, GError **error);
+
+/* XXX These pull-ancestry and lookup-version functions should eventually
+ *     be integrated into libostree, but it's still a bit premature to do
+ *     so now.  Version integration in ostree needs more design work. */
+
+typedef gboolean (*RpmostreedCommitVisitor) (OstreeRepo  *repo,
+                                             const char  *checksum,
+                                             GVariant    *commit,
+                                             gpointer     user_data,
+                                             gboolean    *out_stop,
+                                             GError     **error);
+
+gboolean   rpmostreed_repo_pull_ancestry (OstreeRepo               *repo,
+                                          const char               *refspec,
+                                          RpmostreedCommitVisitor   visitor,
+                                          gpointer                  visitor_data,
+                                          OstreeAsyncProgress      *progress,
+                                          GCancellable             *cancellable,
+                                          GError                  **error);
+
+gboolean   rpmostreed_repo_lookup_version (OstreeRepo           *repo,
+                                           const char           *refspec,
+                                           const char           *version,
+                                           OstreeAsyncProgress  *progress,
+                                           GCancellable         *cancellable,
+                                           char                **out_checksum,
+                                           GError              **error);

--- a/src/daemon/rpmostreed-utils.h
+++ b/src/daemon/rpmostreed-utils.h
@@ -63,3 +63,10 @@ gboolean   rpmostreed_repo_lookup_version (OstreeRepo           *repo,
                                            GCancellable         *cancellable,
                                            char                **out_checksum,
                                            GError              **error);
+
+gboolean   rpmostreed_repo_lookup_cached_version (OstreeRepo    *repo,
+                                                  const char    *refspec,
+                                                  const char    *version,
+                                                  GCancellable  *cancellable,
+                                                  char         **out_checksum,
+                                                  GError       **error);

--- a/src/daemon/rpmostreed-utils.h
+++ b/src/daemon/rpmostreed-utils.h
@@ -70,3 +70,8 @@ gboolean   rpmostreed_repo_lookup_cached_version (OstreeRepo    *repo,
                                                   GCancellable  *cancellable,
                                                   char         **out_checksum,
                                                   GError       **error);
+
+gboolean   rpmostreed_parse_revision (const char  *revision,
+                                      char       **out_checksum,
+                                      char       **out_version,
+                                      GError     **error);


### PR DESCRIPTION
Following up on https://github.com/projectatomic/rpm-ostree/issues/172 and https://github.com/GNOME/ostree/pull/147.

I'm still working on test cases for this, but I wanted to get the code changes posted ASAP.

This enhances the `rpm-ostree rebase` command to allow rebasing to any version.

Syntax changes are:
```
rpm-ostree rebase [-V / --to-version=VERSION] [-R / --to-revision=CHECKSUM] [REFSPEC]
```
Note: `REFSPEC` is now optional, but only if `--to-version` or `--to-revision` is specified.  Defaults to the booted deployment's origin refspec.

I know we talked about putting version lookup directly in `libostree` and I still want to, but I'm shying away from it for the moment because I think it needs more thinking through.  The way I'm solving version lookups here is really slow and clunky and I'd like to come up with a better way before messing with `libostree`.  (Something analogous to git tags feels more like the Right Way to me.  Available tags could be included in summary files.)