### PR TITLE
[merged] mutate-os-release: skip VERSION_ID

### DIFF
--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1380,8 +1380,9 @@ mutate_os_release (const char    *contents,
       if (strlen (line) == 0)
         continue;
 
+      /* NB: we don't mutate VERSION_ID because some libraries expect well-known
+       * values there*/
       if (g_str_has_prefix (line, "VERSION=") || \
-          g_str_has_prefix (line, "VERSION_ID=") || \
           g_str_has_prefix (line, "PRETTY_NAME="))
         {
           g_autofree char *new_line = NULL;


### PR DESCRIPTION
I hit this with librepo subbing out the $releasever with e.g. 7.2016.1
when trying to pull various URLs. It should be enough for the user to
see the ostree version in VERSION and PRETTY_NAME. For applications,
there's OSTREE_VERSION if they need just that.