### PR TITLE
app: Handle progress when not being connected to a tty

### DIFF
--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -354,8 +354,13 @@ static gboolean
 add_status_line (TransactionProgress *self,
                  const char *line)
 {
-  self->in_status_line = TRUE;
-  return gs_console_begin_status_line (self->console, line, NULL, NULL);
+  if (self->console)
+    {
+      self->in_status_line = TRUE;
+      return gs_console_begin_status_line (self->console, line, NULL, NULL);
+    }
+  else
+    return TRUE;
 }
 
 


### PR DESCRIPTION
`rpm-ostree deploy X.Y.Z | cat` was aborting on the client side.  I
noticed this when using it via Ansible.