### PR TITLE
[merged] rebase: add support for rebasing to a specific rev

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure(2) do |config|
 
     if Vagrant.has_plugin?('vagrant-sshfs')
       config.vm.synced_folder ".", "/var/roothome/sync", type: 'sshfs'
-      File.write('.vagrant/using_sshfs', '')
+      File.write(__dir__ + '/.vagrant/using_sshfs', '')
     end
 
     # turn off the default rsync in the vagrant box

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -144,6 +144,7 @@
     <!-- Available options:
          "skip-purge" (type 'b')
          "reboot" (type 'b')
+         "revision" (type 's')
     -->
     <method name="Rebase">
       <arg type="a{sv}" name="options" direction="in"/>

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -649,6 +649,7 @@ os_handle_rebase (RPMOSTreeOS *interface,
   GVariantDict options_dict;
   gboolean opt_skip_purge = FALSE;
   const char *osname;
+  const char *opt_revision = NULL;
   gboolean opt_reboot = FALSE;
   GError *local_error = NULL;
 
@@ -683,6 +684,9 @@ os_handle_rebase (RPMOSTreeOS *interface,
   g_variant_dict_lookup (&options_dict,
                          "reboot", "b",
                          &opt_reboot);
+  g_variant_dict_lookup (&options_dict,
+                         "revision", "&s",
+                         &opt_revision);
 
   g_variant_dict_clear (&options_dict);
 
@@ -690,6 +694,7 @@ os_handle_rebase (RPMOSTreeOS *interface,
                                                    ot_sysroot,
                                                    osname,
                                                    arg_refspec,
+                                                   opt_revision,
                                                    opt_skip_purge,
                                                    opt_reboot,
                                                    cancellable,

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -59,6 +59,7 @@ RpmostreedTransaction *
                                                             OstreeSysroot *sysroot,
                                                             const char *osname,
                                                             const char *refspec,
+                                                            const char *revision,
                                                             gboolean skip_purge,
                                                             gboolean reboot,
                                                             GCancellable *cancellable,

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -341,6 +341,7 @@ os_repository_new_commit ()
     echo "content iteration ${content_iteration}" > usr/bin/content-iteration
 
     version=$(date "+%Y%m%d.${content_iteration}")
+    echo "version: $version"
 
     ostree --repo=${test_tmpdir}/testos-repo commit  --add-metadata-string "version=${version}" -b testos/buildmaster/x86_64-runtime -s "Build"
     cd ${test_tmpdir}

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -13,8 +13,7 @@ if test -z "${INSIDE_VM:-}"; then
 
     set -x
 
-    topdir=$(git rev-parse --show-toplevel)
-    cd ${topdir}
+    cd ${topsrcdir}
     rm insttree -rf
     make install DESTDIR=$(pwd)/insttree
     vm_rsync

--- a/tests/vmcheck/sync.sh
+++ b/tests/vmcheck/sync.sh
@@ -14,8 +14,7 @@ if test -z "${INSIDE_VM:-}"; then
 
     set -x
 
-    topdir=$(git rev-parse --show-toplevel)
-    cd ${topdir}
+    cd ${topsrcdir}
     rm insttree -rf
     make install DESTDIR=$(pwd)/insttree
     vm_rsync
@@ -28,5 +27,6 @@ else
     set -x
     ostree admin unlock || :
     rsync -rv /var/roothome/sync/insttree/usr/ /usr/
+    restorecon /usr/libexec/rpm-ostreed
     systemctl restart rpm-ostreed
 fi

--- a/vagrant/setup.yml
+++ b/vagrant/setup.yml
@@ -4,7 +4,7 @@
   become: yes
   tasks:
     - name: generate config
-      local_action: shell vagrant ssh-config > ssh-config
+      local_action: shell vagrant ssh-config > ../ssh-config
       become: no
 
     # The test suite requires direct ssh to root.


### PR DESCRIPTION
Expand the available options in the `Rebase()` D-Bus method to also have a
`revision` key. Its value has the same semantics as the `revision` key
in the `Deploy()` method (e.g. the `revision=` and `version=` prefixes are
also supported). Also expand the rebase CLI to specify this through a
new `--deploy` switch.

This allows users to rebase to a specific version or checksum, rather
than only to the latest. Conceptually, this is the equivalent of doing a
`rebase` followed by a `deploy`. I.e. we specify an `override-csum` and expect
the same behaviours that apply after a deploy to also apply here.

I had initially added support for this by expanding the `REFSPEC` non-opt
argument that rebase takes to mimic what ostree does, e.g.:

```
rpm-ostree rebase myremote:myref@myversion
```

But I didn't like the idea of confusing what a `REFSPEC` is (in the ostree
case, we don't actually specify a `REFSPEC` when using the `@` notation,
since the pull operation requires the remote to be specified separately
from the branch). It would also have looked confusing to specify e.g.
`REVISION=<sha>` or `VERSION=<version>` in the above syntax.

Closes: #212