### PR TITLE
[merged] main: Consistently set exit code as failure in option processing

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -260,11 +260,11 @@ main (int    argc,
               local_error = g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED,
                                          "Unknown command '%s'", command_name);
             }
-          exit_status = EXIT_FAILURE;
         }
 
       help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
+      exit_status = EXIT_FAILURE;
 
       g_option_context_free (context);
 

--- a/src/app/rpmostree-builtin-compose.c
+++ b/src/app/rpmostree-builtin-compose.c
@@ -128,9 +128,9 @@ rpmostree_builtin_compose (int argc, char **argv, GCancellable *cancellable, GEr
               g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                            "Unknown compose command '%s'", subcommand_name);
             }
-          exit_status = EXIT_FAILURE;
         }
 
+      exit_status = EXIT_FAILURE;
       help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
 

--- a/src/app/rpmostree-builtin-container.c
+++ b/src/app/rpmostree-builtin-container.c
@@ -125,9 +125,9 @@ rpmostree_builtin_container (int argc, char **argv, GCancellable *cancellable, G
               g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                            "Unknown \"container\" subcommand '%s'", subcommand_name);
             }
-          exit_status = EXIT_FAILURE;
         }
 
+      exit_status = EXIT_FAILURE;
       help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
 

--- a/src/app/rpmostree-builtin-db.c
+++ b/src/app/rpmostree-builtin-db.c
@@ -189,9 +189,9 @@ rpmostree_builtin_db (int argc, char **argv, GCancellable *cancellable, GError *
               g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                            "Unknown \"db\" subcommand '%s'", subcommand_name);
             }
-          exit_status = EXIT_FAILURE;
         }
 
+      exit_status = EXIT_FAILURE;
       help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
 

--- a/src/app/rpmostree-builtin-internals.c
+++ b/src/app/rpmostree-builtin-internals.c
@@ -128,9 +128,9 @@ rpmostree_builtin_internals (int argc, char **argv, GCancellable *cancellable, G
               g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                            "Unknown \"internals\" subcommand '%s'", subcommand_name);
             }
-          exit_status = EXIT_FAILURE;
         }
 
+      exit_status = EXIT_FAILURE;
       help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
 


### PR DESCRIPTION
Otherwise we `exit(0)`, but trip an internal warning.

Closes: #261