### PR TITLE
[merged] daemon: Fix ConditionPathExists location

### DIFF
--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=RPM OSTree Manager
+ConditionPathExists=/ostree
 
 [Service]
 Type=dbus
 BusName=org.projectatomic.rpmostree1
 ExecStart=@libexecdir@/rpm-ostreed
-ConditionPathExists=/ostree


### PR DESCRIPTION
It needs to be under `[Unit]`.  I noticed the systemd warning
in my logs; not sure how this worked when I was testing it locally.