### PR TITLE
[merged] Add rpmostree.clientlayer metadata to derived commits

### DIFF
--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -322,7 +322,8 @@ rpmostree_container_builtin_assemble (int             argc,
       goto out;
 
     if (!rpmostree_context_assemble_commit (rocctx->ctx, tmprootfs_dfd, NULL,
-                                            NULL, FALSE, &commit, cancellable, error))
+                                            NULL, RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE,
+                                            FALSE, &commit, cancellable, error))
       goto out;
 
     glnx_shutil_rm_rf_at (rocctx->userroot_dfd, tmprootfs, cancellable, NULL);
@@ -534,7 +535,8 @@ rpmostree_container_builtin_upgrade (int argc, char **argv, GCancellable *cancel
       goto out;
 
     if (!rpmostree_context_assemble_commit (rocctx->ctx, tmprootfs_dfd, NULL,
-                                            NULL, TRUE, &new_commit_checksum,
+                                            NULL, RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE,
+                                            TRUE, &new_commit_checksum,
                                             cancellable, error))
       goto out;
 

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1064,6 +1064,7 @@ overlay_final_pkgset (RpmOstreeSysrootUpgrader *self,
   /* --- Overlay and commit --- */
   if (!rpmostree_context_assemble_commit (ctx, tmprootfs_dfd, devino_cache,
                                           base_rev,
+                                          RPMOSTREE_ASSEMBLE_TYPE_CLIENT_LAYERING,
                                           (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_NOSCRIPTS) > 0,
                                           &self->new_revision,
                                           cancellable, error))

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -103,12 +103,18 @@ gboolean rpmostree_context_relabel (RpmOstreeContext *self,
                                     GCancellable     *cancellable,
                                     GError          **error);
 
+typedef enum {
+  RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE,
+  RPMOSTREE_ASSEMBLE_TYPE_CLIENT_LAYERING
+} RpmOstreeAssembleType;
+
 /* NB: tmprootfs_dfd is allowed to have pre-existing data */
 /* devino_cache can be NULL if no previous cache established */
 gboolean rpmostree_context_assemble_commit (RpmOstreeContext      *self,
                                             int                    tmprootfs_dfd,
                                             OstreeRepoDevInoCache *devino_cache,
                                             const char            *parent,
+                                            RpmOstreeAssembleType  assemble_type,
                                             gboolean               noscripts,
                                             char                 **out_commit,
                                             GCancellable          *cancellable,


### PR DESCRIPTION
In the future we may add more commands that take as input commit
IDs.  However, we really want to distinguish between server and
client generated commits, as some of these operations won't
make sense for derived commits.

This changes the API to have callers say which type of commit
they're generating, which also fixes a FIXME, and helps get us
a bit closer to the "unified core".