### PR TITLE
[merged] build: Make bubblewrap path configurable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,6 +96,12 @@ AC_ARG_ENABLE(installed_tests,
               [enable_installed_tests=no])
 AM_CONDITIONAL(BUILDOPT_INSTALL_TESTS, test x$enable_installed_tests = xyes)
 
+AC_ARG_WITH(bubblewrap,
+              AS_HELP_STRING([--with-bubblewrap],
+                             [Path to bubblewrap binary (default: /usr/bin/bwrap)]),,
+              [with_bubblewrap=/usr/bin/bwrap])
+AC_DEFINE_UNQUOTED(WITH_BUBBLEWRAP_PATH, ["$with_bubblewrap"], [Define to bubblewrap path])
+
 dnl Some distributions may want to support the client tooling, but not
 dnl the server side.
 AC_ARG_ENABLE(compose-tooling,
@@ -143,5 +149,6 @@ echo "
     $PACKAGE $VERSION
 
     compose tooling:	$enable_compose_tooling
+    bubblewrap:         $with_bubblewrap
     gtk-doc:            $enable_gtk_doc
 "

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -261,7 +261,7 @@ run_script_in_bwrap_container (int rootfs_fd,
     created_var_tmp = TRUE;
 
   add_const_args (bwrap_argv,
-                  "bwrap",
+                  WITH_BUBBLEWRAP_PATH,
                   "--bind", rofiles_mnt, "/usr",
                   "--dev", "/dev",
                   "--proc", "/proc",


### PR DESCRIPTION
So that it's easier to build bubblewrap as `Source1` in an RPM
embedded (flatpak is using a git submodule, but for this I think
`Source1` is better).