### PR TITLE
[merged] Error for unknown subcommands overrides unknown option

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -246,20 +246,18 @@ main (int    argc,
       context = option_context_new_with_commands ();
 
       /* This will not return for some options (e.g. --version). */
-      if (rpmostree_option_context_parse (context, NULL, &argc, &argv,
-                                          RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-                                          NULL, NULL, &local_error))
+      (void) rpmostree_option_context_parse (context, NULL, &argc, &argv,
+                                             RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+                                             NULL, NULL, NULL);
+      if (command_name == NULL)
         {
-          if (command_name == NULL)
-            {
-              local_error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_FAILED,
-                                                 "No command specified");
-            }
-          else
-            {
-              local_error = g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED,
-                                         "Unknown command '%s'", command_name);
-            }
+          local_error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_FAILED,
+                                             "No command specified");
+        }
+      else
+        {
+          local_error = g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED,
+                                     "Unknown command '%s'", command_name);
         }
 
       help = g_option_context_get_help (context, FALSE, NULL);

--- a/src/app/rpmostree-builtin-compose.c
+++ b/src/app/rpmostree-builtin-compose.c
@@ -111,23 +111,21 @@ rpmostree_builtin_compose (int argc, char **argv, GCancellable *cancellable, GEr
       context = compose_option_context_new_with_commands ();
 
       /* This will not return for some options (e.g. --version). */
-      if (rpmostree_option_context_parse (context, NULL,
-                                          &argc, &argv,
-                                          RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-                                          cancellable,
-                                          NULL,
-                                          error))
+      (void) rpmostree_option_context_parse (context, NULL,
+                                             &argc, &argv,
+                                             RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+                                             cancellable,
+                                             NULL,
+                                             NULL);
+      if (subcommand_name == NULL)
         {
-          if (subcommand_name == NULL)
-            {
-              g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                                   "No command specified");
-            }
-          else
-            {
-              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                           "Unknown compose command '%s'", subcommand_name);
-            }
+          g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                               "No command specified");
+        }
+      else
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Unknown compose command '%s'", subcommand_name);
         }
 
       exit_status = EXIT_FAILURE;

--- a/src/app/rpmostree-builtin-container.c
+++ b/src/app/rpmostree-builtin-container.c
@@ -108,23 +108,21 @@ rpmostree_builtin_container (int argc, char **argv, GCancellable *cancellable, G
       context = container_option_context_new_with_commands ();
 
       /* This will not return for some options (e.g. --version). */
-      if (rpmostree_option_context_parse (context, NULL,
-                                          &argc, &argv,
-                                          RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-                                          cancellable,
-                                          NULL,
-                                          error))
+      (void) rpmostree_option_context_parse (context, NULL,
+                                             &argc, &argv,
+                                             RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+                                             cancellable,
+                                             NULL,
+                                             NULL);
+      if (subcommand_name == NULL)
         {
-          if (subcommand_name == NULL)
-            {
-              g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                                   "No \"container\" subcommand specified");
-            }
-          else
-            {
-              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                           "Unknown \"container\" subcommand '%s'", subcommand_name);
-            }
+          g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                               "No \"container\" subcommand specified");
+        }
+      else
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Unknown \"container\" subcommand '%s'", subcommand_name);
         }
 
       exit_status = EXIT_FAILURE;

--- a/src/app/rpmostree-builtin-db.c
+++ b/src/app/rpmostree-builtin-db.c
@@ -172,23 +172,21 @@ rpmostree_builtin_db (int argc, char **argv, GCancellable *cancellable, GError *
       context = rpm_option_context_new_with_commands ();
 
       /* This will not return for some options (e.g. --version). */
-      if (rpmostree_option_context_parse (context, NULL,
-                                          &argc, &argv,
-                                          RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-                                          cancellable,
-                                          NULL,
-                                          error))
+      (void) rpmostree_option_context_parse (context, NULL,
+                                             &argc, &argv,
+                                             RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+                                             cancellable,
+                                             NULL,
+                                             NULL);
+      if (subcommand_name == NULL)
         {
-          if (subcommand_name == NULL)
-            {
-              g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                                   "No \"db\" subcommand specified");
-            }
-          else
-            {
-              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                           "Unknown \"db\" subcommand '%s'", subcommand_name);
-            }
+          g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                               "No \"db\" subcommand specified");
+        }
+      else
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Unknown \"db\" subcommand '%s'", subcommand_name);
         }
 
       exit_status = EXIT_FAILURE;

--- a/src/app/rpmostree-builtin-internals.c
+++ b/src/app/rpmostree-builtin-internals.c
@@ -111,23 +111,21 @@ rpmostree_builtin_internals (int argc, char **argv, GCancellable *cancellable, G
       context = internals_option_context_new_with_commands ();
 
       /* This will not return for some options (e.g. --version). */
-      if (rpmostree_option_context_parse (context, NULL,
-                                          &argc, &argv,
-                                          RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-                                          cancellable,
-                                          NULL,
-                                          error))
+      (void) rpmostree_option_context_parse (context, NULL,
+                                             &argc, &argv,
+                                             RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+                                             cancellable,
+                                             NULL,
+                                             NULL);
+      if (subcommand_name == NULL)
         {
-          if (subcommand_name == NULL)
-            {
-              g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                                   "No \"internals\" subcommand specified");
-            }
-          else
-            {
-              g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                           "Unknown \"internals\" subcommand '%s'", subcommand_name);
-            }
+          g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                               "No \"internals\" subcommand specified");
+        }
+      else
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Unknown \"internals\" subcommand '%s'", subcommand_name);
         }
 
       exit_status = EXIT_FAILURE;

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -90,8 +90,12 @@ assert_file_has_content OUTPUT-status.txt '1\.0\.9'
 # Ensure it returns an error when passing a wrong option.
 rpm-ostree --help | awk '/^$/ {in_commands=0} {if(in_commands==1){print $0}} /^Builtin Commands:/ {in_commands=1}' > commands
 while read command; do
-    if rpm-ostree $command --n0t-3xisting-0ption >/dev/null 2>err.txt; then
+    if rpm-ostree $command --n0t-3xisting-0ption &>/dev/null; then
         assert_not_reached "command $command --n0t-3xisting-0ption was successful"
-	assert_file_has_content err.txt 'Unknown.*command'
     fi
 done < commands
+
+if rpm-ostree nosuchcommand --nosuchoption 2>err.txt; then
+    assert_not_reached "Expected an error for nosuchcommand"
+fi
+assert_file_has_content err.txt 'Unknown.*command'

--- a/tests/test-basic.sh
+++ b/tests/test-basic.sh
@@ -90,7 +90,8 @@ assert_file_has_content OUTPUT-status.txt '1\.0\.9'
 # Ensure it returns an error when passing a wrong option.
 rpm-ostree --help | awk '/^$/ {in_commands=0} {if(in_commands==1){print $0}} /^Builtin Commands:/ {in_commands=1}' > commands
 while read command; do
-    if rpm-ostree $command --n0t-3xisting-0ption >/dev/null 2>&1; then
+    if rpm-ostree $command --n0t-3xisting-0ption >/dev/null 2>err.txt; then
         assert_not_reached "command $command --n0t-3xisting-0ption was successful"
+	assert_file_has_content err.txt 'Unknown.*command'
     fi
 done < commands


### PR DESCRIPTION
If one does `rpm-ostree foo --bar`, one would expect to see
`Unknown subcommand foo`, not `Unknown option --bar`.

Closes: #267