### PR TITLE
daemon: Ignore unconfigured-state for rebase

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -762,8 +762,9 @@ rebase_transaction_execute (RpmostreedTransaction *transaction,
 
   sysroot = rpmostreed_transaction_get_sysroot (transaction);
 
-  upgrader = ostree_sysroot_upgrader_new_for_os (sysroot, self->osname,
-                                                 cancellable, error);
+  upgrader = ostree_sysroot_upgrader_new_for_os_with_flags (sysroot, self->osname,
+							    OSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED,
+							    cancellable, error);
   if (upgrader == NULL)
     goto out;
 


### PR DESCRIPTION
It's expected to be able to switch to something different when
rebasing, even if the current origin has unconfigured-state.

Closes #232