### PR TITLE
[merged] postprocessing: Add a g_prefix_error for kernel

### DIFF
--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1001,7 +1001,10 @@ create_rootfs_from_yumroot_content (int            target_root_dfd,
 
   g_print ("Preparing kernel\n");
   if (!container && !do_kernel_prep (src_rootfs_fd, treefile, cancellable, error))
-    goto out;
+    {
+      g_prefix_error (error, "During kernel processing: ");
+      goto out;
+    }
   
   g_print ("Initializing rootfs\n");
   if (!init_rootfs (target_root_dfd, cancellable, error))


### PR DESCRIPTION
Saw this un-prefixed error path in a build; having error prefixes makes for easier debugging.