### PR TITLE
[merged] vmcheck: add a test for RPM scripts

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -25,6 +25,7 @@ testpackages = \
 	tests/common/compose/yum/repo/packages/x86_64/empty-1.0-1.x86_64.rpm \
 	tests/common/compose/yum/repo/packages/x86_64/foo-1.0-1.x86_64.rpm \
 	tests/common/compose/yum/repo/packages/x86_64/bar-1.0-1.x86_64.rpm \
+	tests/common/compose/yum/repo/packages/x86_64/scriptpkg1-1.0-1.x86_64.rpm \
 	$(NULL)
 
 # Create a rule for each testpkg with their respective spec file as dep.

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -115,7 +115,7 @@ testenv:
 	@echo "===== ENTERING TESTENV ====="
 	test_tmpdir=$$(mktemp -d test.XXXXXX) && \
 	  cd $$test_tmpdir && \
-	  env $(BASE_TESTS_ENVIRONMENT) TESTENV=1 \
+	  env $(BASE_TESTS_ENVIRONMENT) PATH=$(abs_builddir):$$PATH TESTENV=1 \
 	    sh ../tests/utils/setup-session.sh bash && \
 	  cd .. && \
 	  rm -rf $$test_tmpdir

--- a/tests/common/compose/yum/scriptpkg1.spec
+++ b/tests/common/compose/yum/scriptpkg1.spec
@@ -1,0 +1,37 @@
+Summary: An app that uses useradd in its %pre
+Name: scriptpkg1
+Version: 1.0
+Release: 1
+License: GPL+
+Group: Development/Tools
+URL: http://foo.bar.com
+BuildArch: x86_64
+
+%description
+%{summary}
+
+%prep
+
+%build
+cat > scriptpkg1 << EOF
+#!/bin/sh
+echo "Hello!"
+EOF
+chmod a+x scriptpkg1
+
+%pre
+groupadd -r scriptpkg1
+
+%install
+mkdir -p %{buildroot}/usr/bin
+install scriptpkg1 %{buildroot}/usr/bin
+
+%clean
+rm -rf %{buildroot}
+
+%files
+/usr/bin/scriptpkg1
+
+%changelog
+* Wed Aug 17 2016 Jonathan Lebon <jlebon@redhat.com> 1.0-1
+- First Build

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Jonathan Lebon <jlebon@redhat.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# SUMMARY: check that RPM scripts are properly handled during package layering
+
+vm_send_test_repo
+
+# make sure the package is not already layered
+vm_assert_layered_pkg scriptpkg1 absent
+
+vm_cmd rpm-ostree pkg-add scriptpkg1
+echo "ok pkg-add scriptpkg1"
+
+vm_reboot
+
+vm_assert_layered_pkg scriptpkg1 present
+echo "ok pkg scriptpkg1 added"
+
+# let's check that the group was successfully added
+vm_cmd getent group scriptpkg1
+echo "ok group scriptpkg1 active"


### PR DESCRIPTION
Thought it'd be fun to write a test for verifying proper handling of
scriptlets during package layering. There's obviously a lot more that
could go in here (patches welcome!), but it's a start.