### PR TITLE
[merged] packaging: Modernize Dockerfile a bit

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,0 +1,6 @@
+# Example invocation:
+# docker run --privileged --net=host -v /srv/work/centos-atomic-host:/srv --workdir /srv/ --rm -ti cgwalters/rpm-ostree compose tree --repo=repo --proxy=http://127.0.0.1:8123 centos-atomic-host.json
+FROM fedora
+RUN yum -y update && yum -y install rpm-ostree && yum clean all
+VOLUME /srv/rpm-ostree
+ENTRYPOINT ["rpm-ostree"]

--- a/packaging/Dockerfile.in
+++ b/packaging/Dockerfile.in
@@ -1,9 +1,0 @@
-FROM fedora:20
-RUN yum -y update
-RUN cd /etc/yum.repos.d && curl -O http://copr-fe.cloud.fedoraproject.org/coprs/walters/rpm-ostree/repo/fedora-20-i386/walters-rpm-ostree-fedora-20-i386.repo
-RUN yum -y install nss-altfiles
-RUN rm /etc/yum.repos.d/walters-rpm-ostree-fedora-20-i386.repo
-RUN sed -i -e 's,passwd:.*,\0 altfiles,' -e 's,group:.*,\0 altfiles,' /etc/nsswitch.conf
-ADD @PACKAGE@ /var/tmp/@PACKAGE@
-RUN yum -y localinstall /var/tmp/@PACKAGE@
-ENTRYPOINT ["rpm-ostree"]


### PR DESCRIPTION
As long as we require uid 0, we should encourage people to run
`compose tree` in its current state inside a Docker/nspawn container.

I didn't spend a lot of time on this yet but it works.  Am considering
switching to a CentOS base though.