### PR TITLE
[merged] compose: Support RPMOSTREE_RPM_VERBOSITY

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -248,6 +248,17 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
   if (opt_proxy)
     hif_context_set_http_proxy (hifctx, opt_proxy);
 
+  /* Hack this here... see https://github.com/rpm-software-management/libhif/issues/53
+   * but in the future we won't be using librpm at all for unpack/scripts, so it won't
+   * matter.
+   */
+  { const char *debuglevel = getenv ("RPMOSTREE_RPM_VERBOSITY");
+    if (!debuglevel)
+      debuglevel = "info";
+    hif_context_set_rpm_verbosity (hifctx, debuglevel);
+    rpmlogSetFile(NULL);
+  }
+
   hif_context_set_repo_dir (hifctx, gs_file_get_path_cached (contextdir));
 
   g_key_file_set_string (treespec, "tree", "ref", self->ref);


### PR DESCRIPTION
In the future we'll be taking over pretty much all RPM functionality
(unpack/scripts) and will be able to provide a lot more useful
information more directly under our control.

But in the meantime:

 - Set the default to "info" which is apparently where things like
   corrupted packages will show up.  It's just info you know?
 - Allow callers to override this via environment variable, specifially
   one can use "debug" for lots of info.