### PR TITLE
[merged] pkg-layering: print transaction on dry run

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1131,10 +1131,9 @@ overlay_final_pkgset (RpmOstreeSysrootUpgrader *self,
   if (!rpmostree_context_prepare_install (ctx, &install, cancellable, error))
     goto out;
 
-  /* we just printed the transaction in prepare_install() -- leave here if it's
-   * a dry run */
   if (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_DRY_RUN)
     {
+      rpmostree_print_transaction (rpmostree_context_get_hif (ctx));
       ret = TRUE;
       goto out;
     }


### PR DESCRIPTION
Commit d153ece removes redundant transaction printing, but we do still
want to print it manually when we're doing a dry run.