### PR TITLE
Add a stub travis file to enable Homu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+# We're just using a "stubbed out" Travis right now so we can
+# use Homu <https://github.com/barosl/homu> to auto-squash
+# etc.
+#
+# In the future we'll hook up better tests.
+language: c
+dist: trusty
+addons:
+    apt:
+    packages:
+      - automake
+      - autotools-dev
+script:
+  - env NOCONFIGURE=1 ./autogen.sh
+
+notifications:
+  # This is Colin's personal Homu instance.  We will
+  # also work on productizing this in Project Atomic.
+  webhooks: http://escher.verbum.org:54856/travis
+  email: false
+
+branches:
+  only:
+    - auto
+

--- a/configure.ac
+++ b/configure.ac
@@ -79,7 +79,11 @@ m4_ifdef([GOBJECT_INTROSPECTION_CHECK], [
 ])
 AM_CONDITIONAL(BUILDOPT_INTROSPECTION, test "x$found_introspection" = xyes)
 
+m4_ifdef([GTK_DOC_CHECK], [
 GTK_DOC_CHECK([1.15], [--flavour no-tmpl])
+],[
+AM_CONDITIONAL([ENABLE_GTK_DOC],[false])
+])
 
 AC_ARG_ENABLE(installed_tests,
               AS_HELP_STRING([--enable-installed-tests],


### PR DESCRIPTION
I'd like to use Homu immediately as a replacement for the github merge
button, because I really dislike merge commits for single patches.

I think it shouldn't be too hard to unify our existing PR testing with
this.