### PR TITLE
tests: Delete intermediate source RPM so it isn't in repodata

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -18,7 +18,7 @@ tests/compose/yum/repodata/repomd.xml: tests/compose/yum/empty tests/compose/yum
 	(cd tests/compose/yum && \
 	 rpmbuild --define "_sourcedir $(shell pwd)/tests/compose/yum" --define "_specdir $(shell pwd)/tests/compose/yum" --define "_builddir $(shell pwd)/tests/compose/yum" \
 	 	--define "_srcrpmdir $(shell pwd)/tests/compose/yum" --define "_rpmdir $(shell pwd)/tests/compose/yum" --define "_buildrootdir $(shell pwd)/tests/compose/yum/.build" \
-	 -ba empty.spec && createrepo_c --no-database $(shell pwd)/tests/compose/yum/)
+	 -ba empty.spec && rm *.src.rpm && createrepo_c --no-database $(shell pwd)/tests/compose/yum/)
 
 tests/compose/test-repo.repo: tests/compose/test-repo.repo.in tests/compose/yum/repodata/repomd.xml
 	cat $< | sed -e "s|%WHERE%|$(installed_testdir)|" > $@


### PR DESCRIPTION
Currently the libhif logic for selecting packages to install might
choose source packages, which causes all sorts of problems in both
libhif and rpm-ostree which aren't prepared to "install" source RPMs.

Fix this by deleting the srpm, which means it won't end up in the
repodata, and we won't abort deep in the bowels of librpm.