### PR TITLE
[merged] RPMOSTreeSysroot: add "booted" entry to deployment variant

### DIFF
--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -13,6 +13,7 @@
        'origin' (type 's')
        'signatures' (type 'av')
        'packages' (type 'as')
+       'booted' (type 'b')
   -->
 
   <interface name="org.projectatomic.rpmostree1.Sysroot">

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -188,6 +188,7 @@ variant_add_commit_details (GVariantDict *dict,
 
 GVariant *
 rpmostreed_deployment_generate_variant (OstreeDeployment *deployment,
+                                        const char *booted_id,
                                         OstreeRepo *repo,
 					GError **error)
 {
@@ -243,6 +244,9 @@ rpmostreed_deployment_generate_variant (OstreeDeployment *deployment,
 
   g_variant_dict_insert (&dict, "unlocked", "s",
 			 ostree_deployment_unlocked_state_to_string (ostree_deployment_get_unlocked (deployment)));
+
+  if (booted_id != NULL)
+    g_variant_dict_insert (&dict, "booted", "b", g_strcmp0 (booted_id, id) == 0);
 
   return g_variant_dict_end (&dict);
 }

--- a/src/daemon/rpmostreed-deployment-utils.h
+++ b/src/daemon/rpmostreed-deployment-utils.h
@@ -37,6 +37,7 @@ void            rpmostreed_deployment_get_refspec_packages (OstreeDeployment *de
 GVariant *      rpmostreed_deployment_generate_blank_variant (void);
 
 GVariant *      rpmostreed_deployment_generate_variant (OstreeDeployment *deployment,
+                                                        const char *booted_id,
                                                         OstreeRepo *repo,
 							GError **error);
 

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -1112,12 +1112,11 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
   ot_repo = rpmostreed_sysroot_get_repo (rpmostreed_sysroot_get ());
 
   booted = ostree_sysroot_get_booted_deployment (ot_sysroot);
-  if (booted && g_strcmp0 (ostree_deployment_get_osname (booted),
-                           name) == 0)
+  if (booted && g_strcmp0 (ostree_deployment_get_osname (booted), name) == 0)
     {
       booted_variant = rpmostreed_deployment_generate_variant (booted, booted_id, ot_repo, error);
       if (!booted_variant)
-	return FALSE;
+        return FALSE;
       booted_id = rpmostreed_deployment_generate_id (booted);
     }
 


### PR DESCRIPTION
Now that the `status` command learned a `--json` option, we can pretty
much avoid parsing human-readable output. The only piece of information
that is missing from the JSON output compared to the output for humans
is *which* deployment we're currently booted in.

This patch fixes that shortcoming by adding a "booted" boolean variant
to the deployment variant.