### PR TITLE
[merged] postprocess: Add `--add ostree` to dracut invocation

### DIFF
--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -414,6 +414,8 @@ do_kernel_prep (GFile         *yumroot,
         g_ptr_array_add (dracut_argv, "--reproducible");
         g_ptr_array_add (dracut_argv, "--gzip");
       }
+    g_ptr_array_add (dracut_argv, "--add");
+    g_ptr_array_add (dracut_argv, "ostree");
     g_ptr_array_add (dracut_argv, "--tmpdir=/tmp");
     g_ptr_array_add (dracut_argv, "-f");
     g_ptr_array_add (dracut_argv, "/var/tmp/initramfs.img");


### PR DESCRIPTION
Right now the `ostree.rpm` package always configures dracut to inject
the ostree setup via a conf file.  But it's actually simpler and
cleaner to just have callers specify it explicitly.

https://bugzilla.redhat.com/show_bug.cgi?id=1331369