### PR TITLE
daemon: don't dump core on error

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -55,8 +55,9 @@ start_daemon (GDBusConnection *connection)
 
   if (local_error != NULL)
     {
-      g_error ("%s", local_error->message);
-      g_assert_not_reached ();
+      g_critical ("Couldn't start daemon: %s\n", local_error->message);
+      g_error_free (local_error);
+      g_main_loop_quit (loop);
     }
 }
 


### PR DESCRIPTION
There are many reasons why the daemon may not be able to start up. An
initialization error doesn't/shouldn't reflect a programming mistake,
but instead a runtime issue in the environment.

Thus, if we fail to start the daemon, we shouldn't use g_error(), which
dumps core. We should instead print the GError and clean up as nicely as
we can.

Resolves: https://github.com/projectatomic/rpm-ostree/issues/194