### PR TITLE
Merge daemon binary into main binary

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -1,5 +1,3 @@
-libexec_PROGRAMS += rpm-ostreed
-
 dbus_built_sources = rpm-ostreed-generated.h rpm-ostreed-generated.c
 
 rpm-ostreed-generated.h: rpm-ostreed-generated.c
@@ -65,24 +63,6 @@ librpmostreed_la_LIBADD = \
 	$(CAP_LIBS)
 	$(NULL)
 
-rpm_ostreed_SOURCES = \
-	src/daemon/main.c \
-	$(NULL)
-
-rpm_ostreed_CFLAGS = \
-	$(AM_CFLAGS) \
-	-DPKGLIBDIR=\"$(pkglibdir)\" \
-	$(PKGDEP_RPMOSTREE_CFLAGS) \
-	-I$(srcdir)/src/daemon \
-	-I$(srcdir)/libglnx \
-	-DG_LOG_DOMAIN=\"rpm-ostreed\" \
-	$(NULL)
-
-rpm_ostreed_LDADD = \
-	librpmostreed.la \
-	$(PKGDEP_RPMOSTREE_LIBS) \
-	$(NULL)
-
 dbusconf_DATA = $(srcdir)/src/daemon/org.projectatomic.rpmostree1.conf
 dbusconfdir = ${sysconfdir}/dbus-1/system.d
 
@@ -97,9 +77,13 @@ endif
 $(systemdunit_DATA): Makefile
 	$(SED_SUBST) $(daemon_asan_options) $@.in > $@
 
+# We keep this stub script around to have SELinux labeling work,
+# plus some backwards compatibility.
+libexec_SCRIPTS = rpm-ostreed
+rpm-ostreed: $(srcdir)/src/daemon/rpm-ostreed-stub.sh.in Makefile
+	$(SED_SUBST) $< > $@.tmp && mv $@.tmp $@
+
 install-daemon-altname-hook:
-	mv $(DESTDIR)$(libexecdir)/rpm-ostreed $(DESTDIR)$(libexecdir)/$(primaryname)d
-	ln -sf $(primaryname)d $(DESTDIR)$(libexecdir)/rpm-ostreed
 	mv $(DESTDIR)$(systemdunitdir)/rpm-ostreed.service $(DESTDIR)$(systemdunitdir)/$(primaryname)d.service
 	ln -sf $(primaryname)d.service $(DESTDIR)$(systemdunitdir)/rpm-ostreed.service
 if BUILDOPT_NEW_NAME
@@ -110,8 +94,8 @@ endif
 service_in_files = $(srcdir)/src/daemon/org.projectatomic.rpmostree1.service.in
 service_DATA     = $(service_in_files:.service.in=.service)
 servicedir       = $(dbusservicedir)
-$(service_DATA):
-	$(SED_SUBST) $@.in > $@
+%.service: %.service.in Makefile
+	$(SED_SUBST) $@.in > $@.tmp && mv $@.tmp $@
 
 EXTRA_DIST += \
 	$(dbusservice_DATA) \

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -41,6 +41,7 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-container-builtins.h \
 	src/app/rpmostree-container-builtins.c \
 	src/app/rpmostree-internals-builtin-unpack.c \
+	src/app/rpmostree-internals-builtin-start-daemon.c \
 	src/app/rpmostree-libbuiltin.c \
 	src/app/rpmostree-libbuiltin.h \
 	$(NULL)
@@ -53,8 +54,10 @@ rpm_ostree_SOURCES += \
 	$(NULL)
 endif
 
-rpm_ostree_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/src/app -I$(srcdir)/src/lib -I$(srcdir)/src/libpriv -I$(libglnx_srcpath) -DPKGLIBDIR=\"$(pkglibdir)\" $(PKGDEP_RPMOSTREE_CFLAGS)
-rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la librpmostree-1.la
+rpm_ostree_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
+	-I$(srcdir)/src/lib -I$(srcdir)/src/libpriv -I$(libglnx_srcpath) \
+  -DPKGLIBDIR=\"$(pkglibdir)\" $(PKGDEP_RPMOSTREE_CFLAGS)
+rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la librpmostree-1.la librpmostreed.la
 
 privdatadir=$(pkglibdir)
 privdata_DATA = src/app/rpm-ostree-0-integration.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -50,6 +50,7 @@ GITIGNOREFILES += build-aux/ gtk-doc.make config.h.in aclocal.m4 insttree/
 SED_SUBST = sed \
         -e 's,[@]libexecdir[@],$(libexecdir),g' \
         -e 's,[@]primaryname[@],$(primaryname),g' \
+        -e 's,[@]bindir[@],$(bindir),g' \
         $(NULL)
 
 libglnx_srcpath := $(srcdir)/libglnx

--- a/src/app/rpmostree-builtin-internals.c
+++ b/src/app/rpmostree-builtin-internals.c
@@ -30,6 +30,7 @@ typedef struct {
 
 static RpmOstreeInternalsCommand internals_subcommands[] = {
   { "unpack", rpmostree_internals_builtin_unpack },
+  { "start-daemon", rpmostree_internals_builtin_start_daemon },
   { NULL, NULL }
 };
 

--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -52,7 +52,9 @@ get_connection_for_path (gchar *sysroot,
   gboolean ret = FALSE;
 
   const gchar *args[] = {
-    "rpm-ostreed",
+    "rpm-ostree",
+    "internals",
+    "start-daemon",
     "--sysroot", sysroot,
     "--dbus-peer", buffer,
     NULL

--- a/src/app/rpmostree-internals-builtins.h
+++ b/src/app/rpmostree-internals-builtins.h
@@ -27,6 +27,7 @@
 G_BEGIN_DECLS
 
 gboolean rpmostree_internals_builtin_unpack (int argc, char **argv, GCancellable *cancellable, GError **error);
+gboolean rpmostree_internals_builtin_start_daemon (int argc, char **argv, GCancellable *cancellable, GError **error);
 
 G_END_DECLS
 

--- a/src/daemon/org.projectatomic.rpmostree1.service.in
+++ b/src/daemon/org.projectatomic.rpmostree1.service.in
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=org.projectatomic.rpmostree1
-Exec=@libexecdir@/@primaryname@d
+Exec=@bindir@/rpm-ostree internals start-daemon
 User=root
 SystemdService=@primaryname@d.service

--- a/src/daemon/rpm-ostreed-stub.sh.in
+++ b/src/daemon/rpm-ostreed-stub.sh.in
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec @bindir@/rpm-ostree internals start-daemon "$@"

--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -6,4 +6,4 @@ ConditionPathExists=/ostree
 Type=dbus
 BusName=org.projectatomic.rpmostree1
 @SYSTEMD_ENVIRON@
-ExecStart=@libexecdir@/@primaryname@d
+ExecStart=@bindir@/rpm-ostree internals start-daemon

--- a/tests/utils/setup-session.sh
+++ b/tests/utils/setup-session.sh
@@ -25,7 +25,7 @@ set -e
 
 # libtest.sh should have added the builddir which contains rpm-ostreed to our
 # path
-exec_binary="$(which rpm-ostreed)"
+exec_binary="$(which rpm-ostree)"
 
 mkdir -p sysroot
 mkdir -p session-services
@@ -56,7 +56,7 @@ EOF
 cat > session-services/rpmostree.service <<EOF
 [D-BUS Service]
 Name=org.projectatomic.rpmostree1
-Exec=${exec_binary} --debug --sysroot=${test_tmpdir}/sysroot
+Exec=${exec_binary} internals start-daemon --debug --sysroot=${test_tmpdir}/sysroot
 EOF
 
 # Tell rpm-ostree to connect to the session bus instead of system

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -18,7 +18,7 @@ if test -z "${INSIDE_VM:-}"; then
     DESTDIR=$(pwd)/insttree
     make install DESTDIR=${DESTDIR}
     for san in a t ub; do
-        if eu-readelf -d ${DESTDIR}/usr/libexec/rpm-ostreed | grep -q "NEEDED.*lib${san}san"; then
+        if eu-readelf -d ${DESTDIR}/usr/bin/rpm-ostree | grep -q "NEEDED.*lib${san}san"; then
             echo "Installing extra sanitizier: lib${san}san"
             cp /usr/lib64/lib${san}san*.so.* ${DESTDIR}/usr/lib64
         fi

--- a/tests/vmcheck/sync.sh
+++ b/tests/vmcheck/sync.sh
@@ -27,6 +27,7 @@ else
     set -x
     ostree admin unlock || :
     rsync -rlv /var/roothome/sync/insttree/usr/ /usr/
-    restorecon /usr/libexec/rpm-ostreed
+    restorecon -v /usr/bin/rpm-ostree
+    restorecon -v /usr/libexec/rpm-ostreed
     systemctl restart rpm-ostreed
 fi


### PR DESCRIPTION
The actual problem I am trying to fix with this is fallout from the
introduction of `/usr/libexec/rpm-ostreed`, which required a SELinux
policy change.  Specifically for CentOS, the base policy is rev'd
slowly.

My hope was that by merging the daemon code back into `/usr/bin/rpm-ostree`
which is labeled `install_exec_t`, starting via systemd would do
the right thing.  It turns out that doesn't happen.

I looked at PackageKit, i.e. `/usr/libexec/packagekitd` which is
actually labeled as `rpm_exec_t` (`rpm_t` at runtime).

So I think we should change SELinux policy to do that.

However - there are still benefits to this change, namely we avoid
more duplicated text (libglnx, internal helpers) between the two
binaries.
