### PR TITLE
[merged] libglnx porting: Switch to glnx_file_get_contents_utf8_at()

### DIFF
--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -410,6 +410,9 @@ rpmostree_check_passwd_groups (gboolean         passwd,
             goto out;
           
           old_path = g_file_resolve_relative_path (root, commit_filepath);
+          /* Note this one can't be ported to glnx_file_get_contents_utf8_at() because
+           * we're loading from ostree via `OstreeRepoFile`.
+           */
           if (!g_file_load_contents (old_path, cancellable, &old_contents, NULL, NULL, error))
             goto out;
         }

--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -29,6 +29,7 @@
 #include <pwd.h>
 #include <grp.h>
 
+#include "libglnx.h"
 #include "rpmostree-util.h"
 #include "rpmostree-json-parsing.h"
 #include "rpmostree-passwd-util.h"
@@ -409,6 +410,8 @@ rpmostree_check_passwd_groups (gboolean         passwd,
             goto out;
           
           old_path = g_file_resolve_relative_path (root, commit_filepath);
+          if (!g_file_load_contents (old_path, cancellable, &old_contents, NULL, NULL, error))
+            goto out;
         }
       else
         {
@@ -417,17 +420,17 @@ rpmostree_check_passwd_groups (gboolean         passwd,
           goto out;
         }
     }
-
-  if (g_str_equal (chk_type, "file"))
+  else if (g_str_equal (chk_type, "file"))
     {
       old_path = g_file_resolve_relative_path (treefile_dirpath, direct);
+      old_contents = glnx_file_get_contents_utf8_at (AT_FDCWD, gs_file_get_path_cached (old_path), NULL,
+                                                     cancellable, error);
+      if (!old_contents)
+        goto out;
     }
 
   if (g_str_equal (chk_type, "previous") || g_str_equal (chk_type, "file"))
     {
-      old_contents = gs_file_load_contents_utf8 (old_path, cancellable, error);
-      if (!old_contents)
-        goto out;
       if (passwd)
         old_ents = data2passwdents (old_contents);
       else
@@ -440,7 +443,8 @@ rpmostree_check_passwd_groups (gboolean         passwd,
   else
     g_ptr_array_sort (old_ents, compare_group_ents);
 
-  new_contents = gs_file_load_contents_utf8 (new_path, cancellable, error);
+  new_contents = glnx_file_get_contents_utf8_at (AT_FDCWD, gs_file_get_path_cached (new_path), NULL,
+                                                 cancellable, error);
   if (!new_contents)
       goto out;
 

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -770,7 +770,8 @@ replace_nsswitch (GFile         *target_usretc,
       g_once_init_leave (&regex_initialized, 1);
     }
 
-  nsswitch_contents = gs_file_load_contents_utf8 (nsswitch_conf, cancellable, error);
+  nsswitch_contents = glnx_file_get_contents_utf8_at (AT_FDCWD, gs_file_get_path_cached (nsswitch_conf), NULL,
+                                                      cancellable, error);
   if (!nsswitch_contents)
     goto out;
 

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -228,7 +228,8 @@ _rpmostree_file_load_contents_utf8_allow_noent (GFile          *path,
   GError *temp_error = NULL;
   g_autofree char *ret_contents = NULL;
 
-  ret_contents = gs_file_load_contents_utf8 (path, cancellable, &temp_error);
+  ret_contents = glnx_file_get_contents_utf8_at (AT_FDCWD, gs_file_get_path_cached (path), NULL,
+                                                 cancellable, &temp_error);
   if (!ret_contents)
     {
       if (g_error_matches (temp_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))


### PR DESCRIPTION
A small one, but a start.