### PR TITLE
[merged]  daemon: use refspec after pulling ancestry 

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1114,8 +1114,9 @@ overlay_packages (RpmOstreeSysrootUpgrader *self,
                                     cancellable, error))
     goto out;
 
-  /* Now, it's possible all requested packages are in the new tree, so
-   * we have another optimization here for that case.
+  /* Now, it's possible all requested packages are in the new tree (or
+   * that the user wants to stop overlaying them), so we have another
+   * optimization here for that case.
    */
   if (g_strv_length (self->requested_packages) == 0)
     {

--- a/src/daemon/rpmostreed-utils.c
+++ b/src/daemon/rpmostreed-utils.c
@@ -301,7 +301,7 @@ rpmostreed_repo_pull_ancestry (OstreeRepo               *repo,
       /* First pass only.  Now we can resolve the ref to a checksum. */
       if (checksum == NULL)
         {
-          if (!ostree_repo_resolve_rev (repo, ref, FALSE, &checksum, error))
+          if (!ostree_repo_resolve_rev (repo, refspec, FALSE, &checksum, error))
             goto out;
         }
 


### PR DESCRIPTION
Previously, in preparation for validating e.g. versions during 'deploy'
operations, we would pull the latest commit metadata. However, we would
then do resolve on the branch name only rather than the full refspec.
But this can sometimes give the wrong checksum. For example, if we have
multiple remotes holding the same branch name, ostree_repo_resolve_rev
will just start looking in each remote for the specified ref, and we may
thus end up with the checksum from the wrong remote.

Related: RHBZ#1390259