### PR TITLE
[merged] compose: support adding external files

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -42,6 +42,8 @@ tests/test-ucontainer.sh: tests/compose/test-repo-local.repo
 installed_test_data = tests/libtest.sh \
 	tests/compose/test-repo.repo \
 	tests/compose/test-repo.json \
+	tests/compose/test-repo-add-files.json \
+	tests/compose/exported_file \
 	tests/compose/test-repo.repo.in \
 	$(NULL)
 

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -43,7 +43,6 @@ installed_test_data = tests/libtest.sh \
 	tests/compose/test-repo.repo \
 	tests/compose/test-repo.json \
 	tests/compose/test-repo-add-files.json \
-	tests/compose/exported_file \
 	tests/compose/test-repo.repo.in \
 	$(NULL)
 

--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -167,3 +167,11 @@ It supports the following parameters:
    rpm-ostree will not do any special handling of kernel, initrd or the
    /boot directory. This is useful if the target for the tree is some kind
    of container which does not have its own kernel.
+
+ * `copy-files`: Array, optional: Copy external files to the rootfs.
+
+   Each array element is an array, whose first member is the source
+   file name, and the second element is the destination name.  The
+   source file must be in the same directory as the treefile.
+
+   Example: `"add-files": [["bar", "/bar"], ["foo", "/foo"]]`

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -146,17 +146,13 @@ compute_checksum_from_treefile_and_goal (RpmOstreeTreeComposeContext   *self,
 
           srcfile = g_file_resolve_relative_path (contextdir, src);
 
-          {
-            g_autofree guchar *ret_csum = NULL;
-            if (!ostree_checksum_file (srcfile,
-                                       OSTREE_OBJECT_TYPE_FILE,
-                                       &ret_csum,
-                                       NULL,
-                                       error))
-              goto out;
+          if (!_rpmostree_util_update_checksum_from_file (checksum,
+                                                          srcfile,
+                                                          NULL,
+                                                          error))
+            goto out;
 
-            g_checksum_update (checksum, ret_csum, 32);
-          }
+          g_checksum_update (checksum, (const guint8 *) dest, strlen (dest));
         }
 
     }

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -796,6 +796,9 @@ rpmostree_compose_builtin_tree (int             argc,
   if (!rpmostree_prepare_rootfs_for_commit (yumroot, treefile, cancellable, error))
     goto out;
 
+  if (!rpmostree_copy_additional_files (yumroot, self->treefile_context_dirs->pdata[0], treefile, cancellable, error))
+    goto out;
+
   if (!rpmostree_check_passwd (repo, yumroot, treefile_dirpath, treefile,
                                cancellable, error))
     goto out;

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -101,6 +101,8 @@ typedef struct {
 static gboolean
 compute_checksum_from_treefile_and_goal (RpmOstreeTreeComposeContext   *self,
                                          HyGoal                         goal,
+                                         GFile                         *contextdir,
+                                         JsonArray                     *add_files,
                                          char                        **out_checksum,
                                          GError                      **error)
 {
@@ -118,6 +120,47 @@ compute_checksum_from_treefile_and_goal (RpmOstreeTreeComposeContext   *self,
     g_checksum_update (checksum, buf, len);
   }
 
+  if (add_files)
+    {
+      guint i, len = json_array_get_length (add_files);
+      for (i = 0; i < len; i++)
+        {
+          gs_unref_object GFile *srcfile = NULL;
+          const char *src, *dest;
+          JsonArray *add_el = json_array_get_array_element (add_files, i);
+          gs_unref_object GFile *child = NULL;
+
+          if (!add_el)
+            {
+              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                           "Element in add-files is not an array");
+              goto out;
+            }
+          src = _rpmostree_jsonutil_array_require_string_element (add_el, 0, error);
+          if (!src)
+            goto out;
+
+          dest = _rpmostree_jsonutil_array_require_string_element (add_el, 1, error);
+          if (!dest)
+            goto out;
+
+          srcfile = g_file_resolve_relative_path (contextdir, src);
+
+          {
+            g_autofree guchar *ret_csum = NULL;
+            if (!ostree_checksum_file (srcfile,
+                                       OSTREE_OBJECT_TYPE_FILE,
+                                       &ret_csum,
+                                       NULL,
+                                       error))
+              goto out;
+
+            g_checksum_update (checksum, ret_csum, 32);
+          }
+        }
+
+    }
+
   /* FIXME; we should also hash the post script */
 
   /* Hash in each package */
@@ -126,6 +169,7 @@ compute_checksum_from_treefile_and_goal (RpmOstreeTreeComposeContext   *self,
   ret_checksum = g_strdup (g_checksum_get_string (checksum));
 
   ret = TRUE;
+ out:
   gs_transfer_out_value (out_checksum, &ret_checksum);
   if (checksum) g_checksum_free (checksum);
   return ret;
@@ -190,6 +234,7 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
   gs_free char *ret_new_inputhash = NULL;
   g_autoptr(GKeyFile) treespec = g_key_file_new ();
   JsonArray *enable_repos = NULL;
+  JsonArray *add_files = NULL;
 
   /* TODO - uncomment this once we have SELinux working */
 #if 0
@@ -268,8 +313,12 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
   if (!rpmostree_context_prepare_install (ctx, &hifinstall, cancellable, error))
     goto out;
 
+  if (json_object_has_member (treedata, "add-files"))
+    add_files = json_object_get_array_member (treedata, "add-files");
+
   /* FIXME - just do a depsolve here before we compute download requirements */
   if (!compute_checksum_from_treefile_and_goal (self, hif_context_get_goal (hifctx),
+                                                contextdir, add_files,
                                                 &ret_new_inputhash, error))
     goto out;
 

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -51,3 +51,9 @@ rpmostree_commit (GFile         *rootfs,
                   gboolean       enable_selinux,
                   GCancellable  *cancellable,
                   GError       **error);
+gboolean
+rpmostree_copy_additional_files (GFile         *rootfs,
+                                 GFile         *context_directory,
+                                 JsonObject    *treefile,
+                                 GCancellable  *cancellable,
+                                 GError       **error);

--- a/tests/compose/exported_file
+++ b/tests/compose/exported_file
@@ -1,0 +1,1 @@
+exported file

--- a/tests/compose/exported_file
+++ b/tests/compose/exported_file
@@ -1,1 +1,0 @@
-exported file

--- a/tests/compose/test-repo-add-files.json
+++ b/tests/compose/test-repo-add-files.json
@@ -3,8 +3,6 @@
 
     "repos": ["test-repo"],
 
-    "bootstrap_packages": [],
-
     "selinux": false,
 
     "packages": ["empty"],

--- a/tests/compose/test-repo-add-files.json
+++ b/tests/compose/test-repo-add-files.json
@@ -1,0 +1,13 @@
+{
+    "ref": "fedora/test",
+
+    "repos": ["test-repo"],
+
+    "bootstrap_packages": [],
+
+    "selinux": false,
+
+    "packages": ["empty"],
+
+    "add-files": [["exported_file", "/exports/exported_file"]]
+}

--- a/tests/test-compose.sh
+++ b/tests/test-compose.sh
@@ -29,7 +29,7 @@ unset G_DEBUG
 
 (arch | grep -q x86_64) || { echo 1>&2 "$0 can be run only on x86_64"; echo "1..0" ; exit 77; }
 
-echo "1..1"
+echo "1..4"
 
 ostree init --repo=repo --mode=archive-z2
 
@@ -47,3 +47,14 @@ ostree --repo=repo refs >refs.txt
 assert_file_has_content refs.txt fedora/test
 
 echo "ok compose"
+
+rpm-ostree --repo=repo compose tree $SRCDIR/test-repo-add-files.json
+ostree --repo=repo ls fedora/test /exports/exported_file | grep exported > exported.txt
+assert_file_has_content exported.txt "/exports/exported_file"
+assert_file_has_content exported.txt "0 0"
+ostree --repo=repo rev-parse fedora/test > oldref.txt
+rpm-ostree --repo=repo compose tree $SRCDIR/test-repo-add-files.json
+ostree --repo=repo rev-parse fedora/test > newref.txt
+assert_streq $(cat oldref.txt) $(cat newref.txt)
+
+echo "ok compose add files"

--- a/tests/test-compose.sh
+++ b/tests/test-compose.sh
@@ -48,13 +48,31 @@ assert_file_has_content refs.txt fedora/test
 
 echo "ok compose"
 
-rpm-ostree --repo=repo compose tree $SRCDIR/test-repo-add-files.json
+# bring them in the current context so we can modify exported_file
+ln -s $SRCDIR/test-repo-add-files.json .
+ln -s $SRCDIR/test-repo.repo .
+
+echo hello > exported_file
+
+rpm-ostree --repo=repo compose tree --touch-if-changed=$(pwd)/touched test-repo-add-files.json
+assert_has_file touched
+old_mtime=$(stat -c %y touched)
 ostree --repo=repo ls fedora/test /exports/exported_file | grep exported > exported.txt
+
 assert_file_has_content exported.txt "/exports/exported_file"
 assert_file_has_content exported.txt "0 0"
 ostree --repo=repo rev-parse fedora/test > oldref.txt
-rpm-ostree --repo=repo compose tree $SRCDIR/test-repo-add-files.json
+rpm-ostree --repo=repo compose tree --touch-if-changed=$(pwd)/touched test-repo-add-files.json
+new_mtime=$(stat -c %y touched)
 ostree --repo=repo rev-parse fedora/test > newref.txt
 assert_streq $(cat oldref.txt) $(cat newref.txt)
+assert_streq "$old_mtime" "$new_mtime"
+
+echo . >> exported_file
+rpm-ostree --repo=repo compose tree --touch-if-changed=$(pwd)/touched test-repo-add-files.json
+new_mtime=$(stat -c %y touched)
+ostree --repo=repo rev-parse fedora/test > newref.txt
+assert_not_streq $(cat oldref.txt) $(cat newref.txt)
+assert_not_streq "$old_mtime" "$new_mtime"
 
 echo "ok compose add files"


### PR DESCRIPTION
This will allow to copy arbitrary files into the rootfs, specifying something like:

"add-files": [["service.template", "/exports/service.template"],
              ["config.json.template", "/exports/config.json.template"]]

It is quite useful when building a container image.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>