### PR TITLE
[merged] Add more tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,7 +130,7 @@ dnl arbitrary path - we don't actually install there.
      -DSYSCONF_INSTALL_DIR:PATH=/usr/libexec/rpm-ostree/etc \
      -DSHARE_INSTALL_PREFIX:PATH=/usr/libexec/rpm-ostree/share \
      -DBUILD_SHARED_LIBS:BOOL=ON \
-     ${cmake_args} ../libhif)
+     ${cmake_args} ../libhif) || exit 1
 
 AC_CONFIG_FILES([
 Makefile

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -223,7 +223,7 @@ rpmostreed_deployment_generate_variant (OstreeDeployment *deployment,
     g_variant_dict_insert (&dict, "osname", "s", osname);
   g_variant_dict_insert (&dict, "serial", "i", serial);
   g_variant_dict_insert (&dict, "checksum", "s", csum);
-  if (origin_packages)
+  if (origin_packages != NULL && g_strv_length (origin_packages) > 0)
     {
       const char *parent = ostree_commit_get_parent (commit);
       g_assert (parent);

--- a/src/daemon/rpmostreed-utils.c
+++ b/src/daemon/rpmostreed-utils.c
@@ -191,13 +191,6 @@ rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
         {
           remote = g_strdup (origin_remote);
         }
-      else
-        {
-          g_set_error (error, RPM_OSTREED_ERROR,
-                       RPM_OSTREED_ERROR_INVALID_REFSPEC,
-                       "Could not determine default remote to pull.");
-          goto out;
-        }
     }
 
   if (g_strcmp0 (origin_remote, remote) == 0 &&
@@ -210,7 +203,11 @@ rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
       goto out;
     }
 
-  *out_refspec = g_strconcat (remote, ":", ref, NULL);
+  if (remote == NULL)
+      *out_refspec = g_steal_pointer (&ref);
+  else
+      *out_refspec = g_strconcat (remote, ":", ref, NULL);
+
   ret = TRUE;
 
 out:

--- a/tests/vmcheck/test-layering-relayer.sh
+++ b/tests/vmcheck/test-layering-relayer.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Jonathan Lebon <jlebon@redhat.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# SUMMARY: check that packages get carried over during reployments from
+# upgrades, deploys, and rebases.
+# METHOD:
+#     Add a package, then test that after an upgrade, deploy, or rebase, we
+#     still have the package.
+
+vm_send_test_repo
+
+# make sure the package is not already layered
+vm_assert_layered_pkg foo absent
+
+vm_cmd rpm-ostree pkg-add foo
+echo "ok pkg-add foo"
+
+vm_reboot
+
+vm_assert_layered_pkg foo present
+echo "ok pkg foo added"
+
+reboot_and_assert_base() {
+  vm_reboot
+  basecsum=$(vm_get_booted_deployment_info base-checksum)
+  if [[ $basecsum != $1 ]]; then
+    assert_not_reached "new base-checksum does not refer to expected base $1"
+  fi
+}
+
+# UPGRADE
+
+# let's synthesize an upgrade
+commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck)
+vm_cmd rpm-ostree upgrade
+reboot_and_assert_base $commit
+echo "ok upgrade"
+
+vm_assert_layered_pkg foo present
+echo "ok pkg foo relayered on upgrade"
+
+# DEPLOY
+
+commit=$(vm_cmd ostree commit -b vmcheck \
+           --tree=ref=vmcheck --add-metadata-string=version=my-commit)
+vm_cmd rpm-ostree deploy my-commit
+reboot_and_assert_base $commit
+echo "ok deploy"
+
+vm_assert_layered_pkg foo present
+echo "ok pkg foo relayered on deploy"
+
+# REBASE
+
+commit=$(vm_cmd ostree commit -b rebase_test --tree=ref=vmcheck)
+vm_cmd rpm-ostree rebase rebase_test
+reboot_and_assert_base $commit
+echo "ok rebase"
+
+vm_assert_layered_pkg foo present
+echo "ok pkg foo relayered on rebase"

--- a/tests/vmcheck/test-layering-rpmdb.sh
+++ b/tests/vmcheck/test-layering-rpmdb.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Jonathan Lebon <jlebon@redhat.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# SUMMARY: check that package layering respects rpmdb
+# METHOD:
+#     - test that during a relayer (e.g. upgrade), if a previously layered pkg
+#       is now part of the base layer, then we gently drop the pkg as layered
+#     - test that layering a pkg that's already in the base layer fails
+#     - test that layering a pkg that's already layered fails
+#     - test that layering a new pkg that conflicts with a layered pkg fails
+#     - test that layering a new pkg that conflicts with a base pkg fails
+#     - test that relayering on a base with a conflicting package fails
+
+vm_send_test_repo
+
+# make sure the package is not already layered
+vm_assert_layered_pkg foo absent
+
+vm_cmd rpm-ostree pkg-add foo
+echo "ok pkg-add foo"
+
+vm_reboot
+
+vm_assert_layered_pkg foo present
+echo "ok pkg foo added"
+
+# let's synthesize an upgrade in which the commit we're upgrading to has foo as
+# part of its base, so we recommit our current (non-base) layer to the branch
+csum=$(vm_cmd ostree commit -b vmcheck --tree=ref=$(vm_get_booted_csum))
+
+# check that upgrading to it will elide the layered pkg from the origin
+vm_cmd rpm-ostree upgrade | tee out.txt
+assert_file_has_content out.txt "'foo' .* will no longer be layered"
+echo "ok layered pkg foo elision msg"
+
+vm_reboot
+new_csum=$(vm_get_booted_csum)
+if [[ $new_csum != $csum ]]; then
+  assert_not_reached "new csum does not refer to expected csum $csum"
+fi
+
+if ! vm_has_packages foo; then
+  assert_not_reached "pkg foo is not in rpmdb"
+elif vm_has_layered_packages foo; then
+  assert_not_reached "pkg foo is layered"
+fi
+echo "ok layered pkg foo elision"
+
+if vm_cmd rpm-ostree pkg-add foo; then
+  assert_not_reached "pkg-add foo succeeded even though it's already in rpmdb"
+fi
+echo "ok can't layer pkg already in base"
+
+if vm_cmd rpm-ostree pkg-add bar; then
+  assert_not_reached "pkg-add bar succeeded but it conflicts with foo in base"
+fi
+echo "ok can't layer conflicting pkg in base"
+
+# let's go back to that first depl in which foo is really layered
+vm_cmd rpm-ostree rollback
+vm_reboot
+vm_assert_layered_pkg foo present
+
+if vm_cmd rpm-ostree pkg-add foo; then
+  assert_not_reached "pkg-add foo succeeded even though it's already layered"
+fi
+echo "ok can't layer pkg already layered"
+
+if vm_cmd rpm-ostree pkg-add bar; then
+  assert_not_reached "pkg-add bar succeeded but it conflicts with layered foo"
+fi
+echo "ok can't layer conflicting pkg already layered"
+
+# let's go back to the original depl without anything
+# XXX: this would be simpler if we had an --onto here
+vm_cmd rpm-ostree pkg-remove foo
+vm_reboot
+vm_assert_layered_pkg foo absent
+echo "ok pkg-remove foo"
+
+vm_cmd rpm-ostree pkg-add bar
+vm_reboot
+vm_assert_layered_pkg bar present
+echo "ok pkg-add bar"
+
+# now let's try to do an upgrade -- the latest commit there is still the one we
+# created at the beginning of this test, containing foo in the base
+if vm_cmd rpm-ostree upgrade; then
+  assert_not_reached "upgrade succeeded but new base has conflicting pkg foo"
+fi
+echo "ok can't upgrade with conflicting layered pkg"

--- a/vagrant/Dockerfile.builder
+++ b/vagrant/Dockerfile.builder
@@ -3,7 +3,8 @@ ADD atomic-centos-continuous.repo /etc/yum.repos.d/atomic-centos-continuous.repo
 RUN yum -y install yum-plugin-priorities sudo && \
     yum -y install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ \
       grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux \
-      which xz python gcc gperf 'pkgconfig(libsystemd)' \
+      which xz python gcc gperf 'pkgconfig(libsystemd)' cmake expat-devel python-devel check-devel \
+      python-sphinx createrepo_c \
     && yum-builddep -y rpm-ostree
 LABEL RUN "/usr/bin/docker run --privileged -ti -v /var/roothome:/root -v /etc:/host/etc -v /usr:/host/usr \${IMAGE}"
 WORKDIR /root/sync

--- a/vagrant/commit_and_deploy.sh
+++ b/vagrant/commit_and_deploy.sh
@@ -14,3 +14,4 @@ fi
 
 eval $cmd
 ostree admin deploy vmcheck
+sync


### PR DESCRIPTION
This patch series adds more vmcheck tests for package layering, though the first few commits are for rpm-ostree itself, so that it can support the basic deployment operations on local refs, which is required by the testsuite.