### PR TITLE
[merged] docs: fix ostree and CONTRIBUTING.md links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+docs/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ New! See the docs online at [Read The Docs (rpm-ostree)](https://rpm-ostree.read
 -----
 
 rpm-ostree is a hybrid image/package system.  It uses
-[OSTree](https://wiki.gnome.org/Projects/OSTree) as an image format,
+[OSTree](https://ostree.readthedocs.io/en/latest/) as an image format,
 and uses RPM as a component model.
 
 The project aims to bring together a hybrid of image-like upgrade
@@ -39,5 +39,5 @@ See [Hacking](HACKING.md).
 Contributing
 ------------
 
-See [Contributing](docs/CONTRIBUTING.md).
+See [Contributing](CONTRIBUTING.md).
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,5 +13,5 @@ Use `make check` for now.
 Coding style
 ------------
 
-See the [OSTree CONTRIBUTING](https://git.gnome.org/browse/ostree/tree/docs/CONTRIBUTING.md)
+See the [OSTree CONTRIBUTING](https://ostree.readthedocs.io/en/latest/CONTRIBUTING/)
 coding style.


### PR DESCRIPTION
- Update links to OSTree documentation.
- Fix CONTRIBUTING.md by making symlink in top dir.