### PR TITLE
[merged] core: Make unprivileged case ignore ownership, add "_compose" context

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -674,7 +674,7 @@ rpmostree_compose_builtin_tree (int             argc,
       goto out;
     }
 
-  corectx = rpmostree_context_new_unprivileged (self->cachedir_dfd, cancellable, error);
+  corectx = rpmostree_context_new_compose (self->cachedir_dfd, cancellable, error);
   if (!corectx)
     goto out;
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -38,6 +38,10 @@ G_DECLARE_FINAL_TYPE (RpmOstreeInstall, rpmostree_install, RPMOSTREE, INSTALL, G
 RpmOstreeContext *rpmostree_context_new_system (GCancellable *cancellable,
                                                 GError **error);
 
+RpmOstreeContext *rpmostree_context_new_compose (int basedir_dfd,
+                                                 GCancellable *cancellable,
+                                                 GError **error);
+
 RpmOstreeContext *rpmostree_context_new_unprivileged (int basedir_dfd,
                                                       GCancellable *cancellable,
                                                       GError **error);

--- a/src/libpriv/rpmostree-unpacker.h
+++ b/src/libpriv/rpmostree-unpacker.h
@@ -36,9 +36,11 @@ GType rpmostree_unpacker_get_type (void);
 /**
  * RpmOstreeUnpackerFlags:
  * @RPMOSTREE_UNPACKER_FLAGS_OSTREE_CONVENTION: Move files to follow ostree convention
+ * @RPMOSTREE_UNPACKER_FLAGS_UNPRIVILEGED: Ignore file ownership and setuid modes
  */
 typedef enum {
-  RPMOSTREE_UNPACKER_FLAGS_OSTREE_CONVENTION =  (1 << 0)
+  RPMOSTREE_UNPACKER_FLAGS_OSTREE_CONVENTION =  (1 << 0),
+  RPMOSTREE_UNPACKER_FLAGS_UNPRIVILEGED =  (1 << 1)
 } RpmOstreeUnpackerFlags;
 
 RpmOstreeUnpacker*


### PR DESCRIPTION
I was in the process of trying to support `%post` scripts, and I
wanted to use `rpm-ostree container` for convenient and safe testing.
However the recent package layering changes broke it to error out
on perms like `filesystem`'s `root:mail` on `/var/mail`.

I decided to introduce a new `rpmostree_context_new_compose` which had
the current behavior, switch `compose tree` to use it, and then change
`_new_unprivileged` to *really* be unprivileged.  Specifically we
ignore file ownership (and fix dir owners) because we assume we'll be
operating with `bare-user` repos.