### PR TITLE
[merged] core: Canonicalize an epoch of zero to the empty string

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -729,6 +729,15 @@ cache_branch_for_n_evr_a (const char *name, const char *evr, const char *arch)
   GString *r = g_string_new ("rpmostree/pkg/");
   append_quoted (r, name);
   g_string_append_c (r, '/');
+  /* Work around the fact that libdnf and librpm have different handling
+   * for an explicit Epoch header of zero.  libdnf right now ignores it,
+   * but librpm will add an explicit 0:.  Since there's no good reason
+   * to have it, let's follow the lead of libdnf.
+   *
+   * https://github.com/projectatomic/rpm-ostree/issues/349
+   */
+  if (g_str_has_prefix (evr, "0:"))
+    evr += 2;
   append_quoted (r, evr);
   g_string_append_c (r, '.');
   append_quoted (r, arch);


### PR DESCRIPTION
We have two different codepaths for creating a cache branch header
string, one from libdnf, and one from librpm.  It turns out if
an RPM package explicitly specifies an `Epoch: 0` like various Fedora
perl subpackages do, these are different.

Explicitly convert `0:` to the empty string to make them match, and
hence installation will work.

Closes: https://github.com/projectatomic/rpm-ostree/issues/349