### PR TITLE
[merged] Run bwrap with fixed environment (PATH + LANG)

### DIFF
--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -31,4 +31,6 @@ void rpmostree_ptrarray_append_strdup (GPtrArray *argv_array, ...) G_GNUC_NULL_T
 gboolean rpmostree_run_sync_fchdir_setup (char **argv_array, GSpawnFlags flags,
                                           int rootfs_fd, GError **error);
 
+gboolean rpmostree_run_bwrap_sync (char **argv_array, int rootfs_fd, GError **error);
+
 gboolean rpmostree_bwrap_selftest (GError **error);

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -68,7 +68,6 @@ run_sync_in_root_at (int           rootfs_fd,
                      char        **child_argv,
                      GError     **error)
 {
-  const GSpawnFlags bwrap_spawnflags = G_SPAWN_SEARCH_PATH;
   g_autoptr(GPtrArray) bwrap_argv = NULL;
 
   bwrap_argv = rpmostree_bwrap_base_argv_new_for_rootfs (rootfs_fd, error);
@@ -97,8 +96,7 @@ run_sync_in_root_at (int           rootfs_fd,
   }
   g_ptr_array_add (bwrap_argv, NULL);
 
-  if (!rpmostree_run_sync_fchdir_setup ((char**)bwrap_argv->pdata, bwrap_spawnflags,
-                                        rootfs_fd, error))
+  if (!rpmostree_run_bwrap_sync ((char**)bwrap_argv->pdata, rootfs_fd, error))
     {
       g_prefix_error (error, "Executing bwrap: ");
       return FALSE;


### PR DESCRIPTION
This is basically a re-implementation of
https://github.com/GNOME/libglnx/commit/85c9dd5c073a8c0d74c4baa2e4a94f5535984e62
for the same reasons: it makes things work for rpm-ostree running
inside NixOS.  But there are other cases where if e.g. an unprivileged
user runs rpm-ostree and may not have `/usr/sbin` in PATH, we still
want the container to pick it up, etc.

While changing things I nuked the hacky `RPMOSTREE_DEBUG_SCRIPT` env
var, we can re-add it later in a better way if needed.