### PR TITLE
[merged] core: Error out if we're trying to do an empty install set

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1899,6 +1899,13 @@ rpmostree_context_assemble_commit (RpmOstreeContext      *self,
                                           DNF_PACKAGE_INFO_INSTALL,
                                           -1);
 
+    if (package_list->len == 0)
+      {
+        g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                             "No packages in installation set");
+        goto out;
+      }
+
     for (i = 0; i < package_list->len; i++)
       {
         DnfPackage *pkg = package_list->pdata[i];


### PR DESCRIPTION
This is a partial fix for
https://github.com/projectatomic/rpm-ostree/issues/529

We could drop into this codepath via multiple ways (containers,
etc.), so it makes sense to have a last ditch error here, even
if we should really give an error earlier.