### PR TITLE
[merged] compose: With --cachedir, retain packages too

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -250,6 +250,10 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
 
   hif_context_set_repo_dir (hifctx, gs_file_get_path_cached (contextdir));
 
+  /* By default, retain packages in addition to metadata with --cachedir */
+  if (opt_cachedir)
+    hif_context_set_keep_cache (hifctx, TRUE);
+
   g_key_file_set_string (treespec, "tree", "ref", self->ref);
   g_key_file_set_string_list (treespec, "tree", "packages", (const char *const*)packages, g_strv_length (packages));
 


### PR DESCRIPTION
Really...we should have done this since day zero.  Given that the
final integration of package layering/compose/rpm caching is finally
over the horizion but not yet here, let's still do this now.

I plan to backport this patch to the 2016.3-fixes branch.