### PR TITLE
.redhat-ci.yml: add vmcheck test

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -7,6 +7,7 @@ container:
     image: projectatomic/ostree-tester
 
 packages:
+  - git
   - clang
   - libubsan
   - python-sphinx
@@ -18,8 +19,11 @@ packages:
   - check-devel
   - pkgconfig(ostree-1)
   - pkgconfig(libgsystem)
+  - pkgconfig(libcap)
   - pkgconfig(librepo)
   - pkgconfig(libsolv)
+  - pkgconfig(libsystemd)
+  - pkgconfig(libarchive)
   - pkgconfig(rpm)
   - pkgconfig(json-glib-1.0)
   - pkgconfig(expat)
@@ -59,3 +63,35 @@ tests:
 context: Clang
 
 artifacts:
+
+---
+
+inherit: true
+
+host:
+  distro: fedora/24/cloud
+
+context: rhci/vmcheck
+
+env:
+  VAGRANT_DEFAULT_PROVIDER: libvirt
+  VAGRANT_BOX_URL: https://ci.centos.org/artifacts/sig-atomic/centos-continuous/images/cloud/latest/images/centos-atomic-host-7-vagrant-libvirt.box
+  VAGRANT_BOX: centos/7/atomic/continuous
+
+# We'll need to add some sugar to redhat-ci to make this
+# nicer. E.g. allow provision multiple hosts, or a host and
+# a container.
+
+tests:
+  - dnf install -y vagrant libvirt qemu-kvm vagrant-libvirt ansible libselinux-python
+  - systemctl start libvirtd virtlogd
+  - vagrant box add --name $VAGRANT_BOX $VAGRANT_BOX_URL
+  - vagrant up
+  - sh autogen.sh
+  - make gitignore # needed to have a clean rsync
+  - make vmcheck
+
+artifacts:
+  - vmcheck.log
+
+timeout: 45m

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,18 +3,17 @@
 # See `HACKING.md` for more information on this.
 
 Vagrant.configure(2) do |config|
-    config.vm.box = "centos/atomic-host"
-    config.vm.hostname = "centosah-dev"
-    config.vm.define "vmcheck" do |vmcheck|
+
+    if ENV['VAGRANT_BOX']
+      config.vm.box = ENV['VAGRANT_BOX']
+    else
+      config.vm.box = "centos/atomic-host"
     end
 
-    # It's just easier to have ssh set up as root from the start so that tests
-    # don't need to sudo, which can sometimes cause issues. If we need to test
-    # any unprivileged things, we can still just sudo back into the vagrant
-    # user.
-    config.ssh.username = 'root'
-    config.ssh.password = 'vagrant'
-    config.ssh.insert_key = 'true'
+    config.vm.hostname = "centosah-dev"
+
+    config.vm.define "vmcheck" do |vmcheck|
+    end
 
     # turn off the default rsync in the vagrant box (the vm tooling does this
     # for use already)
@@ -29,7 +28,6 @@ Vagrant.configure(2) do |config|
     config.vm.provision "ansible" do |ansible|
       ansible.playbook = "vagrant/setup.yml"
       ansible.host_key_checking = false
-      ansible.extra_vars = { ansible_ssh_user: 'root' }
       ansible.raw_ssh_args = ['-o ControlMaster=no']
       # for debugging the ansible playbook
       #ansible.raw_arguments = ['-v']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,8 +20,8 @@ Vagrant.configure(2) do |config|
     config.vm.synced_folder ".", "/home/vagrant/sync", disabled: true
 
     config.vm.provider "libvirt" do |libvirt, override|
-      libvirt.cpus = 2
-      libvirt.memory = 2048
+      libvirt.cpus = 1
+      libvirt.memory = 1024
       libvirt.driver = 'kvm'
     end
 

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -20,11 +20,11 @@
 # prepares the VM and library for action
 vm_setup() {
 
-  # If there's already an ssh-config, just use that one. The user might have
-  # created it for a self-provisioned machine. Otherwise, let's just assume
-  # we're using vagrant and generate an ssh-config.
-  if [ ! -f ssh-config ]; then
-    vagrant ssh-config > "${topsrcdir}/ssh-config"
+  # We assume that there's already a configured ssh-config
+  # file available to tell us how to connect to the VM.
+  if [ ! -f "${topsrcdir}/ssh-config" ]; then
+    echo "ERROR: No ssh-config found."
+    exit 1
   fi
 
   local sshopts="-F ${topsrcdir}/ssh-config \

--- a/vagrant/setup.yml
+++ b/vagrant/setup.yml
@@ -3,6 +3,9 @@
   gather_facts: no
   become: yes
   tasks:
+
+    # if we're not already using the CAHC box, then add the
+    # remote to make it easier for the user to rebase later
     - name: add CAHC ostree remote
       command: >
         ostree remote add --set=gpg-verify=false centos-atomic-continuous
@@ -10,59 +13,27 @@
       args:
         creates: /etc/ostree/remotes.d/centos-atomic-continuous.conf
 
-    # Experimenting with this as a potential new name.
-    - name: link nxs -> rpm-ostree
-      file: src=/usr/bin/rpm-ostree dest=/usr/local/bin/nxs owner=0 group=0 state=link
+    # We generate a valid ssh-config here that libvm.sh can
+    # make use of. This also requires making sure the root
+    # user can be ssh'ed in directly.
 
-    # add a little bit of storage (default is 3G) or docker save complains
-    - name: resize root
-      shell: lvresize -L 4G -r /dev/atomicos/root && touch /root/.resized
-      args:
-        creates: /root/.resized
+    # set up auth key
+    - file: state=directory mode=0600 path=/root/.ssh
+    - command: cp .ssh/authorized_keys /root/.ssh
 
-    - name: check for builder image
-      command: docker inspect rpm-ostree-builder
-      failed_when: False
-      changed_when: False
-      register: inspect
+    # make sure root account is unlocked
+    - name: unlock root account
+      command: passwd -u root
 
-    - name: check for local cache of builder image
-      local_action: stat path=vagrant/buildimg.tar.gz
-      register: cache
+    # generate ssh config
+    - name: generate config
+      local_action: shell vagrant ssh-config > ../ssh-config
       become: no
 
-    - set_fact:
-        # the image is available on the guest
-        on_guest: "{{ inspect.rc == 0 | bool }}"
-        # the image is available on the host
-        on_host: "{{ cache.stat.isreg is defined and cache.stat.isreg | bool }}"
-
-    # sync them up, building if necessary
-
-    # XXX: this is just a stopgap, we should also make it easy to update the
-    # container without having to rebuild it completely
-
-    - name: copy cached builder image
-      copy: src=buildimg.tar.gz dest=/tmp
-      when: not on_guest and on_host
-
-    - name: import cached builder image
-      shell: gunzip -c /tmp/buildimg.tar.gz | docker load
-      when: not on_guest and on_host
-
-    - name: build builder image
-      command: make buildimg
-      args:
-        chdir: sync/vagrant
-      when: not on_guest and not on_host
-
-    - name: export builder image
-      shell: docker save rpm-ostree-builder | gzip -c > /tmp/buildimg.tar.gz
-      when: not on_host
-      args:
-        creates: /tmp/buildimg.tar.gz
-
-    - name: fetch cached builder image
-      fetch: src=/tmp/buildimg.tar.gz dest=. flat=true
-      when: not on_host
+    - name: make sure user in config is root
+      local_action: lineinfile
+        dest=../ssh-config
+        regexp='^( *User) .*$'
+        line='\1 root'
+        backrefs=yes
       become: no


### PR DESCRIPTION
Add a testsuite to the YAML to provision a VM and run the vmcheck tests.
This can probably be reworked into something nicer once we add support
in redhat-ci for provisioning multiple environments in a single suite.