### PR TITLE
deploy: don't change ref and validate checksums

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -648,15 +648,10 @@ rpmostree_sysroot_upgrader_pull (RpmOstreeSysrootUpgrader  *self,
 
   if (self->override_csum != NULL)
     {
-      if (!ostree_repo_set_ref_immediate (repo,
-                                          origin_remote,
-                                          origin_ref,
-                                          self->override_csum,
-                                          cancellable,
-                                          error))
-        goto out;
-
       self->new_revision = g_strdup (self->override_csum);
+
+      /* NB: We already pulled the latest ref during the version/csum lookup, so
+       * let's not set the ref to this new revision, which might be older. */
     }
   else
     {

--- a/src/daemon/rpmostreed-utils.h
+++ b/src/daemon/rpmostreed-utils.h
@@ -64,6 +64,13 @@ gboolean   rpmostreed_repo_lookup_version (OstreeRepo           *repo,
                                            char                **out_checksum,
                                            GError              **error);
 
+gboolean rpmostreed_repo_lookup_checksum (OstreeRepo           *repo,
+                                          const char           *refspec,
+                                          const char           *checksum,
+                                          OstreeAsyncProgress  *progress,
+                                          GCancellable         *cancellable,
+                                          GError              **error);
+
 gboolean   rpmostreed_repo_lookup_cached_version (OstreeRepo    *repo,
                                                   const char    *refspec,
                                                   const char    *version,

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -76,8 +76,11 @@ rpm-ostree status | head --lines 5 | tee OUTPUT-status.txt
 assert_file_has_content OUTPUT-status.txt '1\.0\.9'
 echo "ok deploy older known version"
 
-# Remember the current revision for later.
-revision=$(ostree rev-parse --repo=sysroot/ostree/repo otheros:testos/buildmaster/x86_64-runtime)
+# Remember the current revision for later. This is a really cheesy way of
+# fetching the current default deployment. It'd be easier to get it from
+# rpm-ostree status --json, but we don't mandate jq  yet.
+revision=$(ostree rev-parse --repo=sysroot/ostree/repo \
+           $(ostree refs --list --repo=sysroot/ostree/repo ostree | head -n 1))
 
 # Jump forward to a locally known version.
 rpm-ostree deploy --os=testos 1.0.10


### PR DESCRIPTION
Commit beb026f7 introduced an interesting behaviour. Doing
`rpm-ostree deploy $X` would find the commit associated with the version
tag, fetch it, and set the refspec to that new commit.

This means that whether we deploy an older or newer version, the refspec
would unconditionally get set to that new deployment's commit. We should
instead try to have the refspec always point to the latest known remote
commit, much like git remote refs work.

Another funky behaviour of `rpm-ostree deploy` was that specifying a
csum directly allowed you to jump to _any_ commit, regardless of whether
that commit exists on the current branch or not. We tighten that up here
so that we check that the checksum does exist on the current branch.

That behaviour can be useful of course, but we might want to change how
users access it so that we don't get inconsistencies such as `rpm-ostree
status` saying that we're sitting on a specific branch with a specific
commit which doesn't actually belong to that branch.
