### PR TITLE
[merged] libpriv: Print repository name for each package too

### DIFF
--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -924,7 +924,7 @@ rpmostree_print_transaction (HifContext   *hifctx)
       for (i = 0; i < install->len; i++)
         {
           HifPackage *pkg = install->pdata[i];
-          g_print ("  %s\n", hif_package_get_nevra (pkg));
+          g_print ("  %s (%s)\n", hif_package_get_nevra (pkg), hif_package_get_reponame (pkg));
         }
     }
 }


### PR DESCRIPTION
I'm trying to debug why I'm getting an older version of `docker`,
and it's useful to see the repository name we're getting something
from.  Yum does this by default.

(Though we should probably consider column formatted output too
 on a tty)