### PR TITLE
[merged] deploy: make sure commits are on the current branch

### DIFF
--- a/src/daemon/rpmostreed-utils.h
+++ b/src/daemon/rpmostreed-utils.h
@@ -64,6 +64,13 @@ gboolean   rpmostreed_repo_lookup_version (OstreeRepo           *repo,
                                            char                **out_checksum,
                                            GError              **error);
 
+gboolean rpmostreed_repo_lookup_checksum (OstreeRepo           *repo,
+                                          const char           *refspec,
+                                          const char           *checksum,
+                                          OstreeAsyncProgress  *progress,
+                                          GCancellable         *cancellable,
+                                          GError              **error);
+
 gboolean   rpmostreed_repo_lookup_cached_version (OstreeRepo    *repo,
                                                   const char    *refspec,
                                                   const char    *version,


### PR DESCRIPTION
A funky behaviour of `rpm-ostree deploy` was that specifying a csum
directly allowed you to jump to any commit, regardless of whether that
commit exists on the current branch or not. We tighten that up here so
that we check that the checksum does exist on the current branch.

The previous behaviour can be useful of course, but we might want to
change how users access it so that we don't get inconsistencies such as
rpm-ostree status saying that we're sitting on a specific branch with a
specific commit which doesn't actually belong to that branch.

---

This is split out from #465.