### PR TITLE
[merged] core: Verify no %posts for imported packages

### DIFF
--- a/src/app/rpmostree-builtin-pkgadd.c
+++ b/src/app/rpmostree-builtin-pkgadd.c
@@ -30,11 +30,13 @@
 static char *opt_osname;
 static gboolean opt_reboot;
 static gboolean opt_dry_run;
+static gboolean opt_no_scripts;
 
 static GOptionEntry option_entries[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
   { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after upgrade is prepared", NULL },
   { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction", NULL },
+  { "noscripts", 0, 0, G_OPTION_ARG_NONE, &opt_no_scripts, "Do not run scripts", NULL },
   { NULL }
 };
 
@@ -45,6 +47,8 @@ get_args_variant (void)
   g_variant_dict_init (&dict, NULL);
   g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
   g_variant_dict_insert (&dict, "dry-run", "b", opt_dry_run);
+  if (opt_no_scripts)
+      g_variant_dict_insert (&dict, "noscripts", "b", TRUE);
   return g_variant_dict_end (&dict);
 }
 

--- a/src/app/rpmostree-builtin-pkgdelete.c
+++ b/src/app/rpmostree-builtin-pkgdelete.c
@@ -30,11 +30,13 @@
 static char *opt_osname;
 static gboolean opt_reboot;
 static gboolean opt_dry_run;
+static gboolean opt_no_scripts;
 
 static GOptionEntry option_entries[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
   { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after upgrade is prepared", NULL },
   { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction", NULL },
+  { "noscripts", 0, 0, G_OPTION_ARG_NONE, &opt_no_scripts, "Do not run scripts", NULL },
   { NULL }
 };
 
@@ -45,6 +47,8 @@ get_args_variant (void)
   g_variant_dict_init (&dict, NULL);
   g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
   g_variant_dict_insert (&dict, "dry-run", "b", opt_dry_run);
+  if (opt_no_scripts)
+      g_variant_dict_insert (&dict, "noscripts", "b", TRUE);
   return g_variant_dict_end (&dict);
 }
 

--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -320,7 +320,7 @@ rpmostree_container_builtin_assemble (int             argc,
       goto out;
 
     if (!rpmostree_context_assemble_commit (rocctx->ctx, tmprootfs_dfd, NULL,
-                                            NULL, FALSE, &commit, cancellable, error))
+                                            NULL, TRUE, &commit, cancellable, error))
       goto out;
 
     glnx_shutil_rm_rf_at (rocctx->userroot_dfd, tmprootfs, cancellable, NULL);
@@ -536,8 +536,7 @@ rpmostree_container_builtin_upgrade (int argc, char **argv, GCancellable *cancel
       goto out;
 
     if (!rpmostree_context_assemble_commit (rocctx->ctx, tmprootfs_dfd, NULL,
-                                            NULL, &new_commit_checksum,
-                                            TRUE,
+                                            NULL, TRUE, &new_commit_checksum,
                                             cancellable, error))
       goto out;
 

--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -320,7 +320,7 @@ rpmostree_container_builtin_assemble (int             argc,
       goto out;
 
     if (!rpmostree_context_assemble_commit (rocctx->ctx, tmprootfs_dfd, NULL,
-                                            NULL, &commit, cancellable, error))
+                                            NULL, FALSE, &commit, cancellable, error))
       goto out;
 
     glnx_shutil_rm_rf_at (rocctx->userroot_dfd, tmprootfs, cancellable, NULL);
@@ -537,6 +537,7 @@ rpmostree_container_builtin_upgrade (int argc, char **argv, GCancellable *cancel
 
     if (!rpmostree_context_assemble_commit (rocctx->ctx, tmprootfs_dfd, NULL,
                                             NULL, &new_commit_checksum,
+                                            TRUE,
                                             cancellable, error))
       goto out;
 

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1030,7 +1030,7 @@ final_assembly (RpmOstreeSysrootUpgrader *self,
   /* --- Overlay and commit --- */
   if (!rpmostree_context_assemble_commit (ctx, tmprootfs_dfd, devino_cache,
                                           base_rev,
-                                          (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NOSCRIPTS) > 0,
+                                          (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_NOSCRIPTS) > 0,
                                           &self->new_revision,
                                           cancellable, error))
     goto out;

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1029,7 +1029,9 @@ final_assembly (RpmOstreeSysrootUpgrader *self,
 
   /* --- Overlay and commit --- */
   if (!rpmostree_context_assemble_commit (ctx, tmprootfs_dfd, devino_cache,
-                                          base_rev, &self->new_revision,
+                                          base_rev,
+                                          (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NOSCRIPTS) > 0,
+                                          &self->new_revision,
                                           cancellable, error))
     goto out;
 

--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -39,7 +39,7 @@ typedef struct RpmOstreeSysrootUpgrader RpmOstreeSysrootUpgrader;
  * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER: Do not error if the new deployment was composed earlier than the current deployment
  * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_REDEPLOY: Use the same revision as the current deployment
  * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_DRY_RUN: If layering packages, only print the transaction
- * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NOSCRIPTS: Do not run RPM scripts
+ * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_NOSCRIPTS: Do not run RPM scripts
  *
  * Flags controlling operation of an #RpmOstreeSysrootUpgrader.
  */
@@ -49,7 +49,7 @@ typedef enum {
   RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER          = (1 << 2),
   RPMOSTREE_SYSROOT_UPGRADER_FLAGS_REDEPLOY             = (1 << 3),
   RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_DRY_RUN   = (1 << 4),
-  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NOSCRIPTS            = (1 << 5)
+  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_NOSCRIPTS = (1 << 5)
 } RpmOstreeSysrootUpgraderFlags;
 
 GType rpmostree_sysroot_upgrader_get_type (void);

--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -39,6 +39,7 @@ typedef struct RpmOstreeSysrootUpgrader RpmOstreeSysrootUpgrader;
  * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER: Do not error if the new deployment was composed earlier than the current deployment
  * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_REDEPLOY: Use the same revision as the current deployment
  * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_DRY_RUN: If layering packages, only print the transaction
+ * @RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NOSCRIPTS: Do not run RPM scripts
  *
  * Flags controlling operation of an #RpmOstreeSysrootUpgrader.
  */
@@ -47,7 +48,8 @@ typedef enum {
   RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED  = (1 << 1),
   RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER          = (1 << 2),
   RPMOSTREE_SYSROOT_UPGRADER_FLAGS_REDEPLOY             = (1 << 3),
-  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_DRY_RUN   = (1 << 4)
+  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_DRY_RUN   = (1 << 4),
+  RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NOSCRIPTS            = (1 << 5)
 } RpmOstreeSysrootUpgraderFlags;
 
 GType rpmostree_sysroot_upgrader_get_type (void);

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -735,6 +735,11 @@ pkg_opts_to_flags (GVariant *options)
   if (v)
     flags |= RPMOSTREE_TRANSACTION_PKG_FLAG_DRY_RUN;
 
+  v = FALSE;
+  g_variant_dict_lookup (&dict, "noscripts", "b", &v);
+  if (v)
+    flags |= RPMOSTREE_TRANSACTION_PKG_FLAG_NOSCRIPTS;
+
   g_variant_dict_clear (&dict);
 
   return flags;

--- a/src/daemon/rpmostreed-transaction-pkg-add.c
+++ b/src/daemon/rpmostreed-transaction-pkg-add.c
@@ -81,7 +81,7 @@ pkg_add_transaction_execute (RpmostreedTransaction *transaction,
   if (self->flags & RPMOSTREE_TRANSACTION_PKG_FLAG_DRY_RUN)
     flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_DRY_RUN;
   if (self->flags & RPMOSTREE_TRANSACTION_PKG_FLAG_NOSCRIPTS)
-    flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NOSCRIPTS;
+    flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_NOSCRIPTS;
 
   upgrader = rpmostree_sysroot_upgrader_new (sysroot, self->osname, flags,
                                              cancellable, error);

--- a/src/daemon/rpmostreed-transaction-pkg-add.c
+++ b/src/daemon/rpmostreed-transaction-pkg-add.c
@@ -80,6 +80,8 @@ pkg_add_transaction_execute (RpmostreedTransaction *transaction,
 
   if (self->flags & RPMOSTREE_TRANSACTION_PKG_FLAG_DRY_RUN)
     flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_DRY_RUN;
+  if (self->flags & RPMOSTREE_TRANSACTION_PKG_FLAG_NOSCRIPTS)
+    flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NOSCRIPTS;
 
   upgrader = rpmostree_sysroot_upgrader_new (sysroot, self->osname, flags,
                                              cancellable, error);

--- a/src/daemon/rpmostreed-transaction-pkg-delete.c
+++ b/src/daemon/rpmostreed-transaction-pkg-delete.c
@@ -41,8 +41,7 @@ typedef struct {
   RpmostreedTransaction parent;
   char *osname;
   char **packages;
-  gboolean reboot;
-  gboolean dry_run;
+  RpmOstreeTransactionPkgFlags flags;
 } PkgDeleteTransaction;
 
 typedef RpmostreedTransactionClass PkgDeleteTransactionClass;
@@ -79,7 +78,7 @@ pkg_delete_transaction_execute (RpmostreedTransaction *transaction,
   self = (PkgDeleteTransaction *) transaction;
   sysroot = rpmostreed_transaction_get_sysroot (transaction);
 
-  if (self->dry_run)
+  if (self->flags & RPMOSTREE_TRANSACTION_PKG_FLAG_DRY_RUN)
     flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_DRY_RUN;
 
   upgrader = rpmostree_sysroot_upgrader_new (sysroot, self->osname, flags,
@@ -99,7 +98,7 @@ pkg_delete_transaction_execute (RpmostreedTransaction *transaction,
   if (!rpmostree_sysroot_upgrader_deploy (upgrader, cancellable, error))
     goto out;
 
-  if (self->reboot)
+  if (self->flags & RPMOSTREE_TRANSACTION_PKG_FLAG_REBOOT)
     rpmostreed_reboot (cancellable, error);
 
   ret = TRUE;
@@ -128,8 +127,7 @@ rpmostreed_transaction_new_pkg_delete (GDBusMethodInvocation *invocation,
                                        OstreeSysroot         *sysroot,
                                        const char            *osname,
                                        const char * const    *packages,
-                                       gboolean               reboot,
-                                       gboolean               dry_run,
+				       RpmOstreeTransactionPkgFlags flags,
                                        GCancellable          *cancellable,
                                        GError               **error)
 {
@@ -150,8 +148,7 @@ rpmostreed_transaction_new_pkg_delete (GDBusMethodInvocation *invocation,
     {
       self->osname = g_strdup (osname);
       self->packages = g_strdupv ((char**)packages);
-      self->reboot = reboot;
-      self->dry_run = dry_run;
+      self->flags = flags;
     }
 
   return (RpmostreedTransaction *) self;

--- a/src/daemon/rpmostreed-transaction-pkg-delete.c
+++ b/src/daemon/rpmostreed-transaction-pkg-delete.c
@@ -80,6 +80,8 @@ pkg_delete_transaction_execute (RpmostreedTransaction *transaction,
 
   if (self->flags & RPMOSTREE_TRANSACTION_PKG_FLAG_DRY_RUN)
     flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_DRY_RUN;
+  if (self->flags & RPMOSTREE_TRANSACTION_PKG_FLAG_NOSCRIPTS)
+    flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NOSCRIPTS;
 
   upgrader = rpmostree_sysroot_upgrader_new (sysroot, self->osname, flags,
                                              cancellable, error);

--- a/src/daemon/rpmostreed-transaction-pkg-delete.c
+++ b/src/daemon/rpmostreed-transaction-pkg-delete.c
@@ -81,7 +81,7 @@ pkg_delete_transaction_execute (RpmostreedTransaction *transaction,
   if (self->flags & RPMOSTREE_TRANSACTION_PKG_FLAG_DRY_RUN)
     flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_DRY_RUN;
   if (self->flags & RPMOSTREE_TRANSACTION_PKG_FLAG_NOSCRIPTS)
-    flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NOSCRIPTS;
+    flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_NOSCRIPTS;
 
   upgrader = rpmostree_sysroot_upgrader_new (sysroot, self->osname, flags,
                                              cancellable, error);

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -75,7 +75,8 @@ RpmostreedTransaction *
 
 typedef enum {
   RPMOSTREE_TRANSACTION_PKG_FLAG_REBOOT = (1 << 0),
-  RPMOSTREE_TRANSACTION_PKG_FLAG_DRY_RUN = (1 << 1)
+  RPMOSTREE_TRANSACTION_PKG_FLAG_DRY_RUN = (1 << 1),
+  RPMOSTREE_TRANSACTION_PKG_FLAG_NOSCRIPTS = (1 << 2)
 } RpmOstreeTransactionPkgFlags;
 
 RpmostreedTransaction *

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -73,13 +73,17 @@ RpmostreedTransaction *
                                                             GCancellable *cancellable,
                                                             GError **error);
 
+typedef enum {
+  RPMOSTREE_TRANSACTION_PKG_FLAG_REBOOT = (1 << 0),
+  RPMOSTREE_TRANSACTION_PKG_FLAG_DRY_RUN = (1 << 1)
+} RpmOstreeTransactionPkgFlags;
+
 RpmostreedTransaction *
                rpmostreed_transaction_new_pkg_add          (GDBusMethodInvocation *invocation,
                                                             OstreeSysroot         *sysroot,
                                                             const char            *osname,
                                                             const char *const     *packages,
-                                                            gboolean               reboot,
-                                                            gboolean               dry_run,
+							    RpmOstreeTransactionPkgFlags flags,
                                                             GCancellable          *cancellable,
                                                             GError               **error);
 
@@ -88,7 +92,6 @@ RpmostreedTransaction *
                                                             OstreeSysroot         *sysroot,
                                                             const char            *osname,
                                                             const char *const     *packages,
-                                                            gboolean               reboot,
-                                                            gboolean               dry_run,
+							    RpmOstreeTransactionPkgFlags flags,
                                                             GCancellable          *cancellable,
                                                             GError               **error);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1942,6 +1942,7 @@ static gboolean
 add_to_transaction (rpmts  ts,
                     HifPackage *pkg,
                     int tmp_metadata_dfd,
+                    gboolean noscripts,
                     GError **error)
 {
   gboolean ret = FALSE;
@@ -1958,8 +1959,11 @@ add_to_transaction (rpmts  ts,
   if (!rpmostree_unpacker_read_metainfo (metadata_fd, &hdr, NULL, NULL, error))
     goto out;
 
-  if (!check_package_is_post_posts (hdr, hif_package_get_nevra (pkg), error))
-    goto out;
+  if (!noscripts)
+    {
+      if (!check_package_is_post_posts (hdr, hif_package_get_nevra (pkg), error))
+        goto out;
+    }
 
   r = rpmtsAddInstallElement (ts, hdr, (char*)hif_package_get_nevra (pkg), TRUE, NULL);
   if (r != 0)
@@ -1999,6 +2003,7 @@ rpmostree_context_assemble_commit (RpmOstreeContext      *self,
                                    int                    tmprootfs_dfd,
                                    OstreeRepoDevInoCache *devino_cache,
                                    const char            *parent,
+                                   gboolean               noscripts,
                                    char                 **out_commit,
                                    GCancellable          *cancellable,
                                    GError               **error)
@@ -2097,7 +2102,7 @@ rpmostree_context_assemble_commit (RpmOstreeContext      *self,
                                               cancellable, error))
             goto out;
 
-          if (!add_to_transaction (ordering_ts, pkg, tmp_metadata_dfd, error))
+          if (!add_to_transaction (ordering_ts, pkg, tmp_metadata_dfd, noscripts, error))
             goto out;
         }
 
@@ -2222,7 +2227,7 @@ rpmostree_context_assemble_commit (RpmOstreeContext      *self,
       {
         HifPackage *pkg = k;
 
-        if (!add_to_transaction (rpmdb_ts, pkg, tmp_metadata_dfd, error))
+        if (!add_to_transaction (rpmdb_ts, pkg, tmp_metadata_dfd, noscripts, error))
           goto out;
       }
   }

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -102,6 +102,7 @@ gboolean rpmostree_context_assemble_commit (RpmOstreeContext      *self,
                                             int                    tmprootfs_dfd,
                                             OstreeRepoDevInoCache *devino_cache,
                                             const char            *parent,
+                                            gboolean               noscripts,
                                             char                 **out_commit,
                                             GCancellable          *cancellable,
                                             GError               **error);


### PR DESCRIPTION
This is bringing forward an old PR for libhif:
https://github.com/rpm-software-management/libhif/pull/39

Right now, we aren't running `%post` or any of the other variants.  A
lot of packages will work if we just ignore `%post`, others won't.
Let's be conservative until we start running them, and don't imply we
support things we don't yet.