### PR TITLE
[merged] tests: use our self-built libhif library

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -6,6 +6,12 @@ AM_TESTS_ENVIRONMENT = \
 	topsrcdir=$(abs_top_srcdir) \
 	commondir=$(abs_top_srcdir)/tests/common
 
+# we consume libhif as a submodule, but we may not have installed it yet (and we
+# don't want it to fall back to the system libhif if it's also installed)
+AM_TESTS_ENVIRONMENT += \
+	LD_LIBRARY_PATH=$(abs_builddir)/libhif-build/libhif \
+	$(NULL)
+
 CLEANFILES += \
 	tests/common/compose/yum/repo \
 	tests/common/compose/test-repo.repo \


### PR DESCRIPTION
Tests were failing because we were silently falling back to the system libhif, which, as of https://github.com/rpm-software-management/libhif/pull/158, changed a string from non-const to const, which meant we were double free-ing strings.