### PR TITLE
[merged] vmcheck: Experiment with the name `nxs`

### DIFF
--- a/tests/vmcheck/setup.yml
+++ b/tests/vmcheck/setup.yml
@@ -6,6 +6,10 @@
       args:
         creates: /etc/ostree/remotes.d/centos-atomic-continuous.conf
 
+    # Experimenting with this as a potential new name.
+    - name: Link nxs -> rpm-ostree
+      file: src=/usr/bin/rpm-ostree dest=/usr/local/bin/nxs owner=0 group=0 state=link
+
     - command: docker inspect rpm-ostree-builder
       failed_when: False
       changed_when: False


### PR DESCRIPTION
I find myself not liking the name rpm-ostree anymore; it's
descriptive, but unfortunately we compete with other projects with
easier and sexier names.

Also, people continually find the ostree and rpm-ostree layering
unclear.  It's *much* easier to say "nxs depends on ostree", even
though textually it's obvious "rpm-ostree depends on ostree".

Anyways, just an experiment for now.