### PR TITLE
[merged] treecompose: fix crash when "remove-from-packages" used

### DIFF
--- a/tests/compose/yum/empty.spec
+++ b/tests/compose/yum/empty.spec
@@ -21,6 +21,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 %install
 mkdir -p %{buildroot}/boot
+mkdir -p %{buildroot}/var/lib
 mkdir -p %{buildroot}/var/share/
 mkdir -p %{buildroot}/var/tmp/
 mkdir -p %{buildroot}/usr/sbin
@@ -46,6 +47,7 @@ touch %{buildroot}/var/tmp/initramfs.img
 rm -rf %{buildroot}
 
 %files
+/var/lib
 /var/share/*
 /boot/*
 /usr/sbin/*


### PR DESCRIPTION
This works around a potential issue with libsolv if we go down the
rpmostree_get_pkglist_for_root() path. Though rpm has been using the
/usr/share/rpm location (since the RpmOstreeContext set the _dbpath
macro), the /var/lib/rpm directory will still exist, but be empty.
libsolv gets confused because it sees the /var/lib/rpm dir and doesn't
even try the /usr/share/rpm location, and eventually dies when it tries
to load the data.

So we set the symlink now. This is also what we do on boot anyway for
compatibility reasons using tmpfiles.

This also means we don't have to do the /var/lib/rpm --> /usr/share/rpm
transition during the rootfs postprocess (but we still have to clean up
db and lock files).

Also get rid of the unused pkglist variable.

NB: I used the GFile & gs APIs to mesh with the surrounding code.