### PR TITLE
daemon: Treat local deployments as gpg-verify=false

### DIFF
--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -81,8 +81,15 @@ rpmostreed_deployment_gpg_results (OstreeRepo *repo,
   if (!ostree_parse_refspec (origin_refspec, &remote, NULL, &error))
     goto out;
 
-  if (!ostree_repo_remote_get_gpg_verify (repo, remote, &gpg_verify, &error))
-    goto out;
+  if (remote)
+    {
+      if (!ostree_repo_remote_get_gpg_verify (repo, remote, &gpg_verify, &error))
+	goto out;
+    }
+  else
+    {
+      gpg_verify = FALSE;
+    }
 
   if (!gpg_verify)
     goto out;


### PR DESCRIPTION
Otherwise we trip an assertion.  In the future I think we should
likely encourage `file:///ostree/repo` or so, and thus support
`gpg-verify`.