### PR TITLE
[merged] Suppress uid == 0 check in unit tests

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -126,7 +126,8 @@ rpmostree_option_context_parse (GOptionContext *context,
   use_daemon = ((flags & RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD) == 0);
 
   if ((flags & RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT) > 0
-      && getuid () != 0)
+      && getuid () != 0
+      && getenv ("RPMOSTREE_SUPRESS_REQUIRES_ROOT_CHECK") == NULL)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                    "This command requires root privileges");

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -127,7 +127,7 @@ rpmostree_option_context_parse (GOptionContext *context,
 
   if ((flags & RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT) > 0
       && getuid () != 0
-      && getenv ("RPMOSTREE_SUPRESS_REQUIRES_ROOT_CHECK") == NULL)
+      && getenv ("RPMOSTREE_SUPPRESS_REQUIRES_ROOT_CHECK") == NULL)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                    "This command requires root privileges");

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -20,7 +20,7 @@
 set -e
 
 . ${commondir}/libtest.sh
-export RPMOSTREE_SUPRESS_REQUIRES_ROOT_CHECK=yes
+export RPMOSTREE_SUPPRESS_REQUIRES_ROOT_CHECK=yes
 
 ensure_dbus
 

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -20,6 +20,7 @@
 set -e
 
 . ${commondir}/libtest.sh
+export RPMOSTREE_SUPRESS_REQUIRES_ROOT_CHECK=yes
 
 ensure_dbus
 


### PR DESCRIPTION
Our `make check` runs an unprivileged rpm-ostreed if run as non-root; this is a
feature. We didn't notice in the CI tests since those run as "docker-uid0". It
does break my local workflow though.
