### PR TITLE
[merged] status: handle errors from json-glib

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -298,8 +298,10 @@ rpmostree_builtin_status (int             argc,
       json_root = json_builder_get_root (builder);
       json_generator_set_root (generator, json_root);
       json_node_free (json_root);
-      
-      if (!json_generator_to_stream (generator, stdout_gio, NULL, error))
+
+      /* NB: watch out for the misleading API docs */
+      if (json_generator_to_stream (generator, stdout_gio, NULL, error) <= 0
+          || (error != NULL && *error != NULL))
         goto out;
     }
   else


### PR DESCRIPTION
The API for json_generator_to_stream() says:

    Return value: %TRUE if the write operation was successful, and
    %FALSE on failure. In case of error, the #GError will be filled
    accordingly

When in fact, because it just gives back what g_output_stream_write(),

    1. it doesn't strictly return TRUE/FALSE, but a full-range uint, and
    2. it will return -1 (which is as good as anything > 0 for success
       checks) when an error occurs.

Although a simple <= 0 would fix it, let's just be extra strict and also
check for an error.

Closes: #468