### PR TITLE
[merged] Package layering: add full support for non-root ownership

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -86,7 +86,7 @@ timeout: 30m
 # which we don't have right now; so just provision a VM and do a
 # docker --privileged run.
 host:
-  distro: centos/7/atomic/alpha
+  distro: fedora/25/atomic
 
 tests:
   - >

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -97,7 +97,9 @@ vmsync:
 	@env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/sync.sh
 
 vmoverlay:
-	@env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/overlay.sh
+	@if [ -z "$(SKIP_VMOVERLAY)" ]; then \
+	  env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/overlay.sh; \
+	fi
 
 vmshell: vmsync
 	ssh -F ssh-config vmcheck

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -26,6 +26,7 @@ testpackages = \
 	tests/common/compose/yum/repo/packages/x86_64/foo-1.0-1.x86_64.rpm \
 	tests/common/compose/yum/repo/packages/x86_64/bar-1.0-1.x86_64.rpm \
 	tests/common/compose/yum/repo/packages/x86_64/scriptpkg1-1.0-1.x86_64.rpm \
+	tests/common/compose/yum/repo/packages/x86_64/nonrootcap-1.0-1.x86_64.rpm \
 	$(NULL)
 
 # Create a rule for each testpkg with their respective spec file as dep.

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -990,8 +990,9 @@ overlay_final_pkgset (RpmOstreeSysrootUpgrader *self,
 
   ctx = rpmostree_context_new_system (cancellable, error);
 
-  /* point libhif to the yum.repos.d and os-release of the merge_deployment */
-  { DnfContext *hifctx = rpmostree_context_get_hif (ctx);
+  /* pass merge deployment related values */
+  {
+    DnfContext *hifctx = rpmostree_context_get_hif (ctx);
     g_autofree char *sysroot_path =
       g_file_get_path (ostree_sysroot_get_path (self->sysroot));
     g_autofree char *merge_deployment_dirpath =
@@ -1001,8 +1002,15 @@ overlay_final_pkgset (RpmOstreeSysrootUpgrader *self,
       g_build_filename (sysroot_path, merge_deployment_dirpath, NULL);
     g_autofree char *reposdir = g_build_filename (merge_deployment_root,
                                                   "etc/yum.repos.d", NULL);
+    g_autofree char *passwddir = g_build_filename (merge_deployment_root,
+                                                  "etc", NULL);
+
+    /* point libhif to the yum.repos.d and os-release of the merge deployment */
     dnf_context_set_repo_dir (hifctx, reposdir);
     dnf_context_set_source_root (hifctx, tmprootfs);
+
+    /* point the core to the passwd & group of the merge deployment */
+    rpmostree_context_set_passwd_dir (ctx, passwddir);
   }
 
   /* load the sepolicy to use during import */

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -354,8 +354,10 @@ rpmostree_context_new_system (GCancellable *cancellable,
   dnf_context_set_http_proxy (self->hifctx, g_getenv ("http_proxy"));
 
   dnf_context_set_repo_dir (self->hifctx, "/etc/yum.repos.d");
-  /* Operating on stale metadata is too annoying */
-  dnf_context_set_cache_age (self->hifctx, 0);
+  /* Operating on stale metadata is too annoying -- but provide a way to
+   * override this for testing. */
+  if (g_getenv("RPMOSTREE_USE_CACHED_METADATA") == NULL)
+      dnf_context_set_cache_age (self->hifctx, 0);
   dnf_context_set_cache_dir (self->hifctx, "/var/cache/rpm-ostree/" RPMOSTREE_DIR_CACHE_REPOMD);
   dnf_context_set_solv_dir (self->hifctx, "/var/cache/rpm-ostree/" RPMOSTREE_DIR_CACHE_SOLV);
   dnf_context_set_lock_dir (self->hifctx, "/run/rpm-ostree/" RPMOSTREE_DIR_LOCK);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1980,9 +1980,8 @@ apply_rpmfi_overrides (int            tmp_metadata_dfd,
             return FALSE;
         }
 
-      /* also reapply chmod in case it was setuid */
-      if ((stbuf.st_mode & S_ISUID) &&
-          fchmodat (tmprootfs_dfd, fn, stbuf.st_mode, 0) != 0)
+      /* also reapply chmod since e.g. at least the setuid gets taken off */
+      if (fchmodat (tmprootfs_dfd, fn, stbuf.st_mode, 0) != 0)
         {
           glnx_set_prefix_error_from_errno (error, "%s", "fchmodat");
           return FALSE;

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -287,6 +287,7 @@ struct _RpmOstreeContext {
   gboolean unprivileged;
   char *dummy_instroot_path;
   OstreeSePolicy *sepolicy;
+  char *passwd_dir;
 };
 
 G_DEFINE_TYPE (RpmOstreeContext, rpmostree_context, G_TYPE_OBJECT)
@@ -302,12 +303,14 @@ rpmostree_context_finalize (GObject *object)
   if (rctx->dummy_instroot_path)
     {
       (void) glnx_shutil_rm_rf_at (AT_FDCWD, rctx->dummy_instroot_path, NULL, NULL);
-      g_free (rctx->dummy_instroot_path);
+      g_clear_pointer (&rctx->dummy_instroot_path, g_free);
     }
 
   g_clear_object (&rctx->ostreerepo);
 
   g_clear_object (&rctx->sepolicy);
+
+  g_clear_pointer (&rctx->passwd_dir, g_free);
 
   G_OBJECT_CLASS (rpmostree_context_parent_class)->finalize (object);
 }
@@ -466,6 +469,14 @@ rpmostree_context_set_sepolicy (RpmOstreeContext *self,
                                 OstreeSePolicy   *sepolicy)
 {
   g_set_object (&self->sepolicy, sepolicy);
+}
+
+void
+rpmostree_context_set_passwd_dir (RpmOstreeContext *self,
+                                  const char *passwd_dir)
+{
+  g_clear_pointer (&self->passwd_dir, g_free);
+  self->passwd_dir = g_strdup (passwd_dir);
 }
 
 void
@@ -2199,8 +2210,11 @@ rpmostree_context_assemble_commit (RpmOstreeContext      *self,
       g_autoptr(GHashTable) groupents = g_hash_table_new (g_str_hash,
                                                           g_str_equal);
 
-      if (!rpmostree_passwd_prepare_rpm_layering (tmprootfs_dfd, &have_passwd,
-                                                  cancellable, error))
+      if (!rpmostree_passwd_prepare_rpm_layering (tmprootfs_dfd,
+                                                  self->passwd_dir,
+                                                  &have_passwd,
+                                                  cancellable,
+                                                  error))
         goto out;
 
       /* Also neuter systemctl - at least glusterfs calls it

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -69,6 +69,8 @@ void rpmostree_context_set_repos (RpmOstreeContext *self,
                                   OstreeRepo       *pkgcache_repo);
 void rpmostree_context_set_sepolicy (RpmOstreeContext *self,
                                      OstreeSePolicy   *sepolicy);
+void rpmostree_context_set_passwd_dir (RpmOstreeContext *self,
+                                       const char *passwd_dir);
 void rpmostree_context_set_ignore_scripts (RpmOstreeContext *self,
                                            GHashTable   *ignore_scripts);
 

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -65,6 +65,7 @@ rpmostree_generate_passwd_from_previous (OstreeRepo      *repo,
 
 gboolean
 rpmostree_passwd_prepare_rpm_layering (int       rootfs_dfd,
+                                       const char        *merge_passwd_dir,
                                        gboolean          *out_have_passwd,
                                        GCancellable      *cancellable,
                                        GError  **error);

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -72,3 +72,20 @@ rpmostree_passwd_prepare_rpm_layering (int       rootfs_dfd,
 gboolean
 rpmostree_passwd_complete_rpm_layering (int       rootfs_dfd,
                                         GError  **error);
+
+struct conv_passwd_ent {
+  char *name;
+  uid_t uid;
+  gid_t gid;
+};
+
+struct conv_group_ent {
+  char *name;
+  gid_t gid;
+};
+
+GPtrArray *
+rpmostree_passwd_data2passwdents (const char *data);
+
+GPtrArray *
+rpmostree_passwd_data2groupents (const char *data);

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1542,7 +1542,7 @@ mutate_os_release (const char    *contents,
         continue;
 
       /* NB: we don't mutate VERSION_ID because some libraries expect well-known
-       * values there*/
+       * values there */
       if (g_str_has_prefix (line, "VERSION=") || \
           g_str_has_prefix (line, "PRETTY_NAME="))
         {

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -24,6 +24,7 @@
 
 #include <fnmatch.h>
 #include <sys/ioctl.h>
+#include <sys/capability.h>
 #include <libglnx.h>
 
 #include <rpm/rpmdb.h>
@@ -958,3 +959,69 @@ _rpmostree_reset_rpm_sighandlers (void)
 #endif
 }
 
+struct _cap_struct {
+    struct __user_cap_header_struct head;
+    union {
+        struct __user_cap_data_struct set;
+        __u32 flat[3];
+    } u[_LINUX_CAPABILITY_U32S_2];
+};
+
+/* Rewritten version of _fcaps_save from libcap, since it's not
+ * exposed, and we need to generate the raw value.
+ */
+static void
+cap_t_to_vfs (cap_t cap_d, struct vfs_cap_data *rawvfscap, int *out_size)
+{
+  guint32 eff_not_zero, magic;
+  guint tocopy, i;
+
+  /* Hardcoded to 2.  There is apparently a version 3 but it just maps
+   * to 2.  I doubt another version would ever be implemented, and
+   * even if it was we'd need to be backcompatible forever.  Anyways,
+   * setuid/fcaps binaries should go away entirely.
+   */
+  magic = VFS_CAP_REVISION_2;
+  tocopy = VFS_CAP_U32_2;
+  *out_size = XATTR_CAPS_SZ_2;
+
+  for (eff_not_zero = 0, i = 0; i < tocopy; i++)
+    eff_not_zero |= cap_d->u[i].flat[CAP_EFFECTIVE];
+
+  /* Here we're also not validating that the kernel understands
+   * the capabilities.
+   */
+
+  for (i = 0; i < tocopy; i++)
+    {
+      rawvfscap->data[i].permitted
+        = GUINT32_TO_LE(cap_d->u[i].flat[CAP_PERMITTED]);
+      rawvfscap->data[i].inheritable
+        = GUINT32_TO_LE(cap_d->u[i].flat[CAP_INHERITABLE]);
+    }
+
+  if (eff_not_zero == 0)
+    rawvfscap->magic_etc = GUINT32_TO_LE(magic);
+  else
+    rawvfscap->magic_etc = GUINT32_TO_LE(magic|VFS_CAP_FLAGS_EFFECTIVE);
+}
+
+GVariant *
+rpmostree_fcap_to_xattr_variant (const char *fcap)
+{
+  g_auto(GVariantBuilder) builder;
+  cap_t caps = cap_from_text (fcap);
+  struct vfs_cap_data vfscap = { 0, };
+  g_autoptr(GBytes) vfsbytes = NULL;
+  int vfscap_size;
+
+  cap_t_to_vfs (caps, &vfscap, &vfscap_size);
+  vfsbytes = g_bytes_new (&vfscap, vfscap_size);
+
+  g_variant_builder_init (&builder, (GVariantType*)"a(ayay)");
+  g_variant_builder_add (&builder, "(@ay@ay)",
+                         g_variant_new_bytestring ("security.capability"),
+                         g_variant_new_from_bytes ((GVariantType*)"ay",
+                                                   vfsbytes, FALSE));
+  return g_variant_ref_sink (g_variant_builder_end (&builder));
+}

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -153,3 +153,6 @@ rpmostree_print_transaction (DnfContext   *context);
 
 
 void _rpmostree_reset_rpm_sighandlers (void);
+
+GVariant *
+rpmostree_fcap_to_xattr_variant (const char *fcap);

--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -63,3 +63,11 @@ rpmostree_posttrans_run_sync (DnfPackage    *pkg,
                               int            rootfs_fd,
                               GCancellable  *cancellable,
                               GError       **error);
+
+gboolean
+rpmostree_pre_run_sync (DnfPackage    *pkg,
+                        Header         hdr,
+                        GHashTable    *ignore_scripts,
+                        int            rootfs_fd,
+                        GCancellable  *cancellable,
+                        GError       **error);

--- a/tests/common/compose/yum/nonrootcap.spec
+++ b/tests/common/compose/yum/nonrootcap.spec
@@ -1,0 +1,55 @@
+Summary: An app that uses has non-root files and caps
+Name: nonrootcap
+Version: 1.0
+Release: 1
+License: GPL+
+Group: Development/Tools
+URL: http://foo.bar.com
+BuildArch: x86_64
+
+%description
+%{summary}
+
+%prep
+
+%build
+cat > tmp << EOF
+#!/bin/sh
+echo "Hello!"
+EOF
+
+chmod a+x tmp
+cp tmp nrc-none.sh
+cp tmp nrc-user.sh
+cp tmp nrc-group.sh
+cp tmp nrc-caps.sh
+cp tmp nrc-usergroup.sh
+cp tmp nrc-usergroupcaps.sh
+rm tmp
+
+%pre
+groupadd -r nrcgroup
+useradd -r nrcuser -g nrcgroup -s /sbin/nologin
+
+%install
+mkdir -p %{buildroot}/usr/bin
+install *.sh %{buildroot}/usr/bin
+mkdir -p %{buildroot}/var/lib/nonrootcap
+mkdir -p %{buildroot}/run/nonrootcap
+
+%clean
+rm -rf %{buildroot}
+
+%files
+/usr/bin/nrc-none.sh
+%attr(-, nrcuser, -) /usr/bin/nrc-user.sh
+%attr(-, -, nrcgroup) /usr/bin/nrc-group.sh
+%caps(cap_net_bind_service=ep) /usr/bin/nrc-caps.sh
+%attr(-, nrcuser, nrcgroup) /usr/bin/nrc-usergroup.sh
+%attr(-, nrcuser, nrcgroup) %caps(cap_net_bind_service=ep) /usr/bin/nrc-usergroupcaps.sh
+%attr(-, nrcuser, nrcgroup) /var/lib/nonrootcap
+%attr(-, nrcuser, nrcgroup) /run/nonrootcap
+
+%changelog
+* Wed Jan 05 2017 Jonathan Lebon <jlebon@redhat.com> 1.0-1
+- First Build

--- a/tests/common/compose/yum/nonrootcap.spec
+++ b/tests/common/compose/yum/nonrootcap.spec
@@ -23,8 +23,10 @@ cp tmp nrc-none.sh
 cp tmp nrc-user.sh
 cp tmp nrc-group.sh
 cp tmp nrc-caps.sh
+cp tmp nrc-caps-setuid.sh
 cp tmp nrc-usergroup.sh
 cp tmp nrc-usergroupcaps.sh
+cp tmp nrc-usergroupcaps-setuid.sh
 rm tmp
 
 %pre
@@ -45,8 +47,10 @@ rm -rf %{buildroot}
 %attr(-, nrcuser, -) /usr/bin/nrc-user.sh
 %attr(-, -, nrcgroup) /usr/bin/nrc-group.sh
 %caps(cap_net_bind_service=ep) /usr/bin/nrc-caps.sh
+%attr(4775, -, -) %caps(cap_net_bind_service=ep) /usr/bin/nrc-caps-setuid.sh
 %attr(-, nrcuser, nrcgroup) /usr/bin/nrc-usergroup.sh
 %attr(-, nrcuser, nrcgroup) %caps(cap_net_bind_service=ep) /usr/bin/nrc-usergroupcaps.sh
+%attr(4775, nrcuser, nrcgroup) %caps(cap_net_bind_service=ep) /usr/bin/nrc-usergroupcaps-setuid.sh
 %attr(-, nrcuser, nrcgroup) /var/lib/nonrootcap
 %attr(-, nrcuser, nrcgroup) /run/nonrootcap
 

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -62,6 +62,7 @@ vm_send() {
 
 # copy the test repo to the vm
 vm_send_test_repo() {
+  vm_cmd rm -rf /tmp/vmcheck
   vm_send /tmp/vmcheck ${commondir}/compose/yum/repo
 
   cat > vmcheck.repo << EOF
@@ -103,8 +104,8 @@ vm_reboot() {
   vm_ssh_wait 120 $bootid
 }
 
-# check that the given files exist on the VM
-# - $@    packages to check for
+# check that the given files/dirs exist on the VM
+# - $@    files/dirs to check for
 vm_has_files() {
   for file in "$@"; do
     if ! vm_cmd test -e $file; then

--- a/tests/compose
+++ b/tests/compose
@@ -5,6 +5,9 @@ dn=$(cd $(dirname $0) && pwd)
 
 export topsrcdir=$(cd $dn/.. && pwd)
 
+# avoid refetching yum metadata everytime
+export RPMOSTREE_USE_CACHED_METADATA=1
+
 LOG=${LOG:-compose.log}
 date > ${LOG}
 

--- a/tests/vmcheck/test-layering-non-root-caps.sh
+++ b/tests/vmcheck/test-layering-non-root-caps.sh
@@ -92,3 +92,4 @@ check_file /usr/bin/nrc-usergroup.sh nrcuser nrcgroup ""
 check_file /usr/bin/nrc-usergroupcaps.sh nrcuser nrcgroup "cap_net_bind_service+ep"
 check_file /var/lib/nonrootcap nrcuser nrcgroup
 check_file /run/nonrootcap nrcuser nrcgroup
+echo "ok correct user/group and fcaps"

--- a/tests/vmcheck/test-layering-non-root-caps.sh
+++ b/tests/vmcheck/test-layering-non-root-caps.sh
@@ -88,8 +88,12 @@ check_file /usr/bin/nrc-none.sh root root ""
 check_file /usr/bin/nrc-user.sh nrcuser root ""
 check_file /usr/bin/nrc-group.sh root nrcgroup ""
 check_file /usr/bin/nrc-caps.sh root root "cap_net_bind_service+ep"
+check_file /usr/bin/nrc-caps-setuid.sh root root "cap_net_bind_service+ep"
+vm_cmd test -u /usr/bin/nrc-caps-setuid.sh
 check_file /usr/bin/nrc-usergroup.sh nrcuser nrcgroup ""
 check_file /usr/bin/nrc-usergroupcaps.sh nrcuser nrcgroup "cap_net_bind_service+ep"
+check_file /usr/bin/nrc-usergroupcaps-setuid.sh nrcuser nrcgroup "cap_net_bind_service+ep"
+vm_cmd test -u /usr/bin/nrc-usergroupcaps-setuid.sh
 check_file /var/lib/nonrootcap nrcuser nrcgroup
 check_file /run/nonrootcap nrcuser nrcgroup
 echo "ok correct user/group and fcaps"

--- a/tests/vmcheck/test-layering-non-root-caps.sh
+++ b/tests/vmcheck/test-layering-non-root-caps.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Jonathan Lebon <jlebon@redhat.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# SUMMARY: check that RPM scripts are properly handled during package layering
+
+vm_send_test_repo
+
+# make sure the package is not already layered
+vm_assert_layered_pkg nonrootcap absent
+
+vm_cmd rpm-ostree install nonrootcap
+echo "ok install nonrootcap"
+
+vm_reboot
+
+vm_assert_layered_pkg nonrootcap present
+echo "ok pkg nonrootcap added"
+
+# let's check that the user and group were successfully added
+vm_cmd getent passwd nrcuser
+vm_cmd getent group nrcgroup
+echo "ok user and group added"
+
+if ! vm_has_files /usr/bin/nrc-none.sh \
+                  /usr/bin/nrc-user.sh \
+                  /usr/bin/nrc-group.sh \
+                  /usr/bin/nrc-caps.sh \
+                  /usr/bin/nrc-usergroup.sh \
+                  /usr/bin/nrc-usergroupcaps.sh \
+                  /var/lib/nonrootcap \
+                  /run/nonrootcap; then
+  assert_not_reached "not all files were layered"
+fi
+echo "ok all files layered"
+
+check_user() {
+  user=$(vm_cmd stat -c '%U' $1)
+  if [[ $user != $2 ]]; then
+    assert_not_reached "expected user $2 on file $1 but got $user"
+  fi
+}
+
+check_group() {
+  group=$(vm_cmd stat -c '%G' $1)
+  if [[ $group != $2 ]]; then
+    assert_not_reached "expected group $2 on file $1 but got $group"
+  fi
+}
+
+check_fcap() {
+  fcap=$(vm_cmd getcap $1)
+  fcap=${fcap#* = } # trim filename
+  if [[ $fcap != $2 ]]; then
+    assert_not_reached "expected fcaps $2 on file $1 but got $fcap"
+  fi
+}
+
+check_file() {
+  check_user $1 $2
+  check_group $1 $3
+  check_fcap $1 $4
+}
+
+check_file /usr/bin/nrc-none.sh root root ""
+check_file /usr/bin/nrc-user.sh nrcuser root ""
+check_file /usr/bin/nrc-group.sh root nrcgroup ""
+check_file /usr/bin/nrc-caps.sh root root "cap_net_bind_service+ep"
+check_file /usr/bin/nrc-usergroup.sh nrcuser nrcgroup ""
+check_file /usr/bin/nrc-usergroupcaps.sh nrcuser nrcgroup "cap_net_bind_service+ep"
+check_file /var/lib/nonrootcap nrcuser nrcgroup
+check_file /run/nonrootcap nrcuser nrcgroup


### PR DESCRIPTION
PR #432 added support for non-root ownership of `/run` and `/var` directories. This PR builds upon that work and extends support for non-root ownership of files and directories in `/usr`.

Add a test RPM and vmcheck test case to cover these new paths.