### PR TITLE
[merged] tests: Introduce "vmcheck"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,5 +10,11 @@
 Vagrant.configure(2) do |config|
     config.vm.box = "centos/atomic-host"
     config.vm.hostname = "centosah-dev"
-    config.vm.synced_folder ".", "/srv/vagrant", disabled: true
+
+    config.vm.provision "ansible" do |ansible|
+      ansible.playbook = "tests/vmcheck/setup.yml"
+      ansible.host_key_checking = false
+      ansible.extra_vars = { ansible_ssh_user: 'vagrant' }
+      ansible.raw_ssh_args = ['-o ControlMaster=no']
+    end
 end

--- a/tests/vmcheck/Dockerfile.builder
+++ b/tests/vmcheck/Dockerfile.builder
@@ -1,0 +1,13 @@
+FROM centos/tools
+ADD atomic-centos-continuous.repo /etc/yum.repos.d/atomic-centos-continuous.repo
+RUN yum -y install yum-plugin-priorities sudo && \
+    yum -y install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ \
+      grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux \
+      which xz python gcc \
+    && yum-builddep -y rpm-ostree
+RUN groupadd -g 1000 vagrant && useradd -u 1000 -g vagrant -G wheel vagrant
+RUN echo "%wheel	ALL=(ALL)	NOPASSWD: ALL" >> /etc/sudoers
+ADD host-install.sh /usr/local/bin/host-install
+LABEL RUN "/usr/bin/docker run --privileged -ti -v /var/home:/home -v /etc:/host/etc -v /usr:/host/usr \${IMAGE}"
+USER vagrant
+WORKDIR /home/vagrant/sync

--- a/tests/vmcheck/Makefile
+++ b/tests/vmcheck/Makefile
@@ -1,0 +1,17 @@
+all:
+	echo "Targets: buildimg build install"
+
+buildimg:
+	sudo docker build -t rpm-ostree-builder -f Dockerfile.builder .
+
+runbuilder=sudo /usr/bin/docker run --privileged -ti -v /var/home:/home -v /etc:/host/etc -v /usr:/host/usr rpm-ostree-builder
+
+build:
+	$(runbuilder) /bin/sh -c 'if ! test -f configure; then env NOCONFIGURE=1 ./autogen.sh; fi'
+	$(runbuilder) /bin/sh -c 'if ! test -f Makefile; then ./configure --prefix=/usr --libdir=/usr/lib64; fi'
+	$(runbuilder) /bin/sh -c make -j 4
+
+install: build
+	$(runbuilder) sudo /usr/local/bin/host-install
+
+

--- a/tests/vmcheck/README.md
+++ b/tests/vmcheck/README.md
@@ -6,8 +6,8 @@ One time setup:
 ```
 host$ vagrant up
 host$ vagrant ssh
-vm$ rpm-ostree rebase centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous
-vm$ systemctl reboot -r
+vm$ sudo rpm-ostree rebase centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous
+vm$ systemctl reboot
 ```
 
 Edit source code on the host system; to synchronize, use:
@@ -21,7 +21,7 @@ To build and install into the VM:
 ```
 
 host$ vagrant ssh
-vm$ cd ~/src/tests/vmcheck
+vm$ cd ~/sync/tests/vmcheck
 vm$ make build
 vm$ make install
 vm$ systemctl restart rpm-ostreed

--- a/tests/vmcheck/README.md
+++ b/tests/vmcheck/README.md
@@ -1,0 +1,30 @@
+Using vmcheck
+=============
+
+One time setup:
+
+```
+host$ vagrant up
+host$ vagrant ssh
+vm$ rpm-ostree rebase centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous
+vm$ systemctl reboot -r
+```
+
+Edit source code on the host system; to synchronize, use:
+
+```
+vagrant rsync
+```
+
+To build and install into the VM:
+
+```
+
+host$ vagrant ssh
+vm$ cd ~/src/tests/vmcheck
+vm$ make build
+vm$ make install
+vm$ systemctl restart rpm-ostreed
+```
+
+

--- a/tests/vmcheck/atomic-centos-continuous.repo
+++ b/tests/vmcheck/atomic-centos-continuous.repo
@@ -1,0 +1,4 @@
+[atomic-centos-continuous]
+baseurl=https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/build
+gpgcheck=0
+priority=1

--- a/tests/vmcheck/build.sh
+++ b/tests/vmcheck/build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -xeuo pipefail
-atomic run rpm-ostree-builder make
-docker run --rm --privileged -ti -v /

--- a/tests/vmcheck/build.sh
+++ b/tests/vmcheck/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -xeuo pipefail
+atomic run rpm-ostree-builder make
+docker run --rm --privileged -ti -v /

--- a/tests/vmcheck/host-install.sh
+++ b/tests/vmcheck/host-install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -xeuo pipefail
+eval $(findmnt /host/usr -o OPTIONS -P)
+(IFS=,;
+ for x in ${OPTIONS}; do
+     if test ${x} == "ro"; then
+	 mount -o remount,rw /host/usr
+	 break
+     fi
+ done)
+make install DESTDIR=/host/
+     

--- a/tests/vmcheck/setup.yml
+++ b/tests/vmcheck/setup.yml
@@ -1,0 +1,16 @@
+---
+- hosts: all
+  sudo: yes
+  tasks:
+    - command: ostree remote add --set=gpg-verify=false centos-atomic-continuous https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/ostree/repo/
+      args:
+        creates: /etc/ostree/remotes.d/centos-atomic-continuous.conf
+
+    - command: docker inspect rpm-ostree-builder
+      failed_when: False
+      changed_when: False
+      register: inspect
+
+    - name: build buildimg
+      command: make buildimg
+      when: inspect.rc != 0

--- a/tests/vmcheck/setup.yml
+++ b/tests/vmcheck/setup.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: all
-  sudo: yes
+  become: yes
   tasks:
     - command: ostree remote add --set=gpg-verify=false centos-atomic-continuous https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/ostree/repo/
       args:
@@ -13,4 +13,6 @@
 
     - name: build buildimg
       command: make buildimg
+      args:
+        chdir: sync/tests/vmcheck
       when: inspect.rc != 0


### PR DESCRIPTION
This is infrastructure that's oriented around Vagrant, we do builds
inside the target VM (actually inside a Docker container), but then
directly `make install DESTDIR=/host/`.

The goal here is to have a convenient workflow for:

  - dev -> hand testing
  - dev -> run destructive tests