### PR TITLE
[merged] Fix install-langs support

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -277,7 +277,7 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
   if (json_object_has_member (treedata, "install-langs"))
     {
       JsonArray *a = json_object_get_array_member (treedata, "install-langs");
-      if (!set_keyfile_string_array_from_json (treespec, "tree", "install-langs", a, error))
+      if (!set_keyfile_string_array_from_json (treespec, "tree", "instlangs", a, error))
         goto out;
     }
 


### PR DESCRIPTION
We're looking at changing Atomic Host to use multiple locales (but not all);
See: https://bugzilla.redhat.com/show_bug.cgi?id=1186757

This revealed our `install-langs` support didn't really work.  Our
`treecompose-post.sh` was deleting the extraneous translations anyways,
which masked this.  And for other cases like workstations where
we drag along all the translations anyways, it was fine too.

There were two bugs:
 - In the keyfile spec it's `instlangs`
 - We were setting the macro a bit too late, it should be before
   `dnf_context_setup()`.