### PR TITLE
[merged] core: Always refresh cache, rather than never

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -349,7 +349,8 @@ rpmostree_context_new_system (GCancellable *cancellable,
   hif_context_set_http_proxy (self->hifctx, g_getenv ("http_proxy"));
 
   hif_context_set_repo_dir (self->hifctx, "/etc/yum.repos.d");
-  hif_context_set_cache_age (self->hifctx, G_MAXUINT);
+  /* Operating on stale metadata is too annoying */
+  hif_context_set_cache_age (self->hifctx, 0);
   hif_context_set_cache_dir (self->hifctx, "/var/cache/rpm-ostree/" RPMOSTREE_DIR_CACHE_REPOMD);
   hif_context_set_solv_dir (self->hifctx, "/var/cache/rpm-ostree/" RPMOSTREE_DIR_CACHE_SOLV);
   hif_context_set_lock_dir (self->hifctx, "/run/rpm-ostree/" RPMOSTREE_DIR_LOCK);


### PR DESCRIPTION
I was trying to upgrade my desktop today and hit errors due
the fact I was apparently only upgrading the base, and not
layered packages.  (Due to a newer shared library in the base
needing to be version locked with a layered package).

It turns out we were keeping the cache forever, which is really quite
the opposite of what we want here.

I haven't looked if librepo is doing If-Modified-Since etc. updates or
not, but if it isn't we need to fix that.