### PR TITLE
[merged] tests: check an error is returned on the wrong option

### DIFF
--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -91,7 +91,6 @@ assert_file_has_content OUTPUT-status.txt '1\.0\.9'
 rpm-ostree --help | awk '/^$/ {in_commands=0} {if(in_commands==1){print $0}} /^Builtin Commands:/ {in_commands=1}' > commands
 while read command; do
     if rpm-ostree $command --n0t-3xisting-0ption >/dev/null 2>&1; then
-        echo "command $command --n0t-3xisting-0ption was successful" 1>&2;
-        exit 1
+        assert_not_reached "command $command --n0t-3xisting-0ption was successful"
     fi
 done < commands

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -86,3 +86,12 @@ assert_file_has_content OUTPUT-status.txt $(date "+%Y%m%d\.1")
 rpm-ostree deploy --os=testos REVISION=$revision
 rpm-ostree status | head --lines 3 | tee OUTPUT-status.txt
 assert_file_has_content OUTPUT-status.txt '1\.0\.9'
+
+# Ensure it returns an error when passing a wrong option.
+rpm-ostree --help | awk '/^$/ {in_commands=0} {if(in_commands==1){print $0}} /^Builtin Commands:/ {in_commands=1}' > commands
+while read command; do
+    if rpm-ostree $command --n0t-3xisting-0ption >/dev/null 2>&1; then
+        echo "command $command --n0t-3xisting-0ption was successful" 1>&2;
+        exit 1
+    fi
+done < commands


### PR DESCRIPTION
awk is already used by the tap driver, so it won't be an additional
dependency.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>