### PR TITLE
[merged] daemon: Check for GPG signature on base commit, not layered

### DIFF
--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -214,8 +214,6 @@ rpmostreed_deployment_generate_variant (OstreeDeployment *deployment,
   id = rpmostreed_deployment_generate_id (deployment);
 
   rpmostreed_deployment_get_refspec_packages (deployment, &origin_refspec, &origin_packages);
-  if (origin_refspec)
-    sigs = rpmostreed_deployment_gpg_results (repo, origin_refspec, csum);
 
   g_variant_dict_init (&dict, NULL);
 
@@ -229,7 +227,11 @@ rpmostreed_deployment_generate_variant (OstreeDeployment *deployment,
       const char *parent = ostree_commit_get_parent (commit);
       g_assert (parent);
       g_variant_dict_insert (&dict, "base-checksum", "s", parent);
+      if (origin_refspec)
+	sigs = rpmostreed_deployment_gpg_results (repo, origin_refspec, parent);
     }
+  else if (origin_refspec)
+    sigs = rpmostreed_deployment_gpg_results (repo, origin_refspec, csum);
 
   variant_add_commit_details (&dict, commit);
   if (origin_refspec != NULL)


### PR DESCRIPTION
We don't currently expect people to sign commits locally.

However, long term, I would like to support a verified boot model
where we still support layered packages.  A system administrator could
log in and perform changes, and possibly use a remote hardware token
to sign the commit.  Anyways that's for the future.