### PR TITLE
[merged] libhif: always prefix include directives

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -24,7 +24,7 @@
 #include <glib-unix.h>
 #include <json-glib/json-glib.h>
 #include <gio/gunixoutputstream.h>
-#include <libhif.h>
+#include <libhif/libhif.h>
 #include <libhif/hif-utils.h>
 #include <stdio.h>
 #include <libglnx.h>

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -25,7 +25,6 @@
 #include <json-glib/json-glib.h>
 #include <gio/gunixoutputstream.h>
 #include <libhif/libhif.h>
-#include <libhif/hif-utils.h>
 #include <stdio.h>
 #include <libglnx.h>
 #include <rpm/rpmmacro.h>

--- a/src/app/rpmostree-internals-builtin-unpack.c
+++ b/src/app/rpmostree-internals-builtin-unpack.c
@@ -24,7 +24,6 @@
 #include <glib-unix.h>
 #include <gio/gunixoutputstream.h>
 #include <libhif/libhif.h>
-#include <libhif/hif-utils.h>
 #include <rpm/rpmts.h>
 #include <stdio.h>
 #include <libglnx.h>

--- a/src/app/rpmostree-internals-builtin-unpack.c
+++ b/src/app/rpmostree-internals-builtin-unpack.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <glib-unix.h>
 #include <gio/gunixoutputstream.h>
-#include <libhif.h>
+#include <libhif/libhif.h>
 #include <libhif/hif-utils.h>
 #include <rpm/rpmts.h>
 #include <stdio.h>

--- a/src/daemon/rpmostreed-transaction-pkg-add.c
+++ b/src/daemon/rpmostreed-transaction-pkg-add.c
@@ -23,7 +23,7 @@
 #include <rpm/rpmlib.h>
 #include <rpm/rpmlog.h>
 #include <rpm/rpmdb.h>
-#include <libhif.h>
+#include <libhif/libhif.h>
 #include <libhif/hif-utils.h>
 #include <libgsystem.h>
 

--- a/src/daemon/rpmostreed-transaction-pkg-add.c
+++ b/src/daemon/rpmostreed-transaction-pkg-add.c
@@ -24,7 +24,6 @@
 #include <rpm/rpmlog.h>
 #include <rpm/rpmdb.h>
 #include <libhif/libhif.h>
-#include <libhif/hif-utils.h>
 #include <libgsystem.h>
 
 #include "rpmostreed-transaction-types.h"

--- a/src/daemon/rpmostreed-transaction-pkg-delete.c
+++ b/src/daemon/rpmostreed-transaction-pkg-delete.c
@@ -23,7 +23,7 @@
 #include <rpm/rpmlib.h>
 #include <rpm/rpmlog.h>
 #include <rpm/rpmdb.h>
-#include <libhif.h>
+#include <libhif/libhif.h>
 #include <libhif/hif-utils.h>
 #include <libgsystem.h>
 

--- a/src/daemon/rpmostreed-transaction-pkg-delete.c
+++ b/src/daemon/rpmostreed-transaction-pkg-delete.c
@@ -24,7 +24,6 @@
 #include <rpm/rpmlog.h>
 #include <rpm/rpmdb.h>
 #include <libhif/libhif.h>
-#include <libhif/hif-utils.h>
 #include <libgsystem.h>
 
 #include "rpmostreed-transaction-types.h"

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -29,8 +29,6 @@
 #include <rpm/rpmts.h>
 #include <gio/gunixoutputstream.h>
 #include <libhif/libhif.h>
-#include <libhif/hif-utils.h>
-#include <libhif/hif-package.h>
 #include <librepo/librepo.h>
 
 #include "rpmostree-core.h"

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -28,7 +28,7 @@
 #include <rpm/rpmmacro.h>
 #include <rpm/rpmts.h>
 #include <gio/gunixoutputstream.h>
-#include <libhif.h>
+#include <libhif/libhif.h>
 #include <libhif/hif-utils.h>
 #include <libhif/hif-package.h>
 #include <librepo/librepo.h>

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -22,8 +22,6 @@
 
 #include <gio/gio.h>
 #include <libhif/libhif.h>
-#include <libhif/hif-utils.h>
-#include <libhif/hif-package.h>
 #include <ostree.h>
 
 #include "libglnx.h"

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -21,7 +21,7 @@
 #pragma once
 
 #include <gio/gio.h>
-#include <libhif.h>
+#include <libhif/libhif.h>
 #include <libhif/hif-utils.h>
 #include <libhif/hif-package.h>
 #include <ostree.h>

--- a/src/libpriv/rpmostree-refsack.h
+++ b/src/libpriv/rpmostree-refsack.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libhif.h>
+#include <libhif/libhif.h>
 
 typedef struct {
   volatile gint refcount;

--- a/src/libpriv/rpmostree-refts.h
+++ b/src/libpriv/rpmostree-refts.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <libhif.h>
+#include <libhif/libhif.h>
 
 typedef struct {
   volatile gint refcount;


### PR DESCRIPTION
This is a preemptive response to:
https://github.com/rpm-software-management/libhif/pull/138

:warning: ONLY MERGE IF/WHEN THE ABOVE IS MERGED :warning: 