### PR TITLE
[merged] Vagrantfile: Bump RAM to 2048, update comment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,16 @@
 # vi: set ft=ruby :
 
-# In the future, this might do something more interesting
-# like contain code to sync git from the local dir into
-# the system and do builds/installs there.  But for
-# now at least this exists as a starting point, and
-# once `ostree admin unlock` exists in the next version,
-# things will be a bit simpler.
+# See `tests/vmcheck/README.md` for more information on this.
 
 Vagrant.configure(2) do |config|
     config.vm.box = "centos/atomic-host"
     config.vm.hostname = "centosah-dev"
+
+    config.vm.provider "libvirt" do |libvirt, override|
+      libvirt.cpus = 2
+      libvirt.memory = 2048
+      libvirt.driver = 'kvm'
+    end
 
     config.vm.provision "ansible" do |ansible|
       ansible.playbook = "tests/vmcheck/setup.yml"


### PR DESCRIPTION
I was running out of RAM doing builds in the VM with just 512MB.
I think for single host machines, we can assume a lot of RAM.
If one is doing multi-node Vagrant that's a different thing.

Also update the comment at the top.