### PR TITLE
[merged] Daemon fixes

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -437,6 +437,9 @@ rpmostree_sysroot_upgrader_set_origin_rebase (RpmOstreeSysrootUpgrader *self,
   if (!origin_set_refspec (new_origin, new_refspec, error))
     return FALSE;
 
+  /* we don't want to carry any commit overrides during a rebase */
+  g_key_file_remove_key (new_origin, "origin", "override-commit", NULL);
+
   g_clear_pointer (&self->origin, g_key_file_unref);
   self->origin = g_key_file_ref (new_origin);
 
@@ -454,7 +457,7 @@ rpmostree_sysroot_upgrader_set_origin_override (RpmOstreeSysrootUpgrader *self,
   if (override_commit != NULL)
     g_key_file_set_string (self->origin, "origin", "override-commit", override_commit);
   else
-    g_key_file_remove_key (self->origin, "origin", "override_commit", NULL);
+    g_key_file_remove_key (self->origin, "origin", "override-commit", NULL);
 
   /* just update self manually rather than re-parsing the whole thing */
   g_free (self->override_csum);

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -259,7 +259,7 @@ rpmostreed_commit_generate_cached_details_variant (OstreeDeployment *deployment,
 {
   g_autoptr(GVariant) commit = NULL;
   g_autofree gchar *origin_refspec = NULL;
-  g_autofree gchar *head = NULL;
+  const gchar *head = NULL;
   const gchar *osname;
   GVariant *sigs = NULL; /* floating variant */
   GVariant *ret = NULL; /* floating variant */
@@ -275,9 +275,8 @@ rpmostreed_commit_generate_cached_details_variant (OstreeDeployment *deployment,
   if (!origin_refspec)
     goto out;
 
-  if (!ostree_repo_resolve_rev (repo, origin_refspec,
-                                FALSE, &head, error))
-    goto out;
+  head = ostree_deployment_get_csum (deployment);
+
   if (!ostree_repo_load_variant (repo,
 				 OSTREE_OBJECT_TYPE_COMMIT,
 				 head,


### PR DESCRIPTION
These commits together fix #347. There were actually multiple issues here.

First, we didn't remove the csum override when rebasing, which meant that we would happily deploy the wrong commit. It's even worse than that, because the commit we deploy might not have every been in that branch. I wonder if it would have (correctly) errored out if we would have used the `override-commit-ids` option of `ostree_repo_pull_with_options` here instead of passing the override csum as the ref. This behaviour was causing the strange display issues @miabbott reported in #347:

> If you inspect rpm-ostree status here, the refspec for the pending deployment has changed, but the version and commit id are the same as the live deployment

Second, upon starting the daemon after rebasing, it would try to lookup a rev which was just pruned and subsequently manifested in an assertion error during `nxs status`. This resolves the original issue mentioned in #347.

Let's hope we never see these types of issues as we develop the `vmcheck` testsuite.