### PR TITLE
[merged] unpacker: Fix logic error regression in previous commit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,7 @@ CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
 	-Werror=pointer-arith -Werror=init-self \
         -Werror=missing-declarations \
         -Werror=return-type \
+        -Werror=parenthesis \
         -Werror=overflow \
         -Werror=int-conversion \
 	-Werror=missing-include-dirs -Werror=aggregate-return \

--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -590,8 +590,8 @@ compose_filter_cb (OstreeRepo         *repo,
   (void) get_rpmfi_override (self, path, &user, &group, NULL);
 
   /* First, look for non-root paths in /run and /var */
-  if ((user != NULL || group != NULL)
-      && g_str_has_prefix (path, "/run/") || g_str_has_prefix (path, "/var/"))
+  if ((user != NULL || group != NULL) &&
+      (g_str_has_prefix (path, "/run/") || g_str_has_prefix (path, "/var/")))
     {
       append_tmpfiles_d (self, path, file_info, user, group);
       return OSTREE_REPO_COMMIT_FILTER_SKIP;


### PR DESCRIPTION
I spotted this warning go by in the build logs.  Let's make it
fatal from now on.