### PR TITLE
[merged] Get rid of unnecessary selinux.h include

### DIFF
--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -46,7 +46,6 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <selinux/selinux.h>
 
 typedef GObjectClass RpmOstreeUnpackerClass;
 


### PR DESCRIPTION
Nothing in the file seems to use it. Doing this quickly via GitHub UI under assumption that the magic @walters bot will take care of running the full test suite, but otherwise I'll test it later when I get back to a machine I can use for that.