### PR TITLE
[merged] daemon: Add ConditionPathExists=/ostree

### DIFF
--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -5,3 +5,4 @@ Description=RPM OSTree Manager
 Type=dbus
 BusName=org.projectatomic.rpmostree1
 ExecStart=@libexecdir@/rpm-ostreed
+ConditionPathExists=/ostree


### PR DESCRIPTION
Right now the daemon assumes the system is using ostree, but
for various reasons people can try to start it on non-ostree systems.

This is a simple fix to avoid crashing.  A better fix would
need to rework a lot of the code to return dummy/stub values but
that would be painful.  Maybe later.

https://bugzilla.redhat.com/show_bug.cgi?id=1372194