### PR TITLE
[merged] core: Do not attempt to upgrade (or remove) packages from base

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2081,9 +2081,6 @@ rpmostree_context_assemble_commit (RpmOstreeContext      *self,
 
     package_list = hif_goal_get_packages (hif_context_get_goal (hifctx),
                                           HIF_PACKAGE_INFO_INSTALL,
-                                          HIF_PACKAGE_INFO_REINSTALL,
-                                          HIF_PACKAGE_INFO_DOWNGRADE,
-                                          HIF_PACKAGE_INFO_UPDATE,
                                           -1);
 
     for (i = 0; i < package_list->len; i++)


### PR DESCRIPTION
I was hitting a strange segfault when trying to add a package,
and it ended up being that `krb5-libs` was in the transaction,
but its `rpmteKey()` was `NULL`.

It took me a while to realize that the reason this was happening is
`krb5-libs` was in the base, but there was a newer `krb5-workstation`
package wants a newer version.

We're going to encounter interesting issues with packages that have
hard version locking, where one half of the package is in the base and
the other half is layered.

It works for me to drop out `UPGRADE` etc. from the transaction.  In
this case, what will happen is libsolv seems to silently avoid
upgrading to the newer version of `krb5-workstation`.

In general, we're going to need `pkg-add` to be able to upgrade as
well at the same time, but that's for a later patch.