### PR TITLE
[merged] Add .redhat-ci.yml

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -1,0 +1,61 @@
+branches:
+    - master
+    - auto
+    - try
+
+container:
+    image: projectatomic/ostree-tester
+
+packages:
+  - clang
+  - libubsan
+  - python-sphinx
+  - createrepo_c
+  - gperf
+  - rpm-build
+  - bubblewrap
+  - python-devel
+  - check-devel
+  - pkgconfig(ostree-1)
+  - pkgconfig(libgsystem)
+  - pkgconfig(librepo)
+  - pkgconfig(libsolv)
+  - pkgconfig(rpm)
+  - pkgconfig(json-glib-1.0)
+  - pkgconfig(expat)
+  - cmake
+  - gtk-doc
+
+tests:
+    - ./autogen.sh
+        --prefix=/usr
+        --libdir=/usr/lib64
+        --enable-installed-tests
+        --enable-gtk-doc
+        CFLAGS='-fsanitize=undefined'
+    - make -j2
+    - make check
+    - make install
+    - gnome-desktop-testing-runner rpm-ostree
+    - sudo --user=testuser gnome-desktop-testing-runner rpm-ostree
+
+timeout: 30m
+
+artifacts:
+    - test-suite.log
+
+---
+
+inherit: true
+
+tests:
+    - ./autogen.sh
+        --prefix=/usr
+        --libdir=/usr/lib64
+        --enable-installed-tests
+        --enable-gtk-doc CC=clang
+    - make -j2
+
+context: Clang
+
+artifacts:

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -340,13 +340,18 @@ os_repository_new_commit ()
     cd ${test_tmpdir}
 }
 
+skip() {
+    echo "1..0 # SKIP" "$@"
+    exit 0
+}
+
 check_root_test ()
 {
     if test "$(id -u)" != "0"; then
-       echo "1..0 # requires root"
-       # don't use 77 to signal skip. TAP driver will already know it's a skip
-       # from the 1..0 test plan (and would set as fail if exit code != 0).
-       exit 0
+       skip "This test requires uid 0"
+    fi
+    if ! capsh --print | grep -q 'Bounding set.*[^a-z]cap_sys_admin'; then
+        skip "No CAP_SYS_ADMIN in bounding set"
     fi
 }
 


### PR DESCRIPTION
Copied from ostree, tweaked a little bit.  We can't yet use
`-Werror=unused-variable` until
https://github.com/rpm-software-management/libhif/pull/205
