### PR TITLE
[merged] Add infrastructure for alternative name (currently nts)

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -92,6 +92,16 @@ systemdunitdir       = $(prefix)/lib/systemd/system/
 $(systemdunit_DATA):
 	$(SED_SUBST) $@.in > $@
 
+install-daemon-altname-hook:
+	mv $(DESTDIR)$(libexecdir)/rpm-ostreed $(DESTDIR)$(libexecdir)/$(primaryname)d
+	ln -sf $(primaryname)d $(DESTDIR)$(libexecdir)/rpm-ostreed
+	mv $(DESTDIR)$(systemdunitdir)/rpm-ostreed.service $(DESTDIR)$(systemdunitdir)/$(primaryname)d.service
+	ln -sf $(primaryname)d.service $(DESTDIR)$(systemdunitdir)/rpm-ostreed.service
+if BUILDOPT_NEW_NAME
+INSTALL_DATA_HOOKS += install-daemon-altname-hook
+endif
+
+# We don't yet rename the DBus related items
 service_in_files = $(srcdir)/src/daemon/org.projectatomic.rpmostree1.service.in
 service_DATA     = $(service_in_files:.service.in=.service)
 servicedir       = $(dbusservicedir)

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -57,3 +57,10 @@ rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la librpmostree-1.l
 
 privdatadir=$(pkglibdir)
 privdata_DATA = src/app/rpm-ostree-0-integration.conf
+
+install-bin-hook:
+	mv $(DESTDIR)$(bindir)/rpm-ostree $(DESTDIR)$(bindir)/$(primaryname)
+	ln -sf $(primaryname) $(DESTDIR)$(bindir)/rpm-ostree
+if BUILDOPT_NEW_NAME
+INSTALL_DATA_HOOKS += install-bin-hook
+endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,13 @@
 
 include Makefile-decls.am
 
+newname = nts
+if BUILDOPT_NEW_NAME
+primaryname = $(newname)
+else
+primaryname = rpm-ostree
+endif
+
 SUBDIRS += .
 
 if ENABLE_GTK_DOC
@@ -39,6 +46,7 @@ GITIGNOREFILES += build-aux/ gtk-doc.make config.h.in aclocal.m4
 
 SED_SUBST = sed \
         -e 's,[@]libexecdir[@],$(libexecdir),g' \
+        -e 's,[@]primaryname[@],$(primaryname),g' \
         $(NULL)
 
 libglnx_srcpath := $(srcdir)/libglnx

--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,12 @@ AC_ARG_ENABLE(installed_tests,
               [enable_installed_tests=no])
 AM_CONDITIONAL(BUILDOPT_INSTALL_TESTS, test x$enable_installed_tests = xyes)
 
+AC_ARG_ENABLE(new-name,
+              AS_HELP_STRING([--enable-new-name],
+                             [Install additionally as nts (default: no)]),,
+              [enable_new_name=no])
+AM_CONDITIONAL(BUILDOPT_NEW_NAME, test x$enable_new_name = xyes)
+
 AC_ARG_WITH(bubblewrap,
               AS_HELP_STRING([--with-bubblewrap],
                              [Path to bubblewrap binary (default: /usr/bin/bwrap)]),,
@@ -152,6 +158,7 @@ AC_OUTPUT
 echo "
     $PACKAGE $VERSION
 
+    nts name:	        $enable_new_name
     compose tooling:	$enable_compose_tooling
     bubblewrap:         $with_bubblewrap
     gtk-doc:            $enable_gtk_doc

--- a/src/daemon/org.projectatomic.rpmostree1.service.in
+++ b/src/daemon/org.projectatomic.rpmostree1.service.in
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=org.projectatomic.rpmostree1
-Exec=@libexecdir@/rpm-ostreed
+Exec=@libexecdir@/@primaryname@d
 User=root
-SystemdService=rpm-ostreed.service
+SystemdService=@primaryname@d.service

--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -1,8 +1,8 @@
 [Unit]
-Description=RPM OSTree Manager
+Description=OSTree+RPM package management daemon
 ConditionPathExists=/ostree
 
 [Service]
 Type=dbus
 BusName=org.projectatomic.rpmostree1
-ExecStart=@libexecdir@/rpm-ostreed
+ExecStart=@libexecdir@/@primaryname@d


### PR DESCRIPTION
See https://github.com/projectatomic/rpm-ostree/issues/405

This patch adds an (off by default) `--enable-new-name` build option
which currently defaults to `nts`.  This is purely additive, and
the intention is that we'll support the rpm-ostree name in
perpetuity most likely.

At the moment, we add a new name for:
  - /usr/bin/$name
  - The systemd unit file

But we notably *don't* attempt to add a new name to the DBus API,
as it'd be a lot more invasive of a patch, and less payoff (it's
mostly just programs/scripts that interact with the DBus).