### PR TITLE
[merged] Rename pkg-add -> install, move out of preview

### DIFF
--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -186,7 +186,7 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
-        <term><command>pkg-add</command></term>
+        <term><command>install (pkg-add)</command></term>
 
         <listitem>
           <para>
@@ -210,7 +210,7 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
-        <term><command>pkg-delete</command></term>
+        <term><command>uninstall (pkg-remove)</command></term>
 
         <listitem>
           <para>

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -44,10 +44,16 @@ static RpmOstreeCommand supported_commands[] = {
   { "rollback", rpmostree_builtin_rollback },
   { "status", rpmostree_builtin_status },
   { "upgrade", rpmostree_builtin_upgrade },
+  { "install", rpmostree_builtin_pkg_add },
+  { "uninstall", rpmostree_builtin_pkg_remove },
   { NULL }
 };
 
 static RpmOstreeCommand preview_commands[] = {
+  { NULL }
+};
+
+static RpmOstreeCommand legacy_alias_commands[] = {
   { "pkg-add", rpmostree_builtin_pkg_add },
   { "pkg-remove", rpmostree_builtin_pkg_remove },
   { NULL }
@@ -270,6 +276,8 @@ main (int    argc,
     command_name = "db";
 
   command = lookup_command_of_type (supported_commands, command_name, NULL);
+  if (!command)
+    command = lookup_command_of_type (legacy_alias_commands, command_name, NULL);
 
   if (!command)
     command = lookup_command_of_type (preview_commands, command_name, "a preview");


### PR DESCRIPTION
I think these are suitable for wider consumption now, and we should
be able to support existing installs.

Rename the verb to just `install` since it's what every other package
manager uses.