### PR TITLE
[merged] Switch to glib cleanup macros

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -56,8 +56,8 @@ CLEANFILES += \
 	tests/common/compose/test-repo-local.repo \
 	$(NULL)
 
-tests_check_jsonutil_CPPFLAGS = -I $(srcdir)/src/libpriv
-tests_check_jsonutil_CFLAGS = $(PKGDEP_RPMOSTREE_CFLAGS)
+tests_check_jsonutil_CPPFLAGS = $(AM_CPPFLAGS) -I $(srcdir)/src/libpriv -I $(srcdir)/libglnx
+tests_check_jsonutil_CFLAGS = $(AM_CFLAGS) $(PKGDEP_RPMOSTREE_CFLAGS)
 tests_check_jsonutil_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la
 
 tests/check/test-compose.sh: tests/common/compose/test-repo.repo

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -224,7 +224,7 @@ main (int    argc,
   int exit_status = EXIT_SUCCESS;
   int in, out;
   const char *command_name = NULL;
-  gs_free char *prgname = NULL;
+  g_autofree char *prgname = NULL;
   GError *local_error = NULL;
 
   /* avoid gvfs (http://bugzilla.gnome.org/show_bug.cgi?id=526454) */
@@ -280,7 +280,7 @@ main (int    argc,
   if (!command)
     {
       GOptionContext *context;
-      gs_free char *help = NULL;
+      g_autofree char *help = NULL;
 
       context = option_context_new_with_commands ();
 

--- a/src/app/rpmostree-builtin-compose.c
+++ b/src/app/rpmostree-builtin-compose.c
@@ -68,7 +68,7 @@ rpmostree_builtin_compose (int argc, char **argv, GCancellable *cancellable, GEr
 {
   RpmOstreeComposeCommand *subcommand;
   const char *subcommand_name = NULL;
-  gs_free char *prgname = NULL;
+  g_autofree char *prgname = NULL;
   int exit_status = EXIT_SUCCESS;
   int in, out;
 
@@ -106,7 +106,7 @@ rpmostree_builtin_compose (int argc, char **argv, GCancellable *cancellable, GEr
   if (!subcommand->name)
     {
       GOptionContext *context;
-      gs_free char *help = NULL;
+      g_autofree char *help = NULL;
 
       context = compose_option_context_new_with_commands ();
 

--- a/src/app/rpmostree-builtin-container.c
+++ b/src/app/rpmostree-builtin-container.c
@@ -65,7 +65,7 @@ rpmostree_builtin_container (int argc, char **argv, GCancellable *cancellable, G
 {
   RpmOstreeContainerCommand *subcommand;
   const char *subcommand_name = NULL;
-  gs_free char *prgname = NULL;
+  g_autofree char *prgname = NULL;
   int exit_status = EXIT_SUCCESS;
   int in, out;
 
@@ -103,7 +103,7 @@ rpmostree_builtin_container (int argc, char **argv, GCancellable *cancellable, G
   if (!subcommand->name)
     {
       GOptionContext *context;
-      gs_free char *help = NULL;
+      g_autofree char *help = NULL;
 
       context = container_option_context_new_with_commands ();
 

--- a/src/app/rpmostree-builtin-db.c
+++ b/src/app/rpmostree-builtin-db.c
@@ -73,7 +73,7 @@ rpmostree_db_option_context_parse (GOptionContext *context,
                                    OstreeRepo **out_repo,
                                    GCancellable *cancellable, GError **error)
 {
-  gs_unref_object OstreeRepo *repo = NULL;
+  glnx_unref_object OstreeRepo *repo = NULL;
   gboolean success = FALSE;
 
   /* Entries are listed in --help output in the order added.  We add the
@@ -92,7 +92,7 @@ rpmostree_db_option_context_parse (GOptionContext *context,
 
   if (opt_repo == NULL)
     {
-      gs_unref_object OstreeSysroot *sysroot = NULL;
+      glnx_unref_object OstreeSysroot *sysroot = NULL;
 
       sysroot = ostree_sysroot_new_default ();
       if (!ostree_sysroot_load (sysroot, cancellable, error))
@@ -103,7 +103,7 @@ rpmostree_db_option_context_parse (GOptionContext *context,
     }
   else
     {
-      gs_unref_object GFile *repo_file = g_file_new_for_path (opt_repo);
+      g_autoptr(GFile) repo_file = g_file_new_for_path (opt_repo);
 
       repo = ostree_repo_new (repo_file);
       if (!ostree_repo_open (repo, cancellable, error))
@@ -129,7 +129,7 @@ rpmostree_builtin_db (int argc, char **argv, GCancellable *cancellable, GError *
 {
   RpmOstreeDbCommand *subcommand;
   const char *subcommand_name = NULL;
-  gs_free char *prgname = NULL;
+  g_autofree char *prgname = NULL;
   int exit_status = EXIT_SUCCESS;
   int in, out;
 
@@ -167,7 +167,7 @@ rpmostree_builtin_db (int argc, char **argv, GCancellable *cancellable, GError *
   if (!subcommand->name)
     {
       GOptionContext *context;
-      gs_free char *help = NULL;
+      g_autofree char *help = NULL;
 
       context = rpm_option_context_new_with_commands ();
 

--- a/src/app/rpmostree-builtin-internals.c
+++ b/src/app/rpmostree-builtin-internals.c
@@ -68,7 +68,7 @@ rpmostree_builtin_internals (int argc, char **argv, GCancellable *cancellable, G
 {
   RpmOstreeInternalsCommand *subcommand;
   const char *subcommand_name = NULL;
-  gs_free char *prgname = NULL;
+  g_autofree char *prgname = NULL;
   int exit_status = EXIT_SUCCESS;
   int in, out;
 
@@ -106,7 +106,7 @@ rpmostree_builtin_internals (int argc, char **argv, GCancellable *cancellable, G
   if (!subcommand->name)
     {
       GOptionContext *context;
-      gs_free char *help = NULL;
+      g_autofree char *help = NULL;
 
       context = internals_option_context_new_with_commands ();
 

--- a/src/app/rpmostree-compose-builtin-sign.c
+++ b/src/app/rpmostree-compose-builtin-sign.c
@@ -27,6 +27,7 @@
 #include "rpmostree-libbuiltin.h"
 
 #include "libgsystem.h"
+#include "libglnx.h"
 
 static char *opt_repo_path;
 static char *opt_key_id;
@@ -47,17 +48,17 @@ rpmostree_compose_builtin_sign (int            argc,
 {
   int exit_status = EXIT_FAILURE;
   GOptionContext *context = g_option_context_new ("- Use rpm-sign to sign an OSTree commit");
-  gs_unref_object GFile *repopath = NULL;
-  gs_unref_object OstreeRepo *repo = NULL;
-  gs_unref_object GFile *tmp_commitdata_file = NULL;
-  gs_unref_object GFileIOStream *tmp_sig_stream = NULL;
-  gs_unref_object GFile *tmp_sig_file = NULL;
-  gs_unref_object GFileIOStream *tmp_commitdata_stream = NULL;
+  g_autoptr(GFile) repopath = NULL;
+  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(GFile) tmp_commitdata_file = NULL;
+  g_autoptr(GFileIOStream) tmp_sig_stream = NULL;
+  g_autoptr(GFile) tmp_sig_file = NULL;
+  g_autoptr(GFileIOStream) tmp_commitdata_stream = NULL;
   GOutputStream *tmp_commitdata_output = NULL;
-  gs_unref_object GInputStream *commit_data = NULL;
-  gs_free char *checksum = NULL;
-  gs_unref_variant GVariant *commit_variant = NULL;
-  gs_unref_bytes GBytes *commit_bytes = NULL;
+  g_autoptr(GInputStream) commit_data = NULL;
+  g_autofree char *checksum = NULL;
+  g_autoptr(GVariant) commit_variant = NULL;
+  g_autoptr(GBytes) commit_bytes = NULL;
   
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
@@ -120,7 +121,7 @@ rpmostree_compose_builtin_sign (int            argc,
   {
     char *sigcontent = NULL;
     gsize len;
-    gs_unref_bytes GBytes *sigbytes = NULL;
+    g_autoptr(GBytes) sigbytes = NULL;
 
     if (!g_file_load_contents (tmp_sig_file, cancellable, &sigcontent, &len, NULL,
                                error))

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -73,7 +73,7 @@ static GOptionEntry option_entries[] = {
 static char *
 checksum_version (GVariant *checksum)
 {
-  gs_unref_variant GVariant *metadata = NULL;
+  g_autoptr(GVariant) metadata = NULL;
   const char *ret = NULL;
 
   metadata = g_variant_get_child_value (checksum, 0);
@@ -106,7 +106,7 @@ compute_checksum_from_treefile_and_goal (RpmOstreeTreeComposeContext   *self,
                                          GError                      **error)
 {
   gboolean ret = FALSE;
-  gs_free char *ret_checksum = NULL;
+  g_autofree char *ret_checksum = NULL;
   GChecksum *checksum = g_checksum_new (G_CHECKSUM_SHA256);
   
   /* Hash in the raw treefile; this means reordering the input packages
@@ -124,10 +124,10 @@ compute_checksum_from_treefile_and_goal (RpmOstreeTreeComposeContext   *self,
       guint i, len = json_array_get_length (add_files);
       for (i = 0; i < len; i++)
         {
-          gs_unref_object GFile *srcfile = NULL;
+          g_autoptr(GFile) srcfile = NULL;
           const char *src, *dest;
           JsonArray *add_el = json_array_get_array_element (add_files, i);
-          gs_unref_object GFile *child = NULL;
+          g_autoptr(GFile) child = NULL;
 
           if (!add_el)
             {
@@ -226,7 +226,7 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
   GFile *contextdir = self->treefile_context_dirs->pdata[0];
   g_autoptr(RpmOstreeInstall) hifinstall = { 0, };
   HifContext *hifctx;
-  gs_free char *ret_new_inputhash = NULL;
+  g_autofree char *ret_new_inputhash = NULL;
   g_autoptr(GKeyFile) treespec = g_key_file_new ();
   JsonArray *enable_repos = NULL;
   JsonArray *add_files = NULL;
@@ -332,8 +332,8 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
   /* Only look for previous checksum if caller has passed *out_unmodified */
   if (self->previous_checksum && out_unmodified != NULL)
     {
-      gs_unref_variant GVariant *commit_v = NULL;
-      gs_unref_variant GVariant *commit_metadata = NULL;
+      g_autoptr(GVariant) commit_v = NULL;
+      g_autoptr(GVariant) commit_metadata = NULL;
       const char *previous_inputhash = NULL;
       
       if (!ostree_repo_load_variant (self->repo, OSTREE_OBJECT_TYPE_COMMIT,
@@ -366,7 +366,7 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
     goto out;
   
   { g_auto(GLnxConsoleRef) console = { 0, };
-    gs_unref_object HifState *hifstate = hif_state_new ();
+    glnx_unref_object HifState *hifstate = hif_state_new ();
 
     progress_sigid = g_signal_connect (hifstate, "percentage-changed",
                                      G_CALLBACK (on_hifstate_percentage_changed), 
@@ -411,7 +411,7 @@ process_includes (RpmOstreeTreeComposeContext  *self,
     }
 
   {
-    gs_unref_object GFile *parent = g_file_get_parent (treefile_path);
+    g_autoptr(GFile) parent = g_file_get_parent (treefile_path);
     gboolean existed = FALSE;
     if (self->treefile_context_dirs->len > 0)
       {
@@ -431,9 +431,9 @@ process_includes (RpmOstreeTreeComposeContext  *self,
                                           
   if (include_path)
     {
-      gs_unref_object GFile *treefile_dirpath = g_file_get_parent (treefile_path);
-      gs_unref_object GFile *parent_path = g_file_resolve_relative_path (treefile_dirpath, include_path);
-      gs_unref_object JsonParser *parent_parser = json_parser_new ();
+      g_autoptr(GFile) treefile_dirpath = g_file_get_parent (treefile_path);
+      g_autoptr(GFile) parent_path = g_file_resolve_relative_path (treefile_dirpath, include_path);
+      glnx_unref_object JsonParser *parent_parser = json_parser_new ();
       JsonNode *parent_rootval;
       JsonObject *parent_root;
       GList *members;
@@ -520,7 +520,7 @@ parse_keyvalue_strings (char             **strings,
     {
       const char *s;
       const char *eq;
-      gs_free char *key = NULL;
+      g_autofree char *key = NULL;
 
       s = *iter;
 
@@ -573,19 +573,19 @@ rpmostree_compose_builtin_tree (int             argc,
   RpmOstreeTreeComposeContext *self = &selfdata;
   JsonNode *treefile_rootval = NULL;
   JsonObject *treefile = NULL;
-  gs_free char *cachekey = NULL;
-  gs_free char *new_inputhash = NULL;
-  gs_unref_object GFile *previous_root = NULL;
-  gs_free char *previous_checksum = NULL;
-  gs_unref_object GFile *yumroot = NULL;
-  gs_unref_object GFile *yumroot_varcache = NULL;
-  gs_unref_object OstreeRepo *repo = NULL;
-  gs_unref_ptrarray GPtrArray *bootstrap_packages = NULL;
-  gs_unref_ptrarray GPtrArray *packages = NULL;
-  gs_unref_object GFile *treefile_path = NULL;
-  gs_unref_object GFile *treefile_dirpath = NULL;
-  gs_unref_object GFile *repo_path = NULL;
-  gs_unref_object JsonParser *treefile_parser = NULL;
+  g_autofree char *cachekey = NULL;
+  g_autofree char *new_inputhash = NULL;
+  g_autoptr(GFile) previous_root = NULL;
+  g_autofree char *previous_checksum = NULL;
+  g_autoptr(GFile) yumroot = NULL;
+  g_autoptr(GFile) yumroot_varcache = NULL;
+  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(GPtrArray) bootstrap_packages = NULL;
+  g_autoptr(GPtrArray) packages = NULL;
+  g_autoptr(GFile) treefile_path = NULL;
+  g_autoptr(GFile) treefile_dirpath = NULL;
+  g_autoptr(GFile) repo_path = NULL;
+  glnx_unref_object JsonParser *treefile_parser = NULL;
   gs_unref_variant_builder GVariantBuilder *metadata_builder = 
     g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
   g_autoptr(RpmOstreeContext) corectx = NULL;
@@ -635,7 +635,7 @@ rpmostree_compose_builtin_tree (int             argc,
     }
   else
     {
-      gs_free char *tmpd = NULL;
+      g_autofree char *tmpd = NULL;
 
       if (!rpmostree_mkdtemp ("/var/tmp/rpm-ostree.XXXXXX", &tmpd, NULL, error))
         goto out;
@@ -716,8 +716,8 @@ rpmostree_compose_builtin_tree (int             argc,
 
   if (opt_print_only)
     {
-      gs_unref_object JsonGenerator *generator = json_generator_new ();
-      gs_unref_object GOutputStream *stdout = g_unix_output_stream_new (1, FALSE);
+      glnx_unref_object JsonGenerator *generator = json_generator_new ();
+      g_autoptr(GOutputStream) stdout = g_unix_output_stream_new (1, FALSE);
 
       json_generator_set_pretty (generator, TRUE);
       json_generator_set_root (generator, treefile_rootval);
@@ -761,9 +761,9 @@ rpmostree_compose_builtin_tree (int             argc,
   if (json_object_has_member (treefile, "automatic_version_prefix") &&
       !compose_strv_contains_prefix (opt_metadata_strings, "version="))
     {
-      gs_unref_variant GVariant *variant = NULL;
-      gs_free char *last_version = NULL;
-      gs_free char *next_version = NULL;
+      g_autoptr(GVariant) variant = NULL;
+      g_autofree char *last_version = NULL;
+      g_autofree char *next_version = NULL;
       const char *ver_prefix;
 
       ver_prefix = _rpmostree_jsonutil_object_require_string_member (treefile,
@@ -798,7 +798,7 @@ rpmostree_compose_builtin_tree (int             argc,
     goto out;
   g_ptr_array_add (packages, NULL);
 
-  { gs_unref_object JsonGenerator *generator = json_generator_new ();
+  { glnx_unref_object JsonGenerator *generator = json_generator_new ();
     char *treefile_buf = NULL;
     gsize len;
 
@@ -880,7 +880,7 @@ rpmostree_compose_builtin_tree (int             argc,
   {
     const char *gpgkey;
     gboolean selinux = TRUE;
-    gs_unref_variant GVariant *metadata = NULL;
+    g_autoptr(GVariant) metadata = NULL;
 
     g_variant_builder_add (metadata_builder, "{sv}",
                            "rpmostree.inputhash",

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -36,7 +36,7 @@ rpmostree_db_builtin_diff (int argc, char **argv, GCancellable *cancellable, GEr
 {
   int exit_status = EXIT_FAILURE;
   GOptionContext *context;
-  gs_unref_object OstreeRepo *repo = NULL;
+  glnx_unref_object OstreeRepo *repo = NULL;
   struct RpmRevisionData *rpmrev1 = NULL;
   struct RpmRevisionData *rpmrev2 = NULL;
 

--- a/src/app/rpmostree-db-builtin-list.c
+++ b/src/app/rpmostree-db-builtin-list.c
@@ -44,8 +44,8 @@ _builtin_db_list (OstreeRepo *repo,
 
       if (mrev)
         {
-          gs_unref_ptrarray GPtrArray *range_revs = NULL;
-          gs_free char *revdup = g_strdup (rev);
+          g_autoptr(GPtrArray) range_revs = NULL;
+          g_autofree char *revdup = g_strdup (rev);
 
           mrev = revdup + (mrev - rev);
           *mrev = 0;
@@ -89,9 +89,9 @@ rpmostree_db_builtin_list (int argc, char **argv, GCancellable *cancellable, GEr
 {
   int exit_status = EXIT_FAILURE;
   GOptionContext *context;
-  gs_unref_object OstreeRepo *repo = NULL;
-  gs_unref_ptrarray GPtrArray *patterns = NULL;
-  gs_unref_ptrarray GPtrArray *revs = NULL;
+  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(GPtrArray) patterns = NULL;
+  g_autoptr(GPtrArray) revs = NULL;
   int ii;
 
   context = g_option_context_new ("[PREFIX-PKGNAME...] COMMIT... - List packages within commits");
@@ -112,7 +112,7 @@ rpmostree_db_builtin_list (int argc, char **argv, GCancellable *cancellable, GEr
         g_ptr_array_add (patterns, argv[ii]);
       else
         {
-          gs_free char *commit = NULL;
+          g_autofree char *commit = NULL;
 
           ostree_repo_resolve_rev (repo, argv[ii], TRUE, &commit, NULL);
 

--- a/src/app/rpmostree-db-builtin-version.c
+++ b/src/app/rpmostree-db-builtin-version.c
@@ -39,13 +39,13 @@ _builtin_db_version (OstreeRepo *repo, GPtrArray *revs,
     {
       char *rev = revs->pdata[num];
       _cleanup_rpmrev_ struct RpmRevisionData *rpmrev = NULL;
-      gs_free char *rpmdbv = NULL;
+      g_autofree char *rpmdbv = NULL;
       char *mrev = strstr (rev, "..");
 
       if (mrev)
         {
-          gs_unref_ptrarray GPtrArray *range_revs = NULL;
-          gs_free char *revdup = g_strdup (rev);
+          g_autoptr(GPtrArray) range_revs = NULL;
+          g_autofree char *revdup = g_strdup (rev);
 
           mrev = revdup + (mrev - rev);
           *mrev = 0;
@@ -94,8 +94,8 @@ rpmostree_db_builtin_version (int argc, char **argv, GCancellable *cancellable, 
 {
   int exit_status = EXIT_FAILURE;
   GOptionContext *context;
-  gs_unref_object OstreeRepo *repo = NULL;
-  gs_unref_ptrarray GPtrArray *revs = NULL;
+  glnx_unref_object OstreeRepo *repo = NULL;
+  g_autoptr(GPtrArray) revs = NULL;
   gint ii;
 
   context = g_option_context_new ("COMMIT... - Show rpmdb version of packages within the commits");

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -258,10 +258,10 @@ on_log_handler (const gchar *log_domain,
 static gboolean
 connect_to_peer (int fd)
 {
-  gs_unref_object GSocketConnection *stream = NULL;
-  gs_unref_object GSocket *socket = NULL;
+  g_autoptr(GSocketConnection) stream = NULL;
+  g_autoptr(GSocket) socket = NULL;
   GError *error = NULL;
-  gs_free gchar *guid = NULL;
+  g_autofree gchar *guid = NULL;
   gboolean ret = FALSE;
 
   socket = g_socket_new_from_fd (fd, &error);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -663,7 +663,7 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
 {
   gboolean ret = FALSE;
   guint progress_sigid;
-  gs_unref_object HifState *hifstate = hif_state_new ();
+  glnx_unref_object HifState *hifstate = hif_state_new ();
 
   progress_sigid = g_signal_connect (hifstate, "percentage-changed",
                                      G_CALLBACK (on_hifstate_percentage_changed),
@@ -1123,7 +1123,7 @@ rpmostree_context_download (RpmOstreeContext *ctx,
         g_autofree char *target_dir = NULL;
         HifRepo *src = key;
         GPtrArray *src_packages = value;
-        gs_unref_object HifState *hifstate = hif_state_new ();
+        glnx_unref_object HifState *hifstate = hif_state_new ();
 
         g_autofree char *prefix
           = g_strdup_printf ("  Downloading from %s:", hif_repo_get_id (src));
@@ -1845,7 +1845,7 @@ run_posttrans_sync (int tmp_metadata_dfd,
 static char *
 checksum_version (GVariant *checksum)
 {
-  gs_unref_variant GVariant *metadata = NULL;
+  g_autoptr(GVariant) metadata = NULL;
   const char *ret = NULL;
 
   metadata = g_variant_get_child_value (checksum, 0);

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -120,7 +120,7 @@ pkg_nvr_strdup (Header h1)
 static void
 pkg_print (Header pkg)
 {
-  gs_free char *nevra = pkg_nevra_strdup (pkg);
+  g_autofree char *nevra = pkg_nevra_strdup (pkg);
   printf("%s\n", nevra);
 }
 
@@ -172,9 +172,9 @@ pat_fnmatch_match (Header pkg, const char *name,
                    gsize patprefixlen, const GPtrArray *patterns)
 {
   int num = 0;
-  gs_free char *pkg_na    = NULL;
-  gs_free char *pkg_nevra = NULL;
-  gs_free char *pkg_nvr   = NULL;
+  g_autofree char *pkg_na    = NULL;
+  g_autofree char *pkg_nevra = NULL;
+  g_autofree char *pkg_nvr   = NULL;
 
   if (!patterns)
     return TRUE;
@@ -368,14 +368,14 @@ rpmhdrs_rpmdbv (struct RpmHeaders *l1,
                 GError        **error)
 {
   GChecksum *checksum = g_checksum_new (G_CHECKSUM_SHA1);
-  gs_free char *checksum_cstr = NULL;
+  g_autofree char *checksum_cstr = NULL;
   char *ret = NULL;
   int num = 0;
 
   while (num < l1->hs->len)
     {
       Header pkg = l1->hs->pdata[num++];
-      gs_free char *envra = pkg_envra_strdup (pkg);
+      g_autofree char *envra = pkg_envra_strdup (pkg);
 
       g_checksum_update (checksum, (guint8*)envra, strlen(envra));
     }
@@ -509,7 +509,7 @@ rpmhdrs_diff_prnt_block (struct RpmHeadersDiff *diff)
           while (ncnum > 0)
             {
               GDateTime *dt = NULL;
-              gs_free char *date_time_str = NULL;
+              g_autofree char *date_time_str = NULL;
 
               /* Load next new %changelog entry, starting at the newest. */
               rpmtdNext (nchanges_date);

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -47,7 +47,7 @@ _rpmostree_set_prefix_error_from_errno (GError     **error,
                                         const char  *format,
                                         ...)
 {
-  gs_free char *formatted = NULL;
+  g_autofree char *formatted = NULL;
   va_list args;
   
   va_start (args, format);
@@ -195,7 +195,7 @@ _rpmostree_util_enumerate_directory_allow_noent (GFile               *dirpath,
 {
   gboolean ret = FALSE;
   GError *temp_error = NULL;
-  gs_unref_object GFileEnumerator *ret_direnum = NULL;
+  g_autoptr(GFileEnumerator) ret_direnum = NULL;
 
   ret_direnum = g_file_enumerate_children (dirpath, queryargs, queryflags,
                                            cancellable, &temp_error);
@@ -226,7 +226,7 @@ _rpmostree_file_load_contents_utf8_allow_noent (GFile          *path,
 {
   gboolean ret = FALSE;
   GError *temp_error = NULL;
-  gs_free char *ret_contents = NULL;
+  g_autofree char *ret_contents = NULL;
 
   ret_contents = gs_file_load_contents_utf8 (path, cancellable, &temp_error);
   if (!ret_contents)
@@ -257,7 +257,7 @@ _rpmostree_util_update_checksum_from_file (GChecksum    *checksum,
   gboolean ret = FALSE;
   gsize bytes_read;
   char buf[4096];
-  gs_unref_object GInputStream *filein = NULL;
+  g_autoptr(GInputStream) filein = NULL;
 
   filein = (GInputStream*)g_file_read (src, cancellable, error);
   if (!filein)
@@ -282,8 +282,8 @@ static char *
 ost_get_prev_commit (OstreeRepo *repo, char *checksum)
 {
   char *ret = NULL;
-  gs_unref_variant GVariant *commit = NULL;
-  gs_unref_variant GVariant *parent_csum_v = NULL;
+  g_autoptr(GVariant) commit = NULL;
+  g_autoptr(GVariant) parent_csum_v = NULL;
   GError *tmp_error = NULL;
 
   if (!ostree_repo_load_variant (repo, OSTREE_OBJECT_TYPE_COMMIT, checksum,
@@ -306,9 +306,9 @@ _rpmostree_util_get_commit_hashes (OstreeRepo    *repo,
                                    GError       **error)
 {
   GPtrArray *ret = NULL;
-  gs_free char *beg_checksum = NULL;
-  gs_free char *end_checksum = NULL;
-  gs_free char *parent = NULL;
+  g_autofree char *beg_checksum = NULL;
+  g_autofree char *end_checksum = NULL;
+  g_autofree char *parent = NULL;
   char *checksum = NULL;
   gboolean worked = FALSE;
 
@@ -411,7 +411,7 @@ _rpmostree_util_keyfile_clone (GKeyFile *keyfile)
 {
   GKeyFile *ret = g_key_file_new ();
   gsize len;
-  gs_free char *data = g_key_file_to_data (keyfile, &len, NULL);
+  g_autofree char *data = g_key_file_to_data (keyfile, &len, NULL);
   gboolean loaded;
 
   loaded = g_key_file_load_from_data (ret, data, len, 0, NULL);

--- a/tests/check/jsonutil.c
+++ b/tests/check/jsonutil.c
@@ -1,9 +1,11 @@
+#include "config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <glib-unix.h>
-#include <libgsystem.h>
+#include "libglnx.h"
 #include "rpmostree-json-parsing.h"
 #include "rpmostree-util.h"
 

--- a/tests/check/jsonutil.c
+++ b/tests/check/jsonutil.c
@@ -14,7 +14,7 @@ static JsonObject *
 get_test_data (void)
 {
   GError *error = NULL;
-  gs_unref_object JsonParser *parser = json_parser_new ();
+  glnx_unref_object JsonParser *parser = json_parser_new ();
   (void)json_parser_load_from_data (parser, test_data, -1, &error);
   g_assert_no_error (error);
   return json_object_ref (json_node_get_object (json_parser_get_root (parser)));


### PR DESCRIPTION
We don't have a lot of outstanding changes to the C code, so now seems
like a good time to do this.  I implemented this with some highly
sophisticated sed commands like:

```
find -name '*.c' | while read name; do sed -i -e 's,gs_unref_object \([A-Za-z]*\) \*,g_autoptr(\1),' ${name}; done
```

Part of dropping the dependency on libgsystem, same as what we're
doing in ostree.