### PR TITLE
vmcheck: Ability to run without make and other build tools on host

### DIFF
--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -17,13 +17,16 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
+topsrcdir=$(cd $(dirname $0)/ && git rev-parse --show-toplevel)
+export topsrcdir
+
 # prepares the VM and library for action
 vm_setup() {
 
   # If there's already an ssh-config, just use that one. The user might have
   # created it for a self-provisioned machine. Otherwise, let's just assume
   # we're using vagrant and generate an ssh-config.
-  if [ ! -f ssh-config ]; then
+  if [ ! -s ssh-config ]; then
     vagrant ssh-config > "${topsrcdir}/ssh-config"
   fi
 

--- a/tests/utils/vmbuild.sh
+++ b/tests/utils/vmbuild.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+commondir=$(cd $(dirname $0)/../common && pwd)
 source ${commondir}/libvm.sh
 
 # create ssh-config if needed and export cmds

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -19,6 +19,7 @@
 
 set -e
 
+commondir=$(cd $(dirname $0)/../common && pwd)
 . ${commondir}/libtest.sh
 . ${commondir}/libvm.sh
 

--- a/tests/vmcheck/test-layering-relayer.sh
+++ b/tests/vmcheck/test-layering-relayer.sh
@@ -19,6 +19,7 @@
 
 set -e
 
+commondir=$(cd $(dirname $0)/../common && pwd)
 . ${commondir}/libtest.sh
 . ${commondir}/libvm.sh
 

--- a/tests/vmcheck/test-layering-rpmdb.sh
+++ b/tests/vmcheck/test-layering-rpmdb.sh
@@ -19,6 +19,7 @@
 
 set -e
 
+commondir=$(cd $(dirname $0)/../common && pwd)
 . ${commondir}/libtest.sh
 . ${commondir}/libvm.sh
 

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -19,6 +19,7 @@
 
 set -e
 
+commondir=$(cd $(dirname $0)/../common && pwd)
 . ${commondir}/libtest.sh
 . ${commondir}/libvm.sh
 

--- a/tests/vmcheck/test.sh
+++ b/tests/vmcheck/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+commondir=$(cd $(dirname $0)/../common && pwd)
 . ${commondir}/libvm.sh
 
 # create ssh-config if needed and export cmds


### PR DESCRIPTION
Installing build tools directly on a host system should be considered
an explicit antipattern for Project Atomic (whether servers or
workstations).  I started on changes to be able to run
`./tests/vmcheck/test.sh` directly, assuming I have vagrant on the
host.

However, I ran into the fact that we need to build the test RPMs
etc inside the VM, not on the host.

Filing this as a start of reworking things, will try to pick it up
later.
