### PR TITLE
build: Add .vagrant to GITIGNOREFILES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,7 @@ AM_CFLAGS += -std=gnu99 $(WARN_CFLAGS)
 
 EXTRA_DIST += autogen.sh COPYING
 
-GITIGNOREFILES += build-aux/ gtk-doc.make config.h.in aclocal.m4
+GITIGNOREFILES += build-aux/ gtk-doc.make config.h.in aclocal.m4 .vagrant
 
 SED_SUBST = sed \
         -e 's,[@]libexecdir[@],$(libexecdir),g' \


### PR DESCRIPTION
Since `vagrant up` creates this.  Though I'm not sure we really want
this go away with `git clean -dfx` which argues for using a separate
git repo for the Vagrantfile.