### PR TITLE
[merged] Port to new ostree_repo_checkout_at()

### DIFF
--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -330,13 +330,8 @@ rpmostree_container_builtin_assemble (int             argc,
 
   g_print ("Checking out %s @ %s...\n", name, commit);
 
-  { OstreeRepoCheckoutOptions opts = { OSTREE_REPO_CHECKOUT_MODE_USER,
-                                       OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES, };
-
-    /* For now... to be crash safe we'd need to duplicate some of the
-     * boot-uuid/fsync gating at a higher level.
-     */
-    opts.disable_fsync = TRUE;
+  { OstreeRepoCheckoutAtOptions opts = { OSTREE_REPO_CHECKOUT_MODE_USER,
+                                         OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES, };
 
     /* Also, what we really want here is some sort of sane lifecycle
      * management with whatever is running in the root.
@@ -344,8 +339,8 @@ rpmostree_container_builtin_assemble (int             argc,
     if (!glnx_shutil_rm_rf_at (rocctx->roots_dfd, target_rootdir, cancellable, error))
       goto out;
 
-    if (!ostree_repo_checkout_tree_at (rocctx->repo, &opts, rocctx->roots_dfd, target_rootdir,
-                                       commit, cancellable, error))
+    if (!ostree_repo_checkout_at (rocctx->repo, &opts, rocctx->roots_dfd, target_rootdir,
+                                  commit, cancellable, error))
       goto out;
   }
 
@@ -549,16 +544,11 @@ rpmostree_container_builtin_upgrade (int argc, char **argv, GCancellable *cancel
 
   g_print ("Checking out %s @ %s...\n", name, new_commit_checksum);
 
-  { OstreeRepoCheckoutOptions opts = { OSTREE_REPO_CHECKOUT_MODE_USER,
-                                       OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES, };
+  { OstreeRepoCheckoutAtOptions opts = { OSTREE_REPO_CHECKOUT_MODE_USER,
+                                         OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES, };
 
-    /* For now... to be crash safe we'd need to duplicate some of the
-     * boot-uuid/fsync gating at a higher level.
-     */
-    opts.disable_fsync = TRUE;
-
-    if (!ostree_repo_checkout_tree_at (rocctx->repo, &opts, rocctx->roots_dfd, target_new_root,
-                                       new_commit_checksum, cancellable, error))
+    if (!ostree_repo_checkout_at (rocctx->repo, &opts, rocctx->roots_dfd, target_new_root,
+                                  new_commit_checksum, cancellable, error))
       goto out;
   }
 

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -761,18 +761,17 @@ checkout_min_tree_in_tmp (OstreeRepo            *repo,
   /* also check out sepolicy so that prepare_install() will be able to sort the
    * packages correctly */
   {
-    OstreeRepoCheckoutOptions opts = {0,};
+    OstreeRepoCheckoutAtOptions opts = {0,};
 
     if (!glnx_shutil_mkdir_p_at (tmprootfs_dfd, "usr/etc", 0777,
                                  cancellable, error))
       goto out;
 
     opts.subpath = "usr/etc/selinux";
-    opts.disable_fsync = TRUE;
 
-    if (!ostree_repo_checkout_tree_at (repo, &opts, tmprootfs_dfd,
-                                       "usr/etc/selinux", revision,
-                                       cancellable, error))
+    if (!ostree_repo_checkout_at (repo, &opts, tmprootfs_dfd,
+                                  "usr/etc/selinux", revision,
+                                  cancellable, error))
       goto out;
   }
 
@@ -799,7 +798,7 @@ checkout_tree_in_tmp (OstreeRepo            *repo,
                       GError               **error)
 {
   gboolean ret = FALSE;
-  OstreeRepoCheckoutOptions checkout_options = { 0, };
+  OstreeRepoCheckoutAtOptions checkout_options = { 0, };
 
   g_autofree char *tmprootfs = g_strdup ("tmp/rpmostree-commit-XXXXXX");
   glnx_fd_close int tmprootfs_dfd = -1;
@@ -816,11 +815,10 @@ checkout_tree_in_tmp (OstreeRepo            *repo,
   rpmostree_output_task_begin ("Checking out tree %.7s", revision);
 
   /* we actually only need this here because we use "." for path */
-  checkout_options.disable_fsync = TRUE;
   checkout_options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES;
   checkout_options.devino_to_csum_cache = devino_cache;
-  if (!ostree_repo_checkout_tree_at (repo, &checkout_options, tmprootfs_dfd,
-                                     ".", revision, cancellable, error))
+  if (!ostree_repo_checkout_at (repo, &checkout_options, tmprootfs_dfd,
+                                ".", revision, cancellable, error))
     goto out;
 
   rpmostree_output_task_end ("done");

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1266,8 +1266,8 @@ ostree_checkout_package (OstreeRepo   *repo,
                          GError      **error)
 {
   gboolean ret = FALSE;
-  OstreeRepoCheckoutOptions opts = { OSTREE_REPO_CHECKOUT_MODE_USER,
-                                     OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES, };
+  OstreeRepoCheckoutAtOptions opts = { OSTREE_REPO_CHECKOUT_MODE_USER,
+                                       OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES, };
 
   /* We want the checkout to match the repo type so that we get hardlinks. */
   if (ostree_repo_get_mode (repo) == OSTREE_REPO_MODE_BARE)
@@ -1275,15 +1275,11 @@ ostree_checkout_package (OstreeRepo   *repo,
 
   opts.devino_to_csum_cache = devino_cache;
 
-  /* For now... to be crash safe we'd need to duplicate some of the
-   * boot-uuid/fsync gating at a higher level.
-   */
-  opts.disable_fsync = TRUE;
   /* Always want hardlinks */
   opts.no_copy_fallback = TRUE;
 
-  if (!ostree_repo_checkout_tree_at (repo, &opts, dfd, path,
-                                     pkg_commit, cancellable, error))
+  if (!ostree_repo_checkout_at (repo, &opts, dfd, path,
+                                pkg_commit, cancellable, error))
     goto out;
 
   ret = TRUE;

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -712,7 +712,7 @@ rpmostree_checkout_only_rpmdb_tempdir (OstreeRepo       *repo,
   gboolean ret = FALSE;
   g_autofree char *commit = NULL;
   g_autofree char *tempdir = NULL;
-  OstreeRepoCheckoutOptions checkout_options = { 0, };
+  OstreeRepoCheckoutAtOptions checkout_options = { 0, };
   glnx_fd_close int tempdir_dfd = -1;
 
   g_return_val_if_fail (out_tempdir != NULL, FALSE);
@@ -730,10 +730,10 @@ rpmostree_checkout_only_rpmdb_tempdir (OstreeRepo       *repo,
   checkout_options.mode = OSTREE_REPO_CHECKOUT_MODE_USER;
   checkout_options.subpath = "usr/share/rpm";
 
-  if (!ostree_repo_checkout_tree_at (repo, &checkout_options,
-                                     tempdir_dfd, "usr/share/rpm",
-                                     commit, 
-                                     cancellable, error))
+  if (!ostree_repo_checkout_at (repo, &checkout_options,
+                                tempdir_dfd, "usr/share/rpm",
+                                commit, 
+                                cancellable, error))
     goto out;
 
   /* And make a compat symlink to keep rpm happy */ 


### PR DESCRIPTION
Squashes some deprecation warnings, and now with the latest master we
can stop setting `disable_fsync`.