### PR TITLE
Update D-Bus security policy for rpm-ostreed

### DIFF
--- a/src/daemon/org.projectatomic.rpmostree1.conf
+++ b/src/daemon/org.projectatomic.rpmostree1.conf
@@ -4,7 +4,7 @@
   "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
   "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-  <!-- Only root can own and access the service -->
+  <!-- Only root can own the service -->
   <policy user="root">
     <allow own="org.projectatomic.rpmostree1"/>
     <allow send_destination="org.projectatomic.rpmostree1"/>
@@ -12,5 +12,23 @@
 
   <policy context="default">
     <deny send_destination="org.projectatomic.rpmostree1"/>
+
+    <allow send_destination="org.projectatomic.rpmostree1"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+
+    <allow send_destination="org.projectatomic.rpmostree1"
+           send_interface="org.freedesktop.DBus.Peer"/>
+
+    <allow send_destination="org.projectatomic.rpmostree1"
+           send_interface="org.freedesktop.DBus.Properties"
+           send_member="Get"/>
+
+    <allow send_destination="org.projectatomic.rpmostree1"
+           send_interface="org.freedesktop.DBus.Properties"
+           send_member="GetAll"/>
+
+    <allow send_destination="org.projectatomic.rpmostree1"
+           send_interface="org.projectatomic.rpmostree1.Sysroot"
+           send_member="GetOS"/>
   </policy>
 </busconfig>


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1297473

Gotta poke some holes in the policy so normal users can run `rpm-ostree status`.
Also allow for introspection and property getting, since there's no reason to block those.

This could be a good opportunity to revisit PolicyKit integration, which we originally deferred.

But this gets the bug fixed.