### PR TITLE
[merged] Improve the hacking experience

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -38,13 +38,22 @@ container). We're hoping to improve this workflow soon.
 Hacking
 =======
 
-The `make vmbuild` command will automatically sync the
-current files to the VM, build `rpm-ostree` and install it
-into a new deployment, and finally reboot the VM to use it.
+The `make vmoverlay` command will automatically sync the
+current files to the VM, unlock the current deployment,
+build `rpm-ostree`, and install it.
+
+If you need to test on a locked deployment with the updated
+`rpm-ostree` baked into the tree, you can use the `make
+vmbuild` command, which will install `rpm-ostree` into a new
+deployment and reboot the VM to use it.
 
 For convenience, the `make vmshell` command does the same
-but additionally places you in a shell, ready to test your
-changes.
+as `make vmbuild` but additionally places you in a shell,
+ready to test your changes.
+
+Note that by default, all the commands above try to re-use
+the same configuration files to save speed. If you want to
+force a cleanup, you can use `VMCLEAN=1`.
 
 Testing
 =======

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -7,15 +7,14 @@ AM_TESTS_ENVIRONMENT = \
 	commondir=$(abs_top_srcdir)/tests/common
 
 CLEANFILES += \
-	tests/common/compose/yum/repodata/repomd.xml \
+	tests/common/compose/yum/repo \
 	tests/common/compose/test-repo.repo \
-	tests/common/compose/yum/repodata/*.bz2 \
-	tests/common/compose/yum/repodata/*.gz \
 	$(NULL)
 
 testpackages = \
-	tests/common/compose/yum/x86_64/empty-1.0-1.x86_64.rpm \
-	tests/common/compose/yum/x86_64/foo-1.0-1.x86_64.rpm \
+	tests/common/compose/yum/repo/packages/x86_64/empty-1.0-1.x86_64.rpm \
+	tests/common/compose/yum/repo/packages/x86_64/foo-1.0-1.x86_64.rpm \
+	tests/common/compose/yum/repo/packages/x86_64/bar-1.0-1.x86_64.rpm \
 	$(NULL)
 
 # Create a rule for each testpkg with their respective spec file as dep.
@@ -31,7 +30,7 @@ $(1): tests/common/compose/yum/$(2).spec
 	   --define "_specdir      $$$$PWD" \
 	   --define "_builddir     $$$$PWD/.build" \
 	   --define "_srcrpmdir    $$$$PWD" \
-	   --define "_rpmdir       $$$$PWD" \
+	   --define "_rpmdir       $$$$PWD/repo/packages" \
 	   --define "_buildrootdir $$$$PWD" && \
 	 rm -rf .build && \
 	 rm -f  *.src.rpm)
@@ -39,11 +38,12 @@ endef
 
 $(foreach pkg,$(testpackages),$(eval $(call testpkgbuild_template,$(pkg),$(shell basename $(pkg) | cut -d- -f1))))
 
-tests/common/compose/yum/repodata/repomd.xml: $(testpackages)
-	(cd tests/common/compose/yum && \
+tests/common/compose/yum/repo/repodata/repomd.xml: $(testpackages)
+	(cd tests/common/compose/yum/repo && \
 	 createrepo_c --no-database $$PWD)
 
-tests/common/compose/test-repo.repo: tests/common/compose/test-repo.repo.in tests/common/compose/yum/repodata/repomd.xml
+tests/common/compose/test-repo.repo: tests/common/compose/test-repo.repo.in \
+                                     tests/common/compose/yum/repo/repodata/repomd.xml
 	cat $< | sed -e "s|%WHERE%|$(abs_top_srcdir)|" > $@
 
 CLEANFILES += \
@@ -80,6 +80,8 @@ check-local:
 	@echo "  *** NOTE ***"
 	@echo "  *** NOTE ***"
 
+.PHONY: vmbuild vmshell vmcheck testenv
+
 vmbuild:
 	@if [ -z "$(SKIP_VMBUILD)" ]; then \
 	  vagrant up && \
@@ -94,7 +96,7 @@ vmshell: vmbuild
 	vagrant ssh
 
 # set up test environment to somewhat resemble uninstalled tests
-vmcheck: vmbuild
+vmcheck: vmbuild tests/common/compose/yum/repo/repodata/repomd.xml
 	@env VMTESTS=1 \
 	    builddir="$(abs_builddir)" \
 	    topsrcdir="$(abs_top_srcdir)" \

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -85,12 +85,21 @@ check-local:
 vmbuild:
 	@if [ -z "$(SKIP_VMBUILD)" ]; then \
 	  vagrant up && \
+	  ( [ -z "$(VMCLEAN)" ] || vagrant ssh -c "rm -rf sync" ) && \
 	  vagrant rsync && \
 	  vagrant ssh -c "cd sync/vagrant && \
 	                  make install VERSION=$$(git describe)" && \
 	  ( vagrant ssh -c "sudo systemctl reboot" || : ) && \
 	  sleep 2; \
 	fi
+
+vmoverlay:
+	vagrant up && \
+	( [ -z "$(VMCLEAN)" ] || vagrant ssh -c "rm -rf sync" ) && \
+	vagrant rsync && \
+	vagrant ssh -c "cd sync/vagrant && make ofsinstall" && \
+	vagrant ssh -c "systemctl daemon-reload && \
+	                systemctl restart rpm-ostreed"
 
 vmshell: vmbuild
 	vagrant ssh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,12 @@ Vagrant.configure(2) do |config|
     # containers)
     config.vm.synced_folder ".", "/home/vagrant/sync", disabled: true
     config.vm.synced_folder ".", "/root/sync", type: "rsync",
-      rsync__exclude: [".git/", "vagrant/*.tar.gz"]
+      rsync__exclude: [".git/", "vagrant/*.tar.gz"],
+
+      # override the default args so that
+      #  (1) we don't use --delete (otherwise we will have to regen each time)
+      #  (2) we can tell rsync to skip ignored files
+      rsync__args: ["--verbose", "--archive", "-z", "--filter", ":- .gitignore"]
 
     config.vm.provider "libvirt" do |libvirt, override|
       libvirt.cpus = 2

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,7 @@ Tests are divided into two groups:
 
 - Tests in the `vmcheck` directory are destructive and
   installed. They are run inside a VM. Use `make vmcheck` to
-  run these.
+  run these (see also `HACKING.md` in the top directory).
 
 The `common` directory contains files used by multiple
 tests. The `utils` directory contains helper utilities

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -46,7 +46,7 @@ echo "ok status shows right version"
 rpm-ostree status --json > status.json
 json-glib-format status.json
 if test -x /usr/bin/jq; then
-    jq '.[0].version' < status.json > version.txt
+    jq '.deployments[0].version' < status.json > version.txt
     assert_file_has_content version.txt '1\.0\.10'
 fi
 

--- a/tests/common/compose/test-repo.repo.in
+++ b/tests/common/compose/test-repo.repo.in
@@ -1,6 +1,6 @@
 [test-repo]
 name=test-repo
-baseurl=file://%WHERE%/tests/common/compose/yum
+baseurl=file://%WHERE%/tests/common/compose/yum/repo
 enabled=1
 gpgcheck=0
 skip_if_unavailable=False

--- a/tests/common/compose/yum/bar.spec
+++ b/tests/common/compose/yum/bar.spec
@@ -1,0 +1,37 @@
+Summary: Awesome utility that allows convenient barbing
+Name: bar
+Version: 1.0
+Release: 1
+License: GPL+
+Group: Development/Tools
+URL: http://bar.bar.com
+BuildArch: x86_64
+
+# LONG LIVE BARBING!
+Conflicts: foo
+
+%description
+%{summary}
+
+%prep
+
+%build
+cat > bar << EOF
+#!/bin/sh
+echo "Happy barbing!"
+EOF
+chmod a+x bar
+
+%install
+mkdir -p %{buildroot}/usr/bin
+install bar %{buildroot}/usr/bin
+
+%clean
+rm -rf %{buildroot}
+
+%files
+/usr/bin/bar
+
+%changelog
+* Tue Jun 21 2016 Jonathan Lebon <jlebon@redhat.com> 1.0-1
+- First Build

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -33,18 +33,25 @@ vm_send() {
 }
 
 # wait until ssh is available on the vm
+# - $1    timeout in second (optional)
 vm_ssh_wait() {
-  # XXX: add timeout
-  while ! vm_cmd true &> /dev/null; do
+  timeout=${1:-0}
+  while [ $timeout -gt 0 ]; do
+    if vm_cmd true &> /dev/null; then
+      return 0
+    fi
+    timeout=$((timeout - 1))
     sleep 1
   done
+  # final check at the timeout mark
+  vm_cmd true &> /dev/null
 }
 
 # reboot the vm
 vm_reboot() {
   vm_cmd systemctl reboot || :
   sleep 2 # give time for port to go down
-  vm_ssh_wait
+  vm_ssh_wait 10
 }
 
 # check that the given files exist on the VM

--- a/tests/vmcheck/test-layering.sh
+++ b/tests/vmcheck/test-layering.sh
@@ -42,12 +42,12 @@ elif vm_has_layered_packages foo; then
   assert_not_reached "foo already layered"
 fi
 
-vm_send /tmp/vmcheck ${commondir}/compose
+vm_send /tmp/vmcheck ${commondir}/compose/yum/repo
 
 cat > vmcheck.repo << EOF
 [test-repo]
 name=test-repo
-baseurl=file:///tmp/vmcheck/compose/yum
+baseurl=file:///tmp/vmcheck/repo
 EOF
 
 vm_send /etc/yum.repos.d vmcheck.repo

--- a/tests/vmcheck/test-layering.sh
+++ b/tests/vmcheck/test-layering.sh
@@ -24,15 +24,6 @@ set -e
 
 set -x
 
-# XXX: this should be done by the test harness
-test_cleanup() {
-  if vm_has_packages foo; then
-    vm_cmd rpm-ostree rollback
-    vm_reboot
-  fi
-}
-trap 'test_cleanup; _cleanup_tmpdir' EXIT
-
 # make sure package foo is not already layered
 if vm_has_files /usr/bin/foo; then
   assert_not_reached "/usr/bin/foo already present"

--- a/tests/vmcheck/test.sh
+++ b/tests/vmcheck/test.sh
@@ -9,8 +9,10 @@ echo "  ControlPersist yes" >> ssh-config
 export SSH="ssh -F $PWD/ssh-config vmcheck"
 export SCP="scp -F $PWD/ssh-config"
 
+. ${commondir}/libvm.sh
+
 # stand up ssh connection and sanity check that it all works
-if ! $SSH true &> /dev/null; then
+if ! vm_ssh_wait 10; then
   echo "ERROR: A running VM is required for 'make vmcheck'."
   exit 1
 fi

--- a/vagrant/Dockerfile.builder
+++ b/vagrant/Dockerfile.builder
@@ -3,7 +3,7 @@ ADD atomic-centos-continuous.repo /etc/yum.repos.d/atomic-centos-continuous.repo
 RUN yum -y install yum-plugin-priorities sudo && \
     yum -y install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ \
       grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux \
-      which xz python gcc \
+      which xz python gcc gperf 'pkgconfig(libsystemd)' \
     && yum-builddep -y rpm-ostree
 LABEL RUN "/usr/bin/docker run --privileged -ti -v /var/roothome:/root -v /etc:/host/etc -v /usr:/host/usr \${IMAGE}"
 WORKDIR /root/sync

--- a/vagrant/Makefile
+++ b/vagrant/Makefile
@@ -10,8 +10,13 @@ buildimg:
 	sudo docker build -t $(BUILDER_IMG) -f Dockerfile.builder .
 
 build:
-	$(BUILDER_RUN) ./autogen.sh --prefix=/usr --libdir=/usr/lib64
-	$(BUILDER_RUN) sh -c 'make clean && make -j 4'
+	if ! test -f ../configure; then \
+	  $(BUILDER_RUN) env NOCONFIGURE=1 ./autogen.sh; \
+	fi
+	if ! test -f ../Makefile; then \
+	  $(BUILDER_RUN) ./configure --prefix=/usr --libdir=/usr/lib64; \
+	fi
+	$(BUILDER_RUN) sh -c make -j 4
 
 install: build
 	sudo sh checkout.sh
@@ -19,3 +24,9 @@ install: build
 	                -v /ostree/repo/tmp/vmcheck.ro/usr:/host/usr \
 	                $(BUILDER_IMG) sudo make install DESTDIR=/host
 	sudo VERSION=$(VERSION) sh commit_and_deploy.sh
+
+ofsinstall: build
+	ostree admin unlock || :
+	$(BUILDER_ARGS) -v /etc:/host/etc \
+	                -v /usr:/host/usr \
+	                $(BUILDER_IMG) sudo make install DESTDIR=/host

--- a/vagrant/checkout.sh
+++ b/vagrant/checkout.sh
@@ -5,7 +5,11 @@ set -euo pipefail
 commit=$(rpm-ostree status --json | \
   python -c '
 import sys, json;
-print json.load(sys.stdin)["deployments"][0]["checksum"]')
+deployments = json.load(sys.stdin)["deployments"]
+for deployment in deployments:
+  if deployment["booted"]:
+    print deployment["checksum"]
+    exit()')
 
 if [[ -z $commit ]] || ! ostree rev-parse $commit; then
   echo "Error while determining current commit" >&2


### PR DESCRIPTION
Mostly minor fixes and improvements.

There are two cooler things I'd like to specifically draw attention to.

1. Strengthening the vmcheck test harness

The vmcheck test harness is now smarter. It automatically resets the VM to the starting state before starting the next test. This means that the test can do some pretty destructive things (within some reasonable limit) without having to completely restore state, which is sometimes cumbersome to do when `errexit` is on.

2. `make vmoverlay`

This new target will install rpm-ostree on an unlocked machine instead of a new deployment to make the hack -> build -> test cycle faster. Another thing that used to take time was the fact that we would autoreconf every time. This was to avoid inheriting artifacts from a checkout which was already configured. By using rsync's `--filter` option to skip all the files that coincidentally git also ignores, we not only skirt around that issue completely, but we also speed up the rsync step.

The overall result is that, the time from changing something in `main.c` to being able to test it out in the VM comes down to about `11s`:

```
$ git diff
diff --git a/src/app/main.c b/src/app/main.c
index 3a8a227..1b77670 100644
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -42,7 +42,7 @@ static RpmOstreeCommand supported_commands[] = {
   { "deploy", rpmostree_builtin_deploy },
   { "rebase", rpmostree_builtin_rebase },
   { "rollback", rpmostree_builtin_rollback },
-  { "status", rpmostree_builtin_status },
+  { "statoos", rpmostree_builtin_status },
   { "upgrade", rpmostree_builtin_upgrade },
   { NULL }
 };
$ time make vmoverlay
...
real    0m11.823s
user    0m3.708s
sys     0m0.481s
$ vagrant ssh -c 'rpm-ostree --help'
Usage:
  rpm-ostree [OPTION...] COMMAND

Builtin Commands:
  compose
  db
  deploy
  rebase
  rollback
  statoos
  upgrade
  pkg-add (preview)
  pkg-remove (preview)
...
```