### PR TITLE
[merged] tests: Add ./tests/compose

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -78,3 +78,18 @@ tests:
 
 artifacts:
   - vmcheck.log
+
+---
+context: compose
+build: false
+timeout: 30m
+
+# This test case wants an "unprivileged container with bubblewrap",
+# which we don't have right now; so just provision a VM and do a
+# docker --privileged run.
+host:
+  distro: centos/7/atomic/alpha
+
+tests:
+  # Yes, we're duplicating the build dependencies *again*!  Woo!
+  - docker run --privileged -v $(pwd):/srv/code --rm projectatomic/ostree-tester /bin/sh -c 'yum -y install python-sphinx createrepo_c gperf rpm-build bubblewrap python-devel check-devel "pkgconfig(ostree-1)" "pkgconfig(libgsystem)" "pkgconfig(librepo)" "pkgconfig(libsolv)" "pkgconfig(rpm)" "pkgconfig(json-glib-1.0)" "pkgconfig(expat)" cmake gtk-doc && cd /srv/code && env NOCONFIGURE=1 ./autogen.sh && ./configure --prefix=/usr --libdir=/usr/lib64 && make && make install && ./tests/compose'

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,12 +1,26 @@
-Tests are divided into two groups:
+Tests are divided into three groups:
 
 - Tests in the `check` directory are non-destructive and
   uninstalled. Some of the tests require root privileges.
   Use `make check` to run these.
 
-- Tests in the `vmcheck` directory are destructive and
-  installed. They are run inside a VM. Use `make vmcheck` to
-  run these (see also `HACKING.md` in the top directory).
+- The `composecheck` tests currently require uid 0 capabilities -
+  the default in Docker, or you can run them via a user namespace.
+  They are non-destructive, but are installed.
+
+  To use them, you might do a `make && sudo make install` inside a
+  Docker container.
+
+  Then invoke `./tests/compose`.  Alternatively of course, you
+  can simply run the tests on a host system or in an existing
+  container, without doing a build.
+
+  Note: This is intentionally *not* a `Makefile` target because
+  it doesn't require building and doesn't use uninstalled binaries.
+
+- Tests in the `vmcheck` directory are oriented around using
+  Vagrant.  Use `make vmcheck` to run them.
+  See also `HACKING.md` in the top directory.
 
 The `common` directory contains files used by multiple
 tests. The `utils` directory contains helper utilities

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -32,8 +32,12 @@ if test -z "${SRCDIR:-}"; then
 fi
 
 _cleanup_tmpdir () {
-    if test -f ${test_tmpdir}/.test; then
-        rm ${test_tmpdir} -rf
+    if test -z "${TEST_SKIP_CLEANUP:-}"; then
+	if test -f ${test_tmpdir}/.test; then
+           rm ${test_tmpdir} -rf
+	fi
+    else
+	echo "Skipping cleanup of ${test_tmpdir}"
     fi
 }
 
@@ -44,7 +48,9 @@ if ( test -n "${UNINSTALLEDTESTS:-}" || test -n "${VMTESTS:-}" ) && ! test -f $P
    touch ${test_tmpdir}/.test
    trap _cleanup_tmpdir EXIT
    cd ${test_tmpdir}
-   export PATH=${builddir}:${PATH}
+fi
+if test -n "${UNINSTALLEDTESTS:-}"; then
+    export PATH=${builddir}:${PATH}
 fi
 
 test_tmpdir=$(pwd)

--- a/tests/compose
+++ b/tests/compose
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+dn=$(cd $(dirname $0) && pwd)
+
+uid=$(id -u)
+test_compose_datadir=/var/tmp/rpmostree-compose-cache-${uid}
+export test_compose_datadir
+mkdir -p ${test_compose_datadir}
+datadir_owner=$(stat -c '%u' ${test_compose_datadir})
+test ${uid} = ${datadir_owner}
+
+# Pre-cache RPMs for each test, and share ostree repos between them for efficiency
+repo=${test_compose_datadir}/repo
+export repo
+ostree --repo=${repo} init --mode=archive
+repobuild=${test_compose_datadir}/repo-build
+export repobuild
+ostree --repo=${repobuild} init --mode=bare-user
+mkdir -p ${test_compose_datadir}/cache
+# Delete the default ref, since we want to use subrefs of it
+rm ${repobuild}/refs/heads/* -rf
+rpm-ostree compose --repo=${repobuild} tree --dry-run --cachedir=${test_compose_datadir}/cache ${dn}/composedata/fedora-base.json
+rm ${repobuild}/refs/heads/* -rf
+
+for testname in ${dn}/compose-tests/test*.sh; do
+    ${testname}
+done
+

--- a/tests/compose-tests/libcomposetest.sh
+++ b/tests/compose-tests/libcomposetest.sh
@@ -1,0 +1,40 @@
+dn=$(cd $(dirname $0) && pwd)
+. ${dn}/../common/libtest.sh
+test_tmpdir=$(mktemp -d /var/tmp/rpm-ostree-compose-test.XXXXXX)
+touch ${test_tmpdir}/.test
+trap _cleanup_tmpdir EXIT
+cd ${test_tmpdir}
+
+pyeditjson() {
+    cat >editjson.py <<EOF
+import sys,json
+jd=json.load(sys.stdin)
+${1}
+json.dump(jd,sys.stdout)
+EOF
+    python ./editjson.py && rm -f ./editjson.py
+}
+
+pysetjsonmember() {
+    pyeditjson "jd['"$1"'] = $2" < ${treefile} > ${treefile}.new && mv ${treefile}{.new,}
+}
+
+prepare_compose_test() {
+    name=$1
+    shift
+    cp -r ${dn}/../composedata .
+    export treefile=composedata/fedora-${name}.json
+    pyeditjson "jd['ref'] += \"/${name}\"" < composedata/fedora-base.json > ${treefile}
+    # FIXME extract from json
+    export treeref=fedora/25/x86_64/${name}
+}
+
+runcompose() {
+    rpm-ostree compose --repo=${repobuild} tree --cache-only --cachedir=${test_compose_datadir}/cache ${treefile}
+    ostree --repo=${repo} pull-local ${repobuild}
+}
+
+prepare_run_compose() {
+    prepare_compose_test $1
+    runcompose
+}

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+dn=$(cd $(dirname $0) && pwd)
+. ${dn}/libcomposetest.sh
+
+prepare_run_compose "basic"
+ostree --repo=${repobuild} ls -R ${treeref} /usr/lib/ostree-boot > bootls.txt
+assert_file_has_content bootls.txt vmlinuz
+assert_file_has_content bootls.txt initramfs
+
+ostree --repo=${repobuild} ls -R ${treeref} /usr/share/man > manpages.txt
+assert_file_has_content manpages.txt man5/ostree.repo.5

--- a/tests/compose-tests/test-nodocs.sh
+++ b/tests/compose-tests/test-nodocs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+dn=$(cd $(dirname $0) && pwd)
+. ${dn}/libcomposetest.sh
+
+prepare_compose_test "nodocs"
+pysetjsonmember "documentation" "False"
+runcompose
+
+ostree --repo=${repobuild} ls -R ${treeref} /usr/share/man > manpages.txt
+assert_not_file_has_content manpages.txt man5/ostree.repo.5
+

--- a/tests/composedata/fedora-25.repo
+++ b/tests/composedata/fedora-25.repo
@@ -1,0 +1,8 @@
+[fedora-25]
+name=Fedora 25 (devel) - $basearch
+failovermethod=priority
+baseurl=https://dl.fedoraproject.org/pub/fedora/linux/development/25/Everything/$basearch/os/
+enabled=1
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-25-$basearch
+skip_if_unavailable=False

--- a/tests/composedata/fedora-base.json
+++ b/tests/composedata/fedora-base.json
@@ -1,0 +1,19 @@
+{
+    "ref": "fedora/25/${basearch}",
+
+    "repos": ["fedora-25"],
+
+    "packages": ["kernel", "nss-altfiles", "systemd", "ostree", "selinux-policy-targeted"],
+
+    "packages-aarch64": ["grub2-efi", "ostree-grub2",
+                         "efibootmgr", "shim"],
+
+    "packages-armhfp": ["extlinux-bootloader"],
+
+    "packages-ppc64": ["grub2", "ostree-grub2"],
+
+    "packages-ppc64le": ["grub2", "ostree-grub2"],
+
+    "packages-x86_64": ["grub2", "grub2-efi", "ostree-grub2",
+                         "efibootmgr", "shim"]
+}

--- a/tests/composedata/treecompose-post.sh
+++ b/tests/composedata/treecompose-post.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+# Work around https://bugzilla.redhat.com/show_bug.cgi?id=1265295
+echo 'Storage=persistent' >> /etc/systemd/journald.conf
+
+# Work around https://github.com/systemd/systemd/issues/4082
+find /usr/lib/systemd/system/ -type f -exec sed -i -e '/^PrivateTmp=/d' -e '/^Protect\(Home\|System\)=/d' {} \;


### PR DESCRIPTION
Our current compose tests only use a synthetic `empty.rpm`, but
this really limits usefulness.

Let's make a test suite that requires an internet connection and
downloads Fedora RPMs and does "real" tree composes.

See the updated `tests/README.md` for more information.

This is still a WIP.