### PR TITLE
[merged] daemon: Fix regression in --preview/--check

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -139,23 +139,25 @@ package_diff_transaction_execute (RpmostreedTransaction *transaction,
 
   merge_deployment = ostree_sysroot_get_merge_deployment (sysroot, self->osname);
 
-  self->refspec = g_strdup (rpmostree_sysroot_upgrader_get_refspec (upgrader));
-
   /* Determine if we're upgrading before we set the refspec. */
   upgrading = (self->refspec == NULL && self->revision == NULL);
 
   if (self->refspec != NULL)
     {
       if (!change_upgrader_refspec (sysroot, upgrader,
-                                    self->refspec, cancellable,
-                                    NULL, NULL, error))
-        goto out;
+				    self->refspec, cancellable,
+				    NULL, NULL, error))
+	goto out;
     }
   else
     {
-      g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                           "Booted deployment has no origin");
-      goto out;
+      self->refspec = g_strdup (rpmostree_sysroot_upgrader_get_refspec (upgrader));
+      if (!self->refspec)
+	{
+	  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+			       "Booted deployment has no origin");
+	  goto out;
+	}
     }
 
   progress = ostree_async_progress_new ();


### PR DESCRIPTION
Some code changes in the package layering broke this to always
error out with `refs are equal`.

Reading the code I was confused for a bit until it dawned on
me that `self->refspec` was the input, and we extracted the current
one in a different way.  I ended up modeling it back on the last
working commit I saw (`9eabc1ba`).

That said the logic here could be cleaned up more...it feels like we
should just have a "dry run" flag for the rebase transaction core or
something.  Anyways, going for a surgical fix now.