### PR TITLE
[merged] build: Remove --enable-usrbin-atomic

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -57,10 +57,3 @@ rpm_ostree_LDADD = $(AM_LDFLAGS) $(PKGDEP_RPMOSTREE_LIBS)  librpmostreepriv.la l
 
 privdatadir=$(pkglibdir)
 privdata_DATA = src/app/rpm-ostree-0-integration.conf
-
-if BUILDOPT_USRBINATOMIC
-INSTALL_DATA_HOOKS += install-usrbinatomic-hook
-install-usrbinatomic-hook:
-	ln -sf rpm-ostree $(DESTDIR)$(bindir)/atomic
-	ln -sf rpm-ostree.1.gz $(DESTDIR)$(mandir)/man1/atomic.1.gz
-endif

--- a/configure.ac
+++ b/configure.ac
@@ -97,12 +97,6 @@ AC_ARG_ENABLE(installed_tests,
               [enable_installed_tests=no])
 AM_CONDITIONAL(BUILDOPT_INSTALL_TESTS, test x$enable_installed_tests = xyes)
 
-AC_ARG_ENABLE(usrbinatomic,
-              AS_HELP_STRING([--enable-usrbinatomic],
-                             [Alias client binary as /usr/bin/atomic]),,
-              [enable_usrbinatomic=no])
-AM_CONDITIONAL(BUILDOPT_USRBINATOMIC, [test x$enable_usrbinatomic = xyes])
-
 dnl Some distributions may want to support the client tooling, but not
 dnl the server side.
 AC_ARG_ENABLE(compose-tooling,
@@ -125,7 +119,6 @@ AC_OUTPUT
 echo "
     $PACKAGE $VERSION
 
-    usrbinatomic:	$enable_usrbinatomic
     compose tooling:	$enable_compose_tooling
     gtk-doc:            $enable_gtk_doc
 "


### PR DESCRIPTION
We haven't used this in a long time now that the atomic command
exists.