### PR TITLE
[merged] Layer prein

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -34,6 +34,7 @@
 #include "rpmostree-core.h"
 #include "rpmostree-postprocess.h"
 #include "rpmostree-rpm-util.h"
+#include "rpmostree-passwd-util.h"
 #include "rpmostree-scripts.h"
 #include "rpmostree-unpacker.h"
 #include "rpmostree-output.h"
@@ -2044,6 +2045,8 @@ rpmostree_context_assemble_commit (RpmOstreeContext      *self,
 
   if (!noscripts)
     {
+      if (!rpmostree_passwd_prepare_rpm_layering (tmprootfs_dfd, cancellable, error))
+        goto out;
       for (i = 0; i < n_rpmts_elements; i++)
         {
           rpmte te = rpmtsElement (ordering_ts, i);
@@ -2056,6 +2059,8 @@ rpmostree_context_assemble_commit (RpmOstreeContext      *self,
                                    cancellable, error))
             goto out;
         }
+      if (!rpmostree_passwd_complete_rpm_layering (tmprootfs_dfd, error))
+        goto out;
     }
 
   g_clear_pointer (&ordering_ts, rpmtsFree);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2045,8 +2045,12 @@ rpmostree_context_assemble_commit (RpmOstreeContext      *self,
 
   if (!noscripts)
     {
-      if (!rpmostree_passwd_prepare_rpm_layering (tmprootfs_dfd, cancellable, error))
+      gboolean have_passwd;
+
+      if (!rpmostree_passwd_prepare_rpm_layering (tmprootfs_dfd, &have_passwd,
+                                                  cancellable, error))
         goto out;
+
       for (i = 0; i < n_rpmts_elements; i++)
         {
           rpmte te = rpmtsElement (ordering_ts, i);
@@ -2059,8 +2063,12 @@ rpmostree_context_assemble_commit (RpmOstreeContext      *self,
                                    cancellable, error))
             goto out;
         }
-      if (!rpmostree_passwd_complete_rpm_layering (tmprootfs_dfd, error))
-        goto out;
+
+      if (have_passwd)
+        {
+          if (!rpmostree_passwd_complete_rpm_layering (tmprootfs_dfd, error))
+            goto out;
+        }
     }
 
   g_clear_pointer (&ordering_ts, rpmtsFree);

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -62,3 +62,12 @@ rpmostree_generate_passwd_from_previous (OstreeRepo      *repo,
                                          JsonObject      *treedata,
                                          GCancellable    *cancellable,
                                          GError         **error);
+
+gboolean
+rpmostree_passwd_prepare_rpm_layering (int       rootfs_dfd,
+                                       GCancellable      *cancellable,
+                                       GError  **error);
+
+gboolean
+rpmostree_passwd_complete_rpm_layering (int       rootfs_dfd,
+                                        GError  **error);

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -65,6 +65,7 @@ rpmostree_generate_passwd_from_previous (OstreeRepo      *repo,
 
 gboolean
 rpmostree_passwd_prepare_rpm_layering (int       rootfs_dfd,
+                                       gboolean          *out_have_passwd,
                                        GCancellable      *cancellable,
                                        GError  **error);
 


### PR DESCRIPTION
This series gets us the ability to layer `kubernetes-node`, `etcd`, `flannel` etc.

An interesting case that's not covered:

```
# rpm-ostree pkg-add httpd
...
error: Unpacking httpd-2.4.6-40.el7.centos.4.x86_64: Non-root ownership currently unsupported: path "/usr/sbin/suexec" marked as root:apache)
```

For that, see https://bugzilla.gnome.org/show_bug.cgi?id=722984