### PR TITLE
[merged] daemon: Use new OSTree API to verify commits by remotes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,11 @@ dnl bundled libdnf
 PKGDEP_RPMOSTREE_CFLAGS="-I $(pwd)/libdnf -I $(pwd)/libdnf-build $PKGDEP_RPMOSTREE_CFLAGS"
 PKGDEP_RPMOSTREE_LIBS="-L$(pwd)/libdnf-build/libdnf -ldnf $PKGDEP_RPMOSTREE_LIBS"
 
+save_LIBS=$LIBS
+LIBS=$PKGDEP_RPMOSTREE_LIBS
+AC_CHECK_FUNCS(ostree_repo_verify_commit_for_remote)
+LIBS=$save_LIBS
+
 AC_PATH_PROG([XSLTPROC], [xsltproc])
 
 GLIB_TESTS

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -96,9 +96,7 @@ rpmostreed_deployment_gpg_results (OstreeRepo *repo,
   if (!gpg_verify)
     goto out;
 
-
-  result = ostree_repo_verify_commit_ext (repo, csum, NULL, NULL,
-                                          NULL, &error);
+  result = ostree_repo_verify_commit_for_remote (repo, csum, remote, NULL, &error);
   if (!result)
       goto out;
 

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -96,7 +96,11 @@ rpmostreed_deployment_gpg_results (OstreeRepo *repo,
   if (!gpg_verify)
     goto out;
 
+#ifdef HAVE_OSTREE_REPO_VERIFY_COMMIT_FOR_REMOTE
   result = ostree_repo_verify_commit_for_remote (repo, csum, remote, NULL, &error);
+#else
+  result = ostree_repo_verify_commit_ext (repo, csum, NULL, NULL, NULL, &error);
+#endif
   if (!result)
       goto out;
 


### PR DESCRIPTION
Otherwise, we would show remotes using the new `gpgkeypath`
as unknown.

See: https://github.com/ostreedev/ostree/pull/575
See: https://github.com/ostreedev/ostree/issues/573
See: https://bugzilla.redhat.com/show_bug.cgi?id=1393545