### PR TITLE
[merged] ci: --enable-new-name in clang test

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -56,6 +56,14 @@ env:
     CC: 'clang'
     CFLAGS: '-Werror=unused-variable'
 
+build:
+    config-opts: >
+      --prefix=/usr
+      --libdir=/usr/lib64
+      --enable-installed-tests
+      --enable-gtk-doc
+      --enable-new-name
+
 tests:
 artifacts:
 


### PR DESCRIPTION
So we have some coverage of this before merging.  I didn't make a
whole new context for this though, and it's only mildly useful
because we really want to test the daemon...but this is a start.