### PR TITLE
[merged] upgrade: Print changed packages again

### DIFF
--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -129,13 +129,13 @@ rpmostree_builtin_upgrade (int             argc,
         goto out;
     }
 
-  new_default_deployment = rpmostree_os_dup_default_deployment (os_proxy);
-
   if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
                                                 transaction_address,
                                                 cancellable,
                                                 error))
     goto out;
+
+  new_default_deployment = rpmostree_os_dup_default_deployment (os_proxy);
 
   if (opt_preview || opt_check)
     {
@@ -169,7 +169,7 @@ rpmostree_builtin_upgrade (int             argc,
       if (previous_default_deployment == new_default_deployment)
         changed = FALSE;
       else
-        changed = g_variant_equal (previous_default_deployment, new_default_deployment); 
+        changed = !g_variant_equal (previous_default_deployment, new_default_deployment);
 
       if (!changed)
         {


### PR DESCRIPTION
First I noticed we needed to query the new default *after* the
transaction had run.  Then, I noticed the obvious embarassing logic
error.

Fixes: 3f1e7c85a18182669899f4065d23fec6ac0962c
Closes: #396