### PR TITLE
[merged] core: Define an autocleanup macro for Header

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1813,18 +1813,17 @@ add_to_transaction (rpmts  ts,
                     GCancellable *cancellable,
                     GError **error)
 {
-  gboolean ret = FALSE;
-  Header hdr = NULL;
+  _cleanup_rpmheader_ Header hdr = NULL;
   int r;
 
   hdr = get_header_for_package (tmp_metadata_dfd, pkg, error);
   if (!hdr)
-    goto out;
+    return FALSE;
 
   if (!noscripts)
     {
       if (!rpmostree_script_txn_validate (pkg, hdr, ignore_scripts, cancellable, error))
-        goto out;
+        return FALSE;
     }
 
   r = rpmtsAddInstallElement (ts, hdr, pkg, TRUE, NULL);
@@ -1835,14 +1834,10 @@ add_to_transaction (rpmts  ts,
                    G_IO_ERROR_FAILED,
                    "Failed to add install element for %s",
                    dnf_package_get_filename (pkg));
-      goto out;
+      return FALSE;
     }
 
-  ret = TRUE;
- out:
-  if (hdr)
-    headerFree (hdr);
-  return ret;
+  return TRUE;
 }
 
 static gboolean
@@ -1853,22 +1848,17 @@ run_posttrans_sync (int tmp_metadata_dfd,
                     GCancellable *cancellable,
                     GError    **error)
 {
-  gboolean ret = FALSE;
-  Header hdr;
+  _cleanup_rpmheader_ Header hdr;
 
   hdr = get_header_for_package (tmp_metadata_dfd, pkg, error);
   if (!hdr)
-    goto out;
+    return FALSE;
 
   if (!rpmostree_posttrans_run_sync (pkg, hdr, ignore_scripts, rootfs_dfd,
                                      cancellable, error))
-    goto out;
+    return FALSE;
 
-  ret = TRUE;
- out:
-  if (hdr)
-    headerFree (hdr);
-  return ret;
+  return TRUE;
 }
 
 /* FIXME: This is a copy of ot_admin_checksum_version */

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -62,6 +62,15 @@ rpmhdrs_rpmdbv (struct RpmHeaders *l1,
 void
 rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff);
 
+/* Define cleanup functions for librpm here */
+static inline void
+rpmostree_cleanup_rpmheader (Header *h)
+{
+  if (*h)
+    headerFree (*h);
+}
+#define _cleanup_rpmheader_ __attribute__((cleanup(rpmostree_cleanup_rpmheader)))
+
 void
 rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff);
 

--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -179,7 +179,7 @@ rpmostree_unpacker_read_metainfo (int fd,
   rpmts ts = NULL;
   FD_t rpmfd;
   int r;
-  Header ret_header = NULL;
+  _cleanup_rpmheader_ Header ret_header = NULL;
   rpmfi ret_fi = NULL;
   gsize ret_cpio_offset;
   g_autofree char *abspath = g_strdup_printf ("/proc/self/fd/%d", fd);
@@ -233,8 +233,6 @@ rpmostree_unpacker_read_metainfo (int fd,
   if (out_cpio_offset)
     *out_cpio_offset = ret_cpio_offset;
  out:
-  if (ret_header)
-    headerFree (ret_header);
   if (rpmfd)
     (void) Fclose (rpmfd);
   return ret;
@@ -271,7 +269,7 @@ RpmOstreeUnpacker *
 rpmostree_unpacker_new_fd (int fd, RpmOstreeUnpackerFlags flags, GError **error)
 {
   RpmOstreeUnpacker *ret = NULL;
-  Header hdr = NULL;
+  _cleanup_rpmheader_ Header hdr = NULL;
   rpmfi fi = NULL;
   struct archive *archive;
   gsize cpio_offset;
@@ -296,8 +294,6 @@ rpmostree_unpacker_new_fd (int fd, RpmOstreeUnpackerFlags flags, GError **error)
  out:
   if (archive)
     archive_read_free (archive);
-  if (hdr)
-    headerFree (hdr);
   if (fi)
     rpmfiFree (fi);
   return ret;


### PR DESCRIPTION
And switch a few things to `return FALSE`.  Preparatory work
for other cleanups.