### PR TITLE
[merged] diff: Don't print changelogs by default

### DIFF
--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -25,9 +25,11 @@
 #include "rpmostree-rpm-util.h"
 
 static char *opt_format;
+static gboolean opt_changelogs;
 
 static GOptionEntry option_entries[] = {
   { "format", 'F', 0, G_OPTION_ARG_STRING, &opt_format, "Output format: \"diff\" or (default) \"block\"", "FORMAT" },
+  { "changelogs", 'c', 0, G_OPTION_ARG_NONE, &opt_changelogs, "Also output RPM changelogs", NULL },
   { NULL }
 };
 
@@ -82,7 +84,8 @@ rpmostree_db_builtin_diff (int argc, char **argv, GCancellable *cancellable, GEr
     }
   else if (g_str_equal (opt_format, "block"))
     {
-      rpmhdrs_diff_prnt_block (rpmhdrs_diff (rpmrev_get_headers (rpmrev1),
+      rpmhdrs_diff_prnt_block (opt_changelogs,
+                               rpmhdrs_diff (rpmrev_get_headers (rpmrev1),
                                              rpmrev_get_headers (rpmrev2)));
     }
   else

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -429,7 +429,7 @@ _rpmhdrs_diff_cmp_end (const GPtrArray *hs1, const GPtrArray *hs2)
 }
 
 void
-rpmhdrs_diff_prnt_block (struct RpmHeadersDiff *diff)
+rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff)
 {
   int num = 0;
 
@@ -476,6 +476,9 @@ rpmhdrs_diff_prnt_block (struct RpmHeadersDiff *diff)
 
           printf (" ");
           pkg_print (hn);
+
+          if (!changelogs)
+            continue;
 
           /* Load the old %changelog entries */
           ochanges_date = &ochanges_date_s;

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -60,7 +60,7 @@ rpmhdrs_rpmdbv (struct RpmHeaders *l1,
                 GError **error);
 
 void
-rpmhdrs_diff_prnt_block (struct RpmHeadersDiff *diff);
+rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff);
 
 void
 rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff);


### PR DESCRIPTION
Communicating information is a hard problem, but basically there
are two things here.  First, the changelogs make the diff visual
spaghetti.  (If we were rendering to HTML with expanders or something,
it could work).

Second, I think RPM changelogs are legacy - tooling should pull from
git.

So far when doing release announcements I've been manually stripping
out the changelogs, embarassingly enough.  Time to fix that.

Anyways, we preserve the changelog-emitting code, it's just not the
default now.