### PR TITLE
Use PACKAGE_STRING for version output

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -113,7 +113,7 @@ rpmostree_option_context_parse (GOptionContext *context,
 
   if (opt_version)
     {
-      g_print ("%s\n  %s\n", PACKAGE_NAME, RPM_OSTREE_FEATURES);
+      g_print ("%s\n  %s\n", PACKAGE_STRING, RPM_OSTREE_FEATURES);
       exit (EXIT_SUCCESS);
     }
 


### PR DESCRIPTION
We are currently using `PACKAGE_NAME` for version output, which returns
exactly what it says it does: the package name.  Not very useful when
looking for version information.

`PACKAGE_STRING`, on the the other hand, returns the package name and the
version.  Much better!

This is nicely documented in the autoconf manual [1].

[1] http://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Initializing-configure.html#Initializing-configure

Signed-off-by: Micah Abbott <miabbott@redhat.com>