### PR TITLE
[merged] compose: Nuke mock workaround

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -631,9 +631,6 @@ rpmostree_compose_builtin_tree (int             argc,
       goto out;
     }
 
-  /* Mock->bwrap bootstrap for Fedora */
-  if (!rpmostree_bwrap_bootstrap_if_in_mock (error))
-    goto out;
   /* Test whether or not bwrap is going to work - we will fail inside e.g. a Docker
    * container without --privileged or userns exposed.
    */

--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -31,5 +31,4 @@ void rpmostree_ptrarray_append_strdup (GPtrArray *argv_array, ...) G_GNUC_NULL_T
 gboolean rpmostree_run_sync_fchdir_setup (char **argv_array, GSpawnFlags flags,
                                           int rootfs_fd, GError **error);
 
-gboolean rpmostree_bwrap_bootstrap_if_in_mock (GError **error);
 gboolean rpmostree_bwrap_selftest (GError **error);


### PR DESCRIPTION
It turns out it was buggy (for some reason `PS1` wasn't propagating),
and furthermore, things mostly work if one enables `--new-chroot` i.e.
`systemd-nspawn`, which is what Fedora is going to do, and everyone
else in the world uses Docker.

While we're here, tweak the error message to use `<>` around the URL
which makes it more easily clickable from terminals.