### PR TITLE
[merged] core: Initial implementation of %posttrans using bwrap+rofiles-fuse

### DIFF
--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -30,6 +30,8 @@ librpmostreepriv_la_SOURCES = \
 	src/libpriv/rpmostree-refts.c \
 	src/libpriv/rpmostree-core.c \
 	src/libpriv/rpmostree-core.h \
+	src/libpriv/rpmostree-scripts.c \
+	src/libpriv/rpmostree-scripts.h \
 	src/libpriv/rpmostree-refsack.h \
 	src/libpriv/rpmostree-refsack.c \
 	src/libpriv/rpmostree-cleanup.h \
@@ -57,3 +59,17 @@ librpmostreepriv_la_LIBADD = \
 	libglnx.la \
 	$(CAP_LIBS) \
 	$(NULL)
+
+gperf_gperf_sources = src/libpriv/rpmostree-script-gperf.gperf
+BUILT_SOURCES += $(gperf_gperf_sources:-gperf.gperf=-gperf.c)
+CLEANFILES += $(gperf_gperf_sources:-gperf.gperf=-gperf.c)
+
+nodist_librpmostreepriv_la_SOURCES = src/libpriv/rpmostree-script-gperf.c
+
+AM_V_GPERF = $(AM_V_GPERF_$(V))
+AM_V_GPERF_ = $(AM_V_GPERF_$(AM_DEFAULT_VERBOSITY))
+AM_V_GPERF_0 = @echo "  GPERF   " $@;
+
+src/%.c: src/%.gperf Makefile
+	$(AM_V_at)$(MKDIR_P) $(dir $@)
+	$(AM_V_GPERF)$(GPERF) < $< > $@.tmp && mv $@.tmp $@

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,7 @@ AC_SEARCH_LIBS([rpmsqSetInterruptSafety], [rpmio],
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 >= 2.40.0 json-glib-1.0
 				     ostree-1 >= 2015.1 libgsystem >= 2015.1
+				     libsystemd
 				     rpm libhif librepo
 				     libarchive])
 save_LIBS=$LIBS
@@ -73,6 +74,11 @@ LIBS=$save_LIBS
 AC_PATH_PROG([XSLTPROC], [xsltproc])
 
 GLIB_TESTS
+
+AC_CHECK_TOOL(GPERF, gperf)
+AS_IF([test -z "$GPERF"],
+  AC_MSG_ERROR([*** gperf not found])
+)
 
 m4_ifdef([GOBJECT_INTROSPECTION_CHECK], [
   GOBJECT_INTROSPECTION_CHECK([1.34.0])

--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -320,7 +320,7 @@ rpmostree_container_builtin_assemble (int             argc,
       goto out;
 
     if (!rpmostree_context_assemble_commit (rocctx->ctx, tmprootfs_dfd, NULL,
-                                            NULL, TRUE, &commit, cancellable, error))
+                                            NULL, FALSE, &commit, cancellable, error))
       goto out;
 
     glnx_shutil_rm_rf_at (rocctx->userroot_dfd, tmprootfs, cancellable, NULL);

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -31,12 +31,14 @@ static char *opt_osname;
 static gboolean opt_reboot;
 static gboolean opt_dry_run;
 static gboolean opt_no_scripts;
+static char **opt_ignore_script;
 
 static GOptionEntry option_entries[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
   { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after upgrade is prepared", NULL },
   { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction", NULL },
   { "noscripts", 0, 0, G_OPTION_ARG_NONE, &opt_no_scripts, "Do not run scripts", NULL },
+  { "ignore-script", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_ignore_script, "Ignore a script for a particular RPM", NULL },
   { NULL }
 };
 
@@ -49,6 +51,8 @@ get_args_variant (void)
   g_variant_dict_insert (&dict, "dry-run", "b", opt_dry_run);
   if (opt_no_scripts)
       g_variant_dict_insert (&dict, "noscripts", "b", TRUE);
+  if (opt_ignore_script)
+    g_variant_dict_insert (&dict, "ignore-scripts", "^as", opt_ignore_script);
   return g_variant_dict_end (&dict);
 }
 

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -38,7 +38,7 @@ static GOptionEntry option_entries[] = {
   { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after upgrade is prepared", NULL },
   { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction", NULL },
   { "noscripts", 0, 0, G_OPTION_ARG_NONE, &opt_no_scripts, "Do not run scripts", NULL },
-  { "ignore-script", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_ignore_script, "Ignore a script for a particular RPM", NULL },
+  { "ignore-script", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_ignore_script, "Ignore a script for given PACKAGE", "PACKAGE" },
   { NULL }
 };
 

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -30,15 +30,22 @@
 static char *opt_osname;
 static gboolean opt_reboot;
 static gboolean opt_dry_run;
+/* Turn off the noscripts stuff for now, since we aren't persisting
+ * it, and I hope we can mostly get away with not needing it.
+ */
+#if 0
 static gboolean opt_no_scripts;
 static char **opt_ignore_script;
+#endif
 
 static GOptionEntry option_entries[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
   { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after upgrade is prepared", NULL },
   { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction", NULL },
+#if 0
   { "noscripts", 0, 0, G_OPTION_ARG_NONE, &opt_no_scripts, "Do not run scripts", NULL },
-  { "ignore-script", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_ignore_script, "Ignore a script for given PACKAGE", "PACKAGE" },
+  { "ignore-script", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_ignore_script, "Ignore a script for RPM", NULL },
+#endif
   { NULL }
 };
 
@@ -49,10 +56,12 @@ get_args_variant (void)
   g_variant_dict_init (&dict, NULL);
   g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
   g_variant_dict_insert (&dict, "dry-run", "b", opt_dry_run);
+#if 0
   if (opt_no_scripts)
       g_variant_dict_insert (&dict, "noscripts", "b", TRUE);
   if (opt_ignore_script)
     g_variant_dict_insert (&dict, "ignore-scripts", "^as", opt_ignore_script);
+#endif
   return g_variant_dict_end (&dict);
 }
 

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -57,6 +57,7 @@ struct RpmOstreeSysrootUpgrader {
   GKeyFile *origin;
   char *origin_refspec;
   char **requested_packages;
+  GHashTable *ignore_scripts;
   GHashTable *packages_to_add;
   GHashTable *packages_to_delete;
   char *override_csum;
@@ -458,6 +459,14 @@ rpmostree_sysroot_upgrader_set_origin_override (RpmOstreeSysrootUpgrader *self,
   /* just update self manually rather than re-parsing the whole thing */
   g_free (self->override_csum);
   self->override_csum = g_strdup (override_commit);
+}
+
+void
+rpmostree_sysroot_upgrader_set_ignore_scripts (RpmOstreeSysrootUpgrader *self,
+                                               GHashTable* ignore_scripts)
+{
+  g_clear_pointer (&self->ignore_scripts, g_hash_table_unref);
+  self->ignore_scripts = g_hash_table_ref (ignore_scripts);
 }
 
 const char *

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1125,6 +1125,9 @@ overlay_final_pkgset (RpmOstreeSysrootUpgrader *self,
                                 cancellable, error))
     goto out;
 
+  if (self->ignore_scripts)
+    rpmostree_context_set_ignore_scripts (ctx, self->ignore_scripts);
+
   if (!get_pkgcache_repo (repo, &pkgcache_repo, cancellable, error))
     goto out;
 

--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -80,6 +80,8 @@ gboolean rpmostree_sysroot_upgrader_set_origin_rebase (RpmOstreeSysrootUpgrader 
 void rpmostree_sysroot_upgrader_set_origin_override (RpmOstreeSysrootUpgrader *self,
                                                      const char *override_commit);
 
+void rpmostree_sysroot_upgrader_set_ignore_scripts (RpmOstreeSysrootUpgrader *self,
+                                                    GHashTable* ignore_scripts);
 gboolean
 rpmostree_sysroot_upgrader_add_packages (RpmOstreeSysrootUpgrader *self,
                                          char                    **new_packages,

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -85,6 +85,7 @@ RpmostreedTransaction *
                                                             const char            *osname,
                                                             const char *const     *packages_added,
                                                             const char *const     *packages_removed,
+                                                            const char *const     *ignore_scripts,
 							    RpmOstreeTransactionPkgFlags flags,
                                                             GCancellable          *cancellable,
                                                             GError               **error);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2273,8 +2273,7 @@ rpmostree_context_assemble_commit (RpmOstreeContext      *self,
         HifPackage *pkg = k;
 
         /* Set noscripts since we already validated them above */
-        if (!add_to_transaction (rpmdb_ts, pkg, tmp_metadata_dfd, TRUE,
-                                 self->ignore_scripts,
+        if (!add_to_transaction (rpmdb_ts, pkg, tmp_metadata_dfd, TRUE, NULL,
                                  cancellable, error))
           goto out;
       }

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -68,6 +68,8 @@ void rpmostree_context_set_repo (RpmOstreeContext *self,
                                  OstreeRepo       *repo);
 void rpmostree_context_set_sepolicy (RpmOstreeContext *self,
                                      OstreeSePolicy   *sepolicy);
+void rpmostree_context_set_ignore_scripts (RpmOstreeContext *self,
+                                           GHashTable   *ignore_scripts);
 
 void rpmostree_hif_add_checksum_goal (GChecksum *checksum, HyGoal goal);
 char *rpmostree_context_get_state_sha512 (RpmOstreeContext *self);

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -32,6 +32,16 @@ rpmostree_treefile_postprocessing (GFile         *rootfs,
                                    GError       **error);
 
 gboolean
+rpmostree_rootfs_symlink_emptydir_at (int rootfs_fd,
+                                      const char *dest,
+                                      const char *src,
+                                      GError **error);
+
+gboolean
+rpmostree_rootfs_prepare_links (int           rootfs_fd,
+                                GCancellable *cancellable,
+                                GError       **error);
+gboolean
 rpmostree_rootfs_postprocess_common (int           rootfs_fd,
                                      GCancellable *cancellable,
                                      GError       **error);

--- a/src/libpriv/rpmostree-script-gperf.gperf
+++ b/src/libpriv/rpmostree-script-gperf.gperf
@@ -23,3 +23,5 @@ fedora-release.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
 fedora-release.posttrans, RPMOSTREE_SCRIPT_ACTION_IGNORE
 bash.post, RPMOSTREE_SCRIPT_ACTION_TODO_SHELL_POSTTRANS
 glibc-common.post, RPMOSTREE_SCRIPT_ACTION_TODO_SHELL_POSTTRANS
+/* Seems to be another case of legacy workaround */
+gdb.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE

--- a/src/libpriv/rpmostree-script-gperf.gperf
+++ b/src/libpriv/rpmostree-script-gperf.gperf
@@ -1,0 +1,25 @@
+%{
+#include "config.h"
+#include "rpmostree-scripts.h"
+%}
+struct RpmOstreePackageScriptHandler;
+%language=ANSI-C
+%define slot-name package_script
+%define hash-function-name rpmostree_script_gperf_hash
+%define lookup-function-name rpmostree_script_gperf_lookup
+%readonly-tables
+%omit-struct-type
+%struct-type
+%includes
+%%
+glibc.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE
+coreutils.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE  /* workaround for old bug? */
+ca-certificates.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE  /* Looks like legacy... */
+filesystem.pretrans, RPMOSTREE_SCRIPT_ACTION_IGNORE
+libgcc.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
+setup.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
+pinentry.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE
+fedora-release.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
+fedora-release.posttrans, RPMOSTREE_SCRIPT_ACTION_IGNORE
+bash.post, RPMOSTREE_SCRIPT_ACTION_TODO_SHELL_POSTTRANS
+glibc-common.post, RPMOSTREE_SCRIPT_ACTION_TODO_SHELL_POSTTRANS

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -1,0 +1,402 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+#include <systemd/sd-journal.h>
+#include "rpmostree-output.h"
+#include <err.h>
+#include "libglnx.h"
+
+#include "rpmostree-scripts.h"
+
+typedef struct {
+    const char *desc;
+    rpmsenseFlags sense;
+    rpmTagVal tag;
+    rpmTagVal progtag;
+    rpmTagVal flagtag;
+} KnownRpmScriptKind;
+
+#if 0
+static const KnownRpmScriptKind ignored_scripts[] = {
+  /* Ignore all of the *un variants since we never uninstall
+   * anything in the RPM sense.
+   */
+  { "%preun", 0,
+    RPMTAG_PREUN, RPMTAG_PREUNPROG, RPMTAG_PREUNFLAGS },
+  { "%postun", 0,
+    RPMTAG_POSTUN, RPMTAG_POSTUNPROG, RPMTAG_POSTUNFLAGS },
+  { "%triggerun", RPMSENSE_TRIGGERUN,
+    RPMTAG_TRIGGERUN, 0, 0 },
+  { "%triggerpostun", RPMSENSE_TRIGGERPOSTUN,
+    RPMTAG_TRIGGERPOSTUN, 0, 0 },
+};
+#endif
+
+static const KnownRpmScriptKind posttrans_scripts[] = {
+  /* For now, we treat %post as equivalent to %posttrans */
+  { "%post", 0,
+    RPMTAG_POSTIN, RPMTAG_POSTINPROG, RPMTAG_POSTINFLAGS },
+  { "%posttrans", 0,
+    RPMTAG_POSTTRANS, RPMTAG_POSTTRANSPROG, RPMTAG_POSTTRANSFLAGS },
+};
+
+static const KnownRpmScriptKind unsupported_scripts[] = {
+  { "%prein", 0,
+    RPMTAG_PREIN, RPMTAG_PREINPROG, RPMTAG_PREINFLAGS },
+  { "%pretrans", 0,
+    RPMTAG_PRETRANS, RPMTAG_PRETRANSPROG, RPMTAG_PRETRANSFLAGS },
+  { "%triggerprein", RPMSENSE_TRIGGERPREIN,
+    RPMTAG_TRIGGERPREIN, 0, 0 },
+  { "%triggerin", RPMSENSE_TRIGGERIN,
+    RPMTAG_TRIGGERIN, 0, 0 },
+  { "%verify", 0,
+    RPMTAG_VERIFYSCRIPT, RPMTAG_VERIFYSCRIPTPROG, RPMTAG_VERIFYSCRIPTFLAGS},
+};
+
+static void
+child_setup_fchdir (gpointer user_data)
+{
+  int fd = GPOINTER_TO_INT (user_data);
+  if (fchdir (fd) < 0)
+    err (1, "fchdir");
+}
+
+static void
+add_const_args (GPtrArray *argv_array, ...)
+{
+  va_list args;
+  char *arg;
+
+  va_start (args, argv_array);
+  while ((arg = va_arg (args, char *)))
+    g_ptr_array_add (argv_array, arg);
+  va_end (args);
+}
+
+static void
+fusermount_cleanup (const char *mountpoint)
+{
+  g_autoptr(GError) tmp_error = NULL;
+  const char *fusermount_argv[] = { "fusermount", "-u", mountpoint, NULL};
+  int estatus;
+
+  if (!g_spawn_sync (NULL, (char**)fusermount_argv, NULL, G_SPAWN_SEARCH_PATH,
+                     NULL, NULL, NULL, NULL, &estatus, &tmp_error))
+    {
+      g_prefix_error (&tmp_error, "Executing fusermount: ");
+      goto out;
+    }
+  if (!g_spawn_check_exit_status (estatus, &tmp_error))
+    {
+      g_prefix_error (&tmp_error, "Executing fusermount: ");
+      goto out;
+    }
+
+ out:
+  /* We don't want a failure to unmount to be fatal, so all we do here
+   * is log.  Though in practice what we *really* want is for the
+   * fusermount to be in the bwrap namespace, and hence tied by the
+   * kernel to the lifecycle of the container.  This would require
+   * special casing for somehow doing FUSE mounts in bwrap.  Which
+   * would be hard because NO_NEW_PRIVS turns off the setuid bits for
+   * fuse.
+   */
+  if (tmp_error)
+    sd_journal_print (LOG_WARNING, "%s", tmp_error->message);
+}
+
+static RpmOstreeScriptAction
+lookup_script_action (HifPackage *package,
+                      GHashTable *ignored_scripts,
+                      const char *scriptdesc)
+{
+  const char *pkg_script = glnx_strjoina (hif_package_get_name (package), ".", scriptdesc+1);
+  const struct RpmOstreePackageScriptHandler *handler = rpmostree_script_gperf_lookup (pkg_script, strlen (pkg_script));
+  if (ignored_scripts && g_hash_table_contains (ignored_scripts, pkg_script))
+    return RPMOSTREE_SCRIPT_ACTION_IGNORE;
+  if (!handler)
+    return RPMOSTREE_SCRIPT_ACTION_DEFAULT;
+  return handler->action;
+}
+
+gboolean
+rpmostree_script_txn_validate (HifPackage    *package,
+                               Header         hdr,
+                               GHashTable    *override_ignored_scripts,
+                               GCancellable  *cancellable,
+                               GError       **error)
+{
+  gboolean ret = FALSE;
+  guint i;
+
+  for (i = 0; i < G_N_ELEMENTS (unsupported_scripts); i++)
+    {
+      const char *desc = unsupported_scripts[i].desc;
+      rpmTagVal tagval = unsupported_scripts[i].tag;
+      rpmTagVal progtagval = unsupported_scripts[i].progtag;
+      RpmOstreeScriptAction action;
+
+      if (!(headerIsEntry (hdr, tagval) || headerIsEntry (hdr, progtagval)))
+        continue;
+
+      action = lookup_script_action (package, override_ignored_scripts, desc);
+      switch (action)
+        {
+        case RPMOSTREE_SCRIPT_ACTION_DEFAULT:
+          {
+            g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                         "Package '%s' has (currently) unsupported script of type '%s'",
+                         hif_package_get_name (package), desc);
+            goto out;
+          }
+        case RPMOSTREE_SCRIPT_ACTION_IGNORE:
+          continue;
+        }
+    }
+
+  ret = TRUE;
+ out:
+  return ret;
+}
+
+static gboolean
+run_script_in_bwrap_container (int rootfs_fd,
+                               const char *name,
+                               const char *scriptdesc,
+                               const char *script,
+                               GCancellable  *cancellable,
+                               GError       **error)
+{
+  gboolean ret = FALSE;
+  int i;
+  const char *usr_links[] = {"lib", "lib32", "lib64", "bin", "sbin"};
+  int estatus;
+  char *rofiles_mnt = strdupa ("/tmp/rofiles-fuse.XXXXXX");
+  const char *rofiles_argv[] = { "rofiles-fuse", "./usr", rofiles_mnt, NULL};
+  const char *pkg_script = glnx_strjoina (name, ".", scriptdesc+1);
+  const char *postscript_name = glnx_strjoina ("/", pkg_script);
+  const char *postscript_path_container = glnx_strjoina ("/usr/", postscript_name);
+  const char *postscript_path_host;
+  gboolean mntpoint_created = FALSE;
+  gboolean fuse_mounted = FALSE;
+  g_autoptr(GPtrArray) bwrap_argv = g_ptr_array_new ();
+  g_autoptr(GPtrArray) bwrap_argv_mallocd = g_ptr_array_new_with_free_func (g_free);
+  GSpawnFlags bwrap_spawnflags = G_SPAWN_SEARCH_PATH;
+  gboolean created_var_tmp = FALSE;
+
+  if (!glnx_mkdtempat (AT_FDCWD, rofiles_mnt, 0700, error))
+    goto out;
+
+  mntpoint_created = TRUE;
+
+  if (!g_spawn_sync (NULL, (char**)rofiles_argv, NULL, G_SPAWN_SEARCH_PATH,
+                     child_setup_fchdir, GINT_TO_POINTER (rootfs_fd),
+                     NULL, NULL, &estatus, error))
+    goto out;
+  if (!g_spawn_check_exit_status (estatus, error))
+    {
+      g_prefix_error (error, "Executing rofiles-fuse: ");
+      goto out;
+    }
+
+  fuse_mounted = TRUE;
+
+  postscript_path_host = glnx_strjoina (rofiles_mnt, "/", postscript_name);
+
+  /* TODO - Create a pipe and send this to bwrap so it's inside the
+   * tmpfs
+   */
+  if (!g_file_set_contents (postscript_path_host, script, -1, error))
+    {
+      g_prefix_error (error, "Writing script to %s: ", postscript_path_host);
+      goto out;
+    }
+  if (chmod (postscript_path_host, 0755) != 0)
+    {
+      g_prefix_error (error, "chmod %s: ", postscript_path_host);
+      goto out;
+    }
+
+  /* We need to make the mount point in the case where we're doing
+   * package layering, since the host `/var` tree is empty.  We
+   * *could* point at the real `/var`...but that seems
+   * unnecessary/dangerous to me.  Daemons that need to perform data
+   * migrations should do them as part of their systemd units and not
+   * in %post.
+   *
+   * Another alternative would be to make a tmpfs with the compat
+   * symlinks.
+   */
+  if (mkdirat (rootfs_fd, "var/tmp", 0755) < 0)
+    {
+      if (errno == EEXIST)
+        ;
+      else
+        {
+          glnx_set_error_from_errno (error);
+          goto out;
+        }
+    }
+  else
+    created_var_tmp = TRUE;
+
+  add_const_args (bwrap_argv,
+                  "bwrap",
+                  "--bind", rofiles_mnt, "/usr",
+                  "--dev", "/dev",
+                  "--proc", "/proc",
+                  "--dir", "/tmp",
+                  "--chdir", "/",
+                  /* Scripts can see a /var with compat links like alternatives */
+                  "--ro-bind", "./var", "/var",
+                  /* But no need to access persistent /tmp, so make it /tmp */
+                  "--bind", "/tmp", "/var/tmp",
+                  /* Allow RPM scripts to change the /etc defaults */
+                  "--symlink", "usr/etc", "/etc",
+                  "--ro-bind", "/sys/block", "/sys/block",
+                  "--ro-bind", "/sys/bus", "/sys/bus",
+                  "--ro-bind", "/sys/class", "/sys/class",
+                  "--ro-bind", "/sys/dev", "/sys/dev",
+                  "--ro-bind", "/sys/devices", "/sys/devices",
+                  NULL);
+
+  for (i = 0; i < G_N_ELEMENTS (usr_links); i++)
+    {
+      const char *subdir = usr_links[i];
+      struct stat stbuf;
+      char *path;
+
+      if (!(fstatat (rootfs_fd, subdir, &stbuf, AT_SYMLINK_NOFOLLOW) == 0 && S_ISLNK (stbuf.st_mode)))
+        continue;
+
+      g_ptr_array_add (bwrap_argv, "--symlink");
+
+      path = g_strconcat ("usr/", subdir, NULL);
+      g_ptr_array_add (bwrap_argv_mallocd, path);
+      g_ptr_array_add (bwrap_argv, path);
+
+      path = g_strconcat ("/", subdir, NULL);
+      g_ptr_array_add (bwrap_argv_mallocd, path);
+      g_ptr_array_add (bwrap_argv, path);
+    }
+
+  { const char *debugscript = getenv ("RPMOSTREE_DEBUG_SCRIPT");
+    if (g_strcmp0 (debugscript, pkg_script) == 0)
+      {
+        g_ptr_array_add (bwrap_argv, (char*)"/bin/bash");
+        bwrap_spawnflags |= G_SPAWN_CHILD_INHERITS_STDIN;
+      }
+    else
+      g_ptr_array_add (bwrap_argv, (char*)postscript_path_container);
+  }
+  g_ptr_array_add (bwrap_argv, NULL);
+
+  if (!g_spawn_sync (NULL, (char**)bwrap_argv->pdata, NULL, bwrap_spawnflags,
+                     child_setup_fchdir, GINT_TO_POINTER (rootfs_fd),
+                     NULL, NULL, &estatus, error))
+    {
+      g_prefix_error (error, "Executing bwrap: ");
+      goto out;
+    }
+  if (!g_spawn_check_exit_status (estatus, error))
+    {
+      g_prefix_error (error, "Executing bwrap: ");
+      goto out;
+    }
+
+  ret = TRUE;
+ out:
+  if (fuse_mounted)
+    {
+      (void) unlink (postscript_path_host);
+      fusermount_cleanup (rofiles_mnt);
+    }
+  if (mntpoint_created)
+    (void) unlinkat (AT_FDCWD, rofiles_mnt, AT_REMOVEDIR);
+  if (created_var_tmp)
+    (void) unlinkat (rootfs_fd, "var/tmp", AT_REMOVEDIR);
+  return ret;
+}
+
+gboolean
+rpmostree_posttrans_run_sync (HifPackage    *pkg,
+                              Header         hdr,
+                              GHashTable    *ignore_scripts,
+                              int            rootfs_fd,
+                              GCancellable  *cancellable,
+                              GError       **error)
+{
+  for (guint i = 0; i < G_N_ELEMENTS (posttrans_scripts); i++)
+    {
+      const char *desc = posttrans_scripts[i].desc;
+      rpmTagVal tagval = posttrans_scripts[i].tag;
+      rpmTagVal progtagval = posttrans_scripts[i].progtag;
+      const char *script;
+      RpmOstreeScriptAction action;
+
+      if (!(headerIsEntry (hdr, tagval) || headerIsEntry (hdr, progtagval)))
+        continue;
+      
+      script = headerGetString (hdr, tagval);
+      if (!script)
+        continue;
+
+      action = lookup_script_action (pkg, ignore_scripts, desc);
+      switch (action)
+        {
+        case RPMOSTREE_SCRIPT_ACTION_DEFAULT:
+          {
+            rpmostree_output_task_begin ("Running %s for %s...", desc, hif_package_get_name (pkg));
+            if (!run_script_in_bwrap_container (rootfs_fd, hif_package_get_name (pkg), desc, script,
+                                                cancellable, error))
+              {
+                g_prefix_error (error, "Running %s for %s: ", desc, hif_package_get_name (pkg));
+                return FALSE;
+              }
+            rpmostree_output_task_end ("done");
+          }
+        case RPMOSTREE_SCRIPT_ACTION_IGNORE:
+          continue;
+        }
+    }
+
+  return TRUE;
+}
+
+gboolean
+rpmostree_script_ignore_hash_from_strv (const char *const *strv,
+                                        GHashTable **out_hash,
+                                        GError **error)
+{
+  g_autoptr(GHashTable) ignore_scripts = NULL;
+  if (!strv)
+    {
+      *out_hash = NULL;
+      return TRUE;
+    }
+  ignore_scripts = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+  for (const char *const* iter = strv; iter && *iter; iter++)
+    g_hash_table_add (ignore_scripts, g_strdup (*iter));
+  *out_hash = g_steal_pointer (&ignore_scripts);
+  return TRUE;
+}

--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -1,0 +1,65 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2016 Colin Walters <walters@verbum.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <ostree.h>
+#include <rpm/rpmsq.h>
+#include <rpm/rpmlib.h>
+#include <rpm/rpmlog.h>
+#include <rpm/rpmfi.h>
+#include <rpm/rpmmacro.h>
+#include <rpm/rpmts.h>
+#include <libhif/libhif.h>
+
+#include "libglnx.h"
+
+typedef enum {
+  RPMOSTREE_SCRIPT_ACTION_DEFAULT = 0,
+  RPMOSTREE_SCRIPT_ACTION_IGNORE,
+  RPMOSTREE_SCRIPT_ACTION_TODO_SHELL_POSTTRANS = RPMOSTREE_SCRIPT_ACTION_IGNORE,
+} RpmOstreeScriptAction;
+
+struct RpmOstreePackageScriptHandler {
+  const char *package_script;
+  RpmOstreeScriptAction action;
+};
+
+const struct RpmOstreePackageScriptHandler* rpmostree_script_gperf_lookup(const char *key, unsigned length);
+
+gboolean rpmostree_script_ignore_hash_from_strv (const char *const *strv,
+                                                 GHashTable **out_hash,
+                                                 GError **error);
+
+gboolean
+rpmostree_script_txn_validate (HifPackage    *package,
+                               Header         hdr,
+                               GHashTable    *ignore_scripts,
+                               GCancellable  *cancellable,
+                               GError       **error);
+
+gboolean
+rpmostree_posttrans_run_sync (HifPackage    *pkg,
+                              Header         hdr,
+                              GHashTable    *ignore_scripts,
+                              int            rootfs_fd,
+                              GCancellable  *cancellable,
+                              GError       **error);


### PR DESCRIPTION
In order to make many things work, we need to run scripts.  Short version:
For now, we:

 - Run `%posttrans`
 - Treat most `%post` as the same as `%posttrans`
 - Ignore `%preun` and such since we never uninstall

Most importantly though, we start to build up an "override" list
for script handling.  Currently it's just a blacklist of scripts
we don't need.

Significant work here would be needed to run Lua scripts, so far I've
been able to just skip them.