### PR TITLE
[merged] gitmodules: Update for rename

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libglnx"]
 	path = libglnx
 	url = https://git.gnome.org/browse/libglnx
-[submodule "libhif"]
+[submodule "libdnf"]
 	path = libdnf
 	url = https://github.com/rpm-software-management/libhif


### PR DESCRIPTION
rpmdistro-gitoverlay doesn't like when the submodule name differs
from its path, so let's make it happy.