### PR TITLE
Set KERNEL_INSTALL_NOOP when composing and during scripts

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -32,6 +32,7 @@
 #include "rpmostree-compose-builtins.h"
 #include "rpmostree-util.h"
 #include "rpmostree-bwrap.h"
+#include "rpmostree-scripts.h"
 #include "rpmostree-core.h"
 #include "rpmostree-json-parsing.h"
 #include "rpmostree-postprocess.h"
@@ -600,6 +601,12 @@ rpmostree_compose_builtin_tree (int             argc,
   g_autoptr(GHashTable) varsubsts = NULL;
   gboolean workdir_is_tmp = FALSE;
   g_autofree char *next_version = NULL;
+
+  /* Do this very early on here (before threads etc.) until we port
+   * fully to Unified...we unfortunately can't easily mainipulate the
+   * process environment librpm uses for scripts.
+   */
+  rpmostree_script_set_standard_environ ();
 
   self->treefile_context_dirs = g_ptr_array_new_with_free_func ((GDestroyNotify)g_object_unref);
   

--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -30,6 +30,11 @@ void rpmostree_ptrarray_append_strdup (GPtrArray *argv_array, ...) G_GNUC_NULL_T
 
 gboolean rpmostree_run_sync_fchdir_setup (char **argv_array, GSpawnFlags flags,
                                           int rootfs_fd, GError **error);
+gboolean
+rpmostree_run_sync_full (char **argv_array, GSpawnFlags flags,
+                         int rootfs_fd, GSpawnChildSetupFunc func,
+                         void *user_data,
+                         GError **error);
 
 gboolean rpmostree_bwrap_bootstrap_if_in_mock (GError **error);
 gboolean rpmostree_bwrap_selftest (GError **error);

--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -49,6 +49,8 @@ gboolean rpmostree_script_ignore_hash_from_strv (const char *const *strv,
                                                  GHashTable **out_hash,
                                                  GError **error);
 
+void rpmostree_script_set_standard_environ (void);
+
 gboolean
 rpmostree_script_txn_validate (DnfPackage    *package,
                                Header         hdr,


### PR DESCRIPTION
See https://github.com/systemd/systemd/pull/4103 - basically
this avoids us generating an initramfs from the kernel `%posttrans`
just to discard it right after.
