### PR TITLE
[merged] daemon: add TaskBegin, TaskEnd, and PercentProgress signals

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -51,6 +51,7 @@ librpmostreed_la_CFLAGS = \
 	-DG_LOG_DOMAIN=\"rpm-ostreed\" \
 	-I$(srcdir)/src/daemon \
 	-I$(srcdir)/src/lib \
+	-I$(srcdir)/src/libpriv \
 	-I$(libglnx_srcpath) \
 	$(NULL)
 

--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -41,6 +41,21 @@ librpmostreepriv_la_SOURCES = \
 	src/libpriv/ostree-libarchive-input-stream.h \
 	src/libpriv/rpmostree-ostree-libarchive-copynpaste.c \
 	src/libpriv/rpmostree-ostree-libarchive-copynpaste.h \
+	src/libpriv/rpmostree-output.c \
+	src/libpriv/rpmostree-output.h \
 	$(NULL)
-librpmostreepriv_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/src/libpriv -I$(libglnx_srcpath) -DPKGLIBDIR=\"$(pkglibdir)\" $(PKGDEP_RPMOSTREE_CFLAGS)
-librpmostreepriv_la_LIBADD = $(AM_LDFLAGS) $(PKGDEP_RPMOSTREE_LIBS) libglnx.la $(CAP_LIBS)
+
+librpmostreepriv_la_CFLAGS = \
+	$(AM_CFLAGS) \
+	-I$(srcdir)/src/libpriv \
+	-I$(libglnx_srcpath) \
+	-DPKGLIBDIR=\"$(pkglibdir)\" \
+	$(PKGDEP_RPMOSTREE_CFLAGS) \
+	$(NULL)
+
+librpmostreepriv_la_LIBADD = \
+	$(AM_LDFLAGS) \
+	$(PKGDEP_RPMOSTREE_LIBS) \
+	libglnx.la \
+	$(CAP_LIBS) \
+	$(NULL)

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -191,9 +191,24 @@
       <arg name="error_message" type="s" direction="out"/>
     </signal>
 
-    <!-- For miscellaneous messages. -->
+    <!-- For miscellaneous messages; line-buffered. -->
     <signal name="Message">
       <arg name="text" type="s" direction="out"/>
+    </signal>
+
+    <!-- Tasks are notifications that work is being done. -->
+    <signal name="TaskBegin">
+      <arg name="text" type="s" direction="out"/>
+    </signal>
+
+    <signal name="TaskEnd">
+      <arg name="text" type="s" direction="out"/>
+    </signal>
+
+    <!-- Generic percentage progress. -->
+    <signal name="PercentProgress">
+      <arg name="text" type="s" direction="out"/>
+      <arg name="percentage" type="u" direction="out"/>
     </signal>
 
     <signal name="DownloadProgress">

--- a/src/daemon/rpmostreed-sysroot.h
+++ b/src/daemon/rpmostreed-sysroot.h
@@ -32,7 +32,7 @@ GType               rpmostreed_sysroot_get_type         (void) G_GNUC_CONST;
 RpmostreedSysroot * rpmostreed_sysroot_get              (void);
 
 gboolean            rpmostreed_sysroot_populate         (RpmostreedSysroot *self,
-							 GCancellable *cancellable,
+                                                         GCancellable *cancellable,
                                                          GError **error);
 gboolean            rpmostreed_sysroot_reload           (RpmostreedSysroot *self,
                                                          GError **error);

--- a/src/libpriv/rpmostree-output.c
+++ b/src/libpriv/rpmostree-output.c
@@ -1,0 +1,99 @@
+/*
+* Copyright (C) 2016 Red Hat, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "config.h"
+
+#include <ostree.h>
+#include <libglnx.h>
+
+#include "rpmostree-output.h"
+
+/* These are helper functions that automatically determine whether data should
+ * be sent through an appropriate D-Bus signal or sent directly to the local
+ * terminal. This is helpful in situations in which code may be executed both
+ * from the daemon and daemon-less. */
+
+static GLnxConsoleRef console;
+
+void
+rpmostree_output_default_handler (RpmOstreeOutputType type,
+                                  void *data,
+                                  void *opaque)
+{
+  switch (type)
+  {
+  case RPMOSTREE_OUTPUT_TASK_BEGIN:
+    /* XXX: move to libglnx spinner once it's implemented */
+    g_print ("%s... ", ((RpmOstreeOutputTaskBegin*)data)->text);
+    break;
+  case RPMOSTREE_OUTPUT_TASK_END:
+    g_print ("%s\n", ((RpmOstreeOutputTaskEnd*)data)->text);
+    break;
+  case RPMOSTREE_OUTPUT_PERCENT_PROGRESS:
+    if (!console.locked)
+      glnx_console_lock (&console);
+    glnx_console_progress_text_percent (
+      ((RpmOstreeOutputPercentProgress*)data)->text,
+      ((RpmOstreeOutputPercentProgress*)data)->percentage);
+    break;
+  case RPMOSTREE_OUTPUT_PERCENT_PROGRESS_END:
+    if (console.locked)
+      glnx_console_unlock (&console);
+    break;
+  }
+}
+
+static void (*active_cb)(RpmOstreeOutputType, void*, void*) =
+  rpmostree_output_default_handler;
+
+static void *active_cb_opaque;
+
+void
+rpmostree_output_set_callback (void (*cb)(RpmOstreeOutputType, void*, void*),
+                               void* opaque)
+{
+  active_cb = cb ?: rpmostree_output_default_handler;
+  active_cb_opaque = opaque;
+}
+
+void
+rpmostree_output_task_begin (const char *text)
+{
+  RpmOstreeOutputTaskBegin task = { text };
+  active_cb (RPMOSTREE_OUTPUT_TASK_BEGIN, &task, active_cb_opaque);
+}
+
+void
+rpmostree_output_task_end (const char *text)
+{
+  RpmOstreeOutputTaskEnd task = { text };
+  active_cb (RPMOSTREE_OUTPUT_TASK_END, &task, active_cb_opaque);
+}
+
+void
+rpmostree_output_percent_progress (const char *text, int percentage)
+{
+  RpmOstreeOutputPercentProgress progress = { text, percentage };
+  active_cb (RPMOSTREE_OUTPUT_PERCENT_PROGRESS, &progress, active_cb_opaque);
+}
+
+void
+rpmostree_output_percent_progress_end (void)
+{
+  active_cb (RPMOSTREE_OUTPUT_PERCENT_PROGRESS_END, NULL, active_cb_opaque);
+}

--- a/src/libpriv/rpmostree-output.h
+++ b/src/libpriv/rpmostree-output.h
@@ -1,0 +1,55 @@
+/*
+* Copyright (C) 2016 Red Hat, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#pragma once
+
+typedef enum {
+  RPMOSTREE_OUTPUT_TASK_BEGIN,
+  RPMOSTREE_OUTPUT_TASK_END,
+  RPMOSTREE_OUTPUT_PERCENT_PROGRESS,
+  RPMOSTREE_OUTPUT_PERCENT_PROGRESS_END,
+} RpmOstreeOutputType;
+
+void
+rpmostree_output_default_handler (RpmOstreeOutputType type, void *data, void *opaque);
+
+void
+rpmostree_output_set_callback (void (*cb)(RpmOstreeOutputType, void*, void*), void*);
+
+typedef struct {
+  const char *text;
+} RpmOstreeOutputTaskBegin;
+
+void
+rpmostree_output_task_begin (const char *text);
+
+typedef RpmOstreeOutputTaskBegin RpmOstreeOutputTaskEnd;
+
+void
+rpmostree_output_task_end (const char *text);
+
+typedef struct {
+  const char *text;
+  guint32 percentage;
+} RpmOstreeOutputPercentProgress;
+
+void
+rpmostree_output_percent_progress (const char *text, int percentage);
+
+void
+rpmostree_output_percent_progress_end (void);


### PR DESCRIPTION
- Add a new RawMessage signal for direct output to the terminal, as is.
- Simplify the loopback stdout stream reader, which no longer needs to
  peek for newlines, but instead just emits RawMessage signals for
  whatever is ready to be read.

---

It always annoyed me that you couldn't output data on the same line in two different chunks when running code from the daemon. For example, a common pattern is to have:

```C
g_print ("Doing stuff... ");
do_stuff ();
g_print ("done\n");
```

Of course, this breakdown of steps becomes useless when in the daemon since users will not see the whole message until we're done. I realized that it's because the (elaborate!) stdout cb specifically looks for newlines before emitting a Message.

This is my naive attempt at enabling same line printouts while also simplifying the logic. I say naive because reading the code it feels like I may be missing context which required newline peeking in the first place. Thus why I made it an RFC.