### PR TITLE
tests: make ostree use mutable deployments

### DIFF
--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -22,6 +22,10 @@ test_tmpdir=$(pwd)
 
 export G_DEBUG=fatal-warnings
 
+# Don't flag deployments as immutable so that test harnesses can
+# easily clean up.
+export OSTREE_SYSROOT_DEBUG=mutable-deployments
+
 export TEST_GPG_KEYID="472CDAFA"
 export TEST_GPG_KEYHOME=${SRCDIR}/gpghome
 export OSTREE_GPG_HOME=${TEST_GPG_KEYHOME}/trusted

--- a/tests/setup-session.sh.in
+++ b/tests/setup-session.sh.in
@@ -57,4 +57,8 @@ EOF
 
 export RPMOSTREE_USE_SESSION_BUS=1
 
+# Don't flag deployments as immutable so that test harnesses can
+# easily clean up.
+export OSTREE_SYSROOT_DEBUG=mutable-deployments
+
 exec @installed_testdir@/dbus-run-session --config-file=${test_tmpdir}/session.conf $@


### PR DESCRIPTION
For the same reasons as described in GNOME/ostree#187. In summary: we
want to make it easy for testers to clean up after we're done by not
setting the immutable flag.

Note that I had to also add it to setup-session.sh so that the daemon
inherited the env var. The libtest.sh hunk is redundant in that case,
but still necessary if the tests are run directly.