### PR TITLE
[merged] docs: Point compose server intro to CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,7 @@ For more information on this, see `CONTRIBUTING.md`.
 More documentation
 ------------------
 
-New! See the docs online at [Read The Docs (OSTree)](https://ostree.readthedocs.org/en/latest/ )
-
-Some more information is available on the old wiki page:
-https://wiki.gnome.org/Projects/OSTree
+New! See the docs online at [Read The Docs (rpm-ostree)](https://rpm-ostree.readthedocs.org/en/latest/ )
 
 Contributing
 ------------

--- a/docs/manual/background.md
+++ b/docs/manual/background.md
@@ -35,8 +35,8 @@ on the compose server, clients get it.  If one removes a package, it's
 also removed when clients upgrade.
 
 One simple mental model for rpm-ostree is: imagine taking a set of
-packages on the server side, install them to a chroot, then doing `git
-commit` on the result.  And imagine clients just `git pull -r` from
+packages on the server side, install them to a chroot, then doing `git commit`
+on the result.  And imagine clients just `git pull -r` from
 that.  What OSTree adds to this picture is support for file uid/gid,
 extended attributes, handling of bootloader configuration, and merges
 of `/etc`.
@@ -51,7 +51,7 @@ backups such as LVM or BTRFS.
 
 ## Who should use this?
 
-Currently, rpm operates on a read-only mode on installed systems; it
+Currently, `rpm-ostree` operates on a read-only mode on installed systems; it
 is not possible to add or remove anything on the client.  If this
 matches your deployment scenario, rpm-ostree is a good choice.
 Classic examples of this are fixed purpose server farms, "corporate


### PR DESCRIPTION
We should make this less abstract and rather point people directly at
the CentOS bits as it's more likely to be a real-world useful example
and produce something they want.

Fix a few other typos and bits.