### PR TITLE
[merged] vagrant: Switch to CentOS by default

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,7 @@
 # things will be a bit simpler.
 
 Vagrant.configure(2) do |config|
-    config.vm.box = "fedora/23-atomic-host"
-    config.vm.hostname = "fedoraah-dev"
+    config.vm.box = "centos/atomic-host"
+    config.vm.hostname = "centosah-dev"
+    config.vm.synced_folder ".", "/srv/vagrant", disabled: true
 end


### PR DESCRIPTION
Because this now works:

```
ostree remote add --set=gpg-verify=false centos-atomic-continuous https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/ostree/repo/
rpm-ostree rebase centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous
```

In the future we'll need infra to switch between Fedora and CentOS for
dev, but for now, I think we should focus on CentOS becuase it has to
work in order to produce downstream work.