### PR TITLE
test-ucontainer.sh: use test-repo in srcdir

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -23,11 +23,17 @@ tests/compose/yum/repodata/repomd.xml: tests/compose/yum/empty tests/compose/yum
 tests/compose/test-repo.repo: tests/compose/test-repo.repo.in tests/compose/yum/repodata/repomd.xml
 	cat $< | sed -e "s|%WHERE%|$(installed_testdir)|" > $@
 
+# A version of the repo that points directly to the srcdir (for uninstalled tests)
+tests/compose/test-repo-local.repo: tests/compose/test-repo.repo.in tests/compose/yum/repodata/repomd.xml
+	cat $< | sed -e "s|%WHERE%|$(shell pwd)|" > $@
+
 tests_jsonutil_CPPFLAGS = -I $(srcdir)/src/libpriv
 tests_jsonutil_CFLAGS = $(PKGDEP_RPMOSTREE_CFLAGS)
 tests_jsonutil_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la
 
 tests/test-compose.sh: tests/compose/test-repo.repo
+
+tests/test-ucontainer.sh: tests/compose/test-repo-local.repo
 
 installed_test_data = tests/libtest.sh \
 	tests/compose/test-repo.repo \

--- a/tests/test-ucontainer.sh
+++ b/tests/test-ucontainer.sh
@@ -29,7 +29,13 @@ if test -d ${SRCDIR}/compose; then
 else
     composedatadir=${SRCDIR}
 fi
-cp ${composedatadir}/test-repo.repo rpmmd.repos.d
+
+REPO=test-repo
+if test -n "${UNINSTALLEDTESTS:-}"; then
+   REPO=test-repo-local
+fi
+
+cp ${composedatadir}/$REPO.repo rpmmd.repos.d
 
 cat >empty.conf <<EOF
 [tree]


### PR DESCRIPTION
Running `make check` would fail because test-ucontainer.sh uses
test-repo, which points directly to the installed_testdir, where it is
not installed yet.

We make another processed version of test-repo.repo.in which instead
points to the repo in the srcdir and make use of that in
test-ucontainer.sh.

There are probably other ways of solving this, but this is the one that
jumped out at me.