### PR TITLE
[merged] bwrap: Turn on all namespaces

### DIFF
--- a/src/libpriv/rpmostree-bwrap.c
+++ b/src/libpriv/rpmostree-bwrap.c
@@ -203,6 +203,15 @@ rpmostree_bwrap_new (int rootfs_fd,
                                      "--ro-bind", "/sys/class", "/sys/class",
                                      "--ro-bind", "/sys/dev", "/sys/dev",
                                      "--ro-bind", "/sys/devices", "/sys/devices",
+                                     /* Here we do all namespaces except the user one.
+                                      * Down the line we want to do a userns too I think,
+                                      * but it may need some mapping work.
+                                      */
+                                     "--unshare-pid",
+                                     "--unshare-net",
+                                     "--unshare-uts",
+                                     "--unshare-ipc",
+                                     "--unshare-cgroup-try",
                                      NULL);
 
   for (guint i = 0; i < G_N_ELEMENTS (usr_links); i++)


### PR DESCRIPTION
The fact we weren't doing this is an oversight.  We should *really*
be using the PID namespace at a minimum, but I decided to just turn
them all on.

The one that seems most likely to potentially introduce a regression is turning
on the netns (i.e. disabling networking). But I can't really think of what we'd
be running in a script today that would break in practice.
