### PR TITLE
[merged] Support "system/regenerate-initramfs=true" flag in origin

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -77,6 +77,8 @@ artifacts:
   - vmcheck.log
   - vmcheck-journal.txt
 
+timeout: 1h
+
 ---
 
 context: compose

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -27,6 +27,7 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-builtin-rollback.c \
 	src/app/rpmostree-builtin-deploy.c \
 	src/app/rpmostree-builtin-rebase.c \
+  src/app/rpmostree-builtin-initramfs.c \
 	src/app/rpmostree-pkg-builtins.c \
 	src/app/rpmostree-builtin-status.c \
 	src/app/rpmostree-builtin-internals.c \

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -334,6 +334,38 @@ Boston, MA 02111-1307, USA.
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><command>initramfs</command></term>
+
+        <listitem>
+          <para>
+            By default, the primary use case mode for rpm-ostree is to replicate
+            an initramfs as part of a base layer. However, some use cases
+            require locally regenerating it to add configuration or drivers. Use
+            <command>rpm-ostree initramfs</command> to inspect the current
+            status.
+          </para>
+
+          <para>
+            Use <command>--enable</command> to turn on client side initramfs
+            regeneration. A new deployment will be generated, and after reboot,
+            further upgrades will continue regenerating. You must reboot for the
+            new initramfs to take effect.
+          </para>
+
+          <para>
+            To append additional custom arguments to the initramfs program
+            (currently dracut), use <command>--arg</command>. For example,
+            <command>--arg=-I --arg=/etc/someconfigfile</command>.
+          </para>
+
+          <para>
+            The <command>--disable</command> option will disable
+            regeneration.  You must reboot for the change to take effect.
+          </para>
+        </listitem>
+      </varlistentry>
+
     </variablelist>
   </refsect1>
 

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -43,6 +43,7 @@ static RpmOstreeCommand supported_commands[] = {
   { "rollback", rpmostree_builtin_rollback },
   { "status", rpmostree_builtin_status },
   { "upgrade", rpmostree_builtin_upgrade },
+  { "initramfs", rpmostree_builtin_initramfs },
   { "install", rpmostree_builtin_pkg_add },
   { "uninstall", rpmostree_builtin_pkg_remove },
   { NULL }

--- a/src/app/rpmostree-builtin-initramfs.c
+++ b/src/app/rpmostree-builtin-initramfs.c
@@ -1,0 +1,153 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Colin Walters <walters@verbum.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <glib-unix.h>
+
+#include "rpmostree-builtins.h"
+#include "rpmostree-libbuiltin.h"
+#include "rpmostree-dbus-helpers.h"
+
+#include <libglnx.h>
+
+static gboolean opt_enable;
+static gboolean opt_disable;
+static char **opt_add_arg;
+
+static GOptionEntry option_entries[] = {
+  { "enable", 0, 0, G_OPTION_ARG_NONE, &opt_enable, "Enable regenerating initramfs locally", NULL },
+  { "arg", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_add_arg, "Append ARG to the dracut arguments", "ARG" },
+  { "disable", 0, 0, G_OPTION_ARG_NONE, &opt_disable, "Disable regenerating initramfs locally", NULL },
+  { NULL }
+};
+
+int
+rpmostree_builtin_initramfs (int             argc,
+                             char          **argv,
+                             GCancellable   *cancellable,
+                             GError        **error)
+{
+  int exit_status = EXIT_FAILURE;
+  g_autoptr(GOptionContext) context = g_option_context_new ("- Enable or disable local initramfs regeneration");
+  glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
+  glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
+  g_autofree char *transaction_address = NULL;
+  g_autoptr(GVariantBuilder) opts_builder = g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
+
+  if (!rpmostree_option_context_parse (context,
+                                       option_entries,
+                                       &argc, &argv,
+                                       RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
+                                       cancellable,
+                                       &sysroot_proxy,
+                                       error))
+    goto out;
+
+  if (!rpmostree_load_os_proxy (sysroot_proxy, NULL,
+                                cancellable, &os_proxy, error))
+    goto out;
+
+  if (!(opt_enable || opt_disable))
+    {
+      GVariantIter iter;
+      g_autoptr(GVariant) deployments = rpmostree_sysroot_dup_deployments (sysroot_proxy);
+
+      g_variant_iter_init (&iter, deployments);
+
+      while (TRUE)
+        {
+          gboolean cur_regenerate;
+          g_autoptr(GVariant) child = g_variant_iter_next_value (&iter);
+          g_autoptr(GVariantDict) dict = NULL;
+          g_autofree char **initramfs_args = NULL;
+          gboolean is_booted;
+
+          if (child == NULL)
+            break;
+
+          dict = g_variant_dict_new (child);
+
+          if (!g_variant_dict_lookup (dict, "booted", "b", &is_booted))
+            continue;
+          if (!is_booted)
+            continue;
+
+          if (!g_variant_dict_lookup (dict, "regenerate-initramfs", "b", &cur_regenerate))
+            cur_regenerate = FALSE;
+          if (cur_regenerate)
+            {
+              g_variant_dict_lookup (dict, "initramfs-args", "^a&s", &initramfs_args);
+            }
+
+          g_print ("Initramfs regeneration: %s\n", cur_regenerate ? "enabled" : "disabled");
+          if (initramfs_args)
+            {
+              g_print ("Initramfs args: ");
+              for (char **iter = initramfs_args; iter && *iter; iter++)
+                g_print ("%s ", *iter);
+              g_print ("\n");
+            }
+        }
+    }
+  else if (opt_enable && opt_disable)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "Cannot simultaenously specify --enable and --disable");
+      goto out;
+    }
+  else
+    {
+      char *empty_strv[] = {NULL};
+      if (opt_disable && opt_add_arg)
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Cannot simultaenously specify --disable and --arg");
+          goto out;
+        }
+      if (!opt_add_arg)
+        opt_add_arg = empty_strv;
+      if (!rpmostree_os_call_set_initramfs_state_sync (os_proxy,
+                                                       opt_enable,
+                                                       (const char *const*)opt_add_arg,
+                                                       g_variant_builder_end (opts_builder),
+                                                       &transaction_address,
+                                                       cancellable,
+                                                       error))
+        goto out;
+
+      if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
+                                                    transaction_address,
+                                                    cancellable,
+                                                    error))
+        goto out;
+
+      g_print ("Initramfs regeneration is now: %s\n", opt_enable ? "enabled" : "disabled");
+    }
+
+  exit_status = EXIT_SUCCESS;
+
+out:
+  /* Does nothing if using the message bus. */
+  rpmostree_cleanup_peer ();
+
+  return exit_status;
+}

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -47,6 +47,7 @@ BUILTINPROTO(upgrade);
 BUILTINPROTO(deploy);
 BUILTINPROTO(rebase);
 BUILTINPROTO(rollback);
+BUILTINPROTO(initramfs);
 BUILTINPROTO(status);
 BUILTINPROTO(db);
 BUILTINPROTO(internals);

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -181,6 +181,13 @@
       <arg type="s" name="transaction_address" direction="out"/>
     </method>
 
+    <method name="SetInitramfsState">
+      <arg type="b" name="regenerate" direction="in"/>
+      <arg type="as" name="args" direction="in"/>
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="s" name="transaction_address" direction="out"/>
+    </method>
+
   </interface>
 
   <interface name="org.projectatomic.rpmostree1.Transaction">

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -940,8 +940,7 @@ overlay_final_pkgset (RpmOstreeSysrootUpgrader *self,
   g_autoptr(RpmOstreeTreespec) treespec = NULL;
   g_autoptr(RpmOstreeInstall) install = {0,};
   g_autoptr(GHashTable) pkgset = hashset_from_strv (rpmostree_origin_get_packages (self->origin));
-  const gboolean have_packages = g_hash_table_size (pkgset) > 0 ||
-    g_hash_table_size (self->packages_to_add) > 0;
+  const gboolean have_packages = g_hash_table_size (pkgset) > 0;
   glnx_unref_object OstreeRepo *pkgcache_repo = NULL;
 
   ctx = rpmostree_context_new_system (cancellable, error);

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -219,6 +219,13 @@ rpmostreed_deployment_generate_variant (OstreeDeployment *deployment,
   g_variant_dict_insert (&dict, "unlocked", "s",
 			 ostree_deployment_unlocked_state_to_string (ostree_deployment_get_unlocked (deployment)));
 
+  g_variant_dict_insert (&dict, "regenerate-initramfs", "b",
+                         rpmostree_origin_get_regenerate_initramfs (origin));
+  { g_auto(GStrv) args = rpmostree_origin_get_initramfs_args (origin);
+    if (args && *args)
+      g_variant_dict_insert (&dict, "initramfs-args", "^as", args);
+  }
+
   if (booted_id != NULL)
     g_variant_dict_insert (&dict, "booted", "b", g_strcmp0 (booted_id, id) == 0);
 

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -781,7 +781,9 @@ os_handle_set_initramfs_state (RPMOSTreeOS *interface,
   glnx_unref_object RpmostreedTransaction *transaction = NULL;
   glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
   g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  g_autoptr(GVariantDict) dict = NULL;
   const char *osname;
+  gboolean reboot = FALSE;
   GError *local_error = NULL;
 
   transaction = merge_compatible_txn (self, invocation);
@@ -797,11 +799,15 @@ os_handle_set_initramfs_state (RPMOSTreeOS *interface,
 
   osname = rpmostree_os_get_name (interface);
 
+  dict = g_variant_dict_new (arg_options);
+  g_variant_dict_lookup (dict, "reboot", "b", &reboot);
+
   transaction = rpmostreed_transaction_new_initramfs_state (invocation,
                                                             ot_sysroot,
                                                             osname,
                                                             regenerate,
                                                             (char**)args,
+                                                            reboot,
                                                             cancellable,
                                                             &local_error);
   if (transaction == NULL)

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -771,6 +771,60 @@ out:
 }
 
 static gboolean
+os_handle_set_initramfs_state (RPMOSTreeOS *interface,
+                               GDBusMethodInvocation *invocation,
+                               gboolean regenerate,
+                               const char *const*args,
+                               GVariant *arg_options)
+{
+  RpmostreedOS *self = RPMOSTREED_OS (interface);
+  glnx_unref_object RpmostreedTransaction *transaction = NULL;
+  glnx_unref_object OstreeSysroot *ot_sysroot = NULL;
+  g_autoptr(GCancellable) cancellable = g_cancellable_new ();
+  const char *osname;
+  GError *local_error = NULL;
+
+  transaction = merge_compatible_txn (self, invocation);
+  if (transaction)
+    goto out;
+
+  if (!rpmostreed_sysroot_load_state (rpmostreed_sysroot_get (),
+                                      cancellable,
+                                      &ot_sysroot,
+                                      NULL,
+                                      &local_error))
+    goto out;
+
+  osname = rpmostree_os_get_name (interface);
+
+  transaction = rpmostreed_transaction_new_initramfs_state (invocation,
+                                                            ot_sysroot,
+                                                            osname,
+                                                            regenerate,
+                                                            (char**)args,
+                                                            cancellable,
+                                                            &local_error);
+  if (transaction == NULL)
+    goto out;
+
+  rpmostreed_transaction_monitor_add (self->transaction_monitor, transaction);
+
+out:
+  if (local_error != NULL)
+    {
+      g_dbus_method_invocation_take_error (invocation, local_error);
+    }
+  else
+    {
+      const char *client_address;
+      client_address = rpmostreed_transaction_get_client_address (transaction);
+      rpmostree_os_complete_pkg_change (interface, invocation, client_address);
+    }
+
+  return TRUE;
+}
+
+static gboolean
 os_handle_get_cached_rebase_rpm_diff (RPMOSTreeOS *interface,
                                       GDBusMethodInvocation *invocation,
                                       const char *arg_refspec,
@@ -1154,6 +1208,7 @@ rpmostreed_os_iface_init (RPMOSTreeOSIface *iface)
   iface->handle_clear_rollback_target      = os_handle_clear_rollback_target;
   iface->handle_rebase                     = os_handle_rebase;
   iface->handle_pkg_change                 = os_handle_pkg_change;
+  iface->handle_set_initramfs_state        = os_handle_set_initramfs_state;
   iface->handle_get_cached_rebase_rpm_diff = os_handle_get_cached_rebase_rpm_diff;
   iface->handle_download_rebase_rpm_diff   = os_handle_download_rebase_rpm_diff;
   iface->handle_get_cached_deploy_rpm_diff = os_handle_get_cached_deploy_rpm_diff;

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1058,6 +1058,7 @@ typedef struct {
   char *osname;
   gboolean regenerate;
   char **args;
+  gboolean reboot;
 } InitramfsStateTransaction;
 
 typedef RpmostreedTransactionClass InitramfsStateTransactionClass;
@@ -1127,6 +1128,9 @@ initramfs_state_transaction_execute (RpmostreedTransaction *transaction,
   if (!rpmostree_sysroot_upgrader_deploy (upgrader, cancellable, error))
     return FALSE;
 
+  if (self->reboot)
+    rpmostreed_reboot (cancellable, error);
+
   return TRUE;
 }
 
@@ -1152,6 +1156,7 @@ rpmostreed_transaction_new_initramfs_state (GDBusMethodInvocation *invocation,
                                             const char *osname,
                                             gboolean regenerate,
                                             char **args,
+                                            gboolean reboot,
                                             GCancellable *cancellable,
                                             GError **error)
 {
@@ -1171,6 +1176,7 @@ rpmostreed_transaction_new_initramfs_state (GDBusMethodInvocation *invocation,
       self->osname = g_strdup (osname);
       self->regenerate = regenerate;
       self->args = g_strdupv (args);
+      self->reboot = reboot;
     }
 
   return (RpmostreedTransaction *) self;

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -90,3 +90,11 @@ RpmostreedTransaction *
 							    RpmOstreeTransactionPkgFlags flags,
                                                             GCancellable          *cancellable,
                                                             GError               **error);
+RpmostreedTransaction *
+rpmostreed_transaction_new_initramfs_state       (GDBusMethodInvocation *invocation,
+                                                  OstreeSysroot         *sysroot,
+                                                  const char            *osname,
+                                                  gboolean               regenerate,
+                                                  char                 **args,
+                                                  GCancellable          *cancellable,
+                                                  GError               **error);

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -96,5 +96,6 @@ rpmostreed_transaction_new_initramfs_state       (GDBusMethodInvocation *invocat
                                                   const char            *osname,
                                                   gboolean               regenerate,
                                                   char                 **args,
+                                                  gboolean               reboot,
                                                   GCancellable          *cancellable,
                                                   GError               **error);

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -64,6 +64,8 @@ gboolean rpmostree_context_setup (RpmOstreeContext     *self,
                                   GCancellable  *cancellable,
                                   GError       **error);
 
+void rpmostree_context_set_is_empty (RpmOstreeContext *self);
+
 void rpmostree_context_set_repos (RpmOstreeContext *self,
                                   OstreeRepo       *base_repo,
                                   OstreeRepo       *pkgcache_repo);

--- a/src/libpriv/rpmostree-kernel.h
+++ b/src/libpriv/rpmostree-kernel.h
@@ -40,6 +40,7 @@ rpmostree_finalize_kernel (int rootfs_dfd,
 gboolean
 rpmostree_run_dracut (int     rootfs_dfd,
                       char   **argv,
+                      const char *rebuild_from_initramfs,
                       int     *out_initramfs_tmpfd,
                       char   **out_initramfs_tmppath,
                       GCancellable  *cancellable,

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -28,18 +28,18 @@ void rpmostree_origin_unref (RpmOstreeOrigin *origin);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeOrigin, rpmostree_origin_unref)
 
 typedef enum {
-  RPMOSTREE_ORIGIN_FLAGS_IGNORE_UNCONFIGURED = (1 << 0)
-} RpmOstreeOriginFlags;
+  RPMOSTREE_ORIGIN_PARSE_FLAGS_IGNORE_UNCONFIGURED = (1 << 0)
+} RpmOstreeOriginParseFlags;
 
 RpmOstreeOrigin *
 rpmostree_origin_parse_keyfile (GKeyFile *keyfile,
-                                RpmOstreeOriginFlags flags,
+                                RpmOstreeOriginParseFlags flags,
                                 GError **error);
 
 static inline
 RpmOstreeOrigin *
 rpmostree_origin_parse_deployment_ex (OstreeDeployment *deployment,
-                                      RpmOstreeOriginFlags flags,
+                                      RpmOstreeOriginParseFlags flags,
                                       GError **error)
 {
   GKeyFile *origin = ostree_deployment_get_origin (deployment);
@@ -74,6 +74,12 @@ rpmostree_origin_get_packages (RpmOstreeOrigin *origin);
 const char *
 rpmostree_origin_get_override_commit (RpmOstreeOrigin *origin);
 
+gboolean
+rpmostree_origin_get_regenerate_initramfs (RpmOstreeOrigin *origin);
+
+char **
+rpmostree_origin_get_initramfs_args (RpmOstreeOrigin *origin);
+
 char *
 rpmostree_origin_get_string (RpmOstreeOrigin *origin,
                              const char *section,
@@ -84,3 +90,6 @@ rpmostree_origin_get_keyfile (RpmOstreeOrigin *origin);
 GKeyFile *
 rpmostree_origin_dup_keyfile (RpmOstreeOrigin *origin);
 
+void rpmostree_origin_set_regenerate_initramfs (GKeyFile *mutable_origin,
+                                                gboolean regenerate,
+                                                char **args);

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -206,7 +206,7 @@ do_kernel_prep (int            rootfs_dfd,
       }
     g_ptr_array_add (dracut_argv, NULL);
 
-    if (!rpmostree_run_dracut (rootfs_dfd, (char**)dracut_argv->pdata,
+    if (!rpmostree_run_dracut (rootfs_dfd, (char**)dracut_argv->pdata, NULL,
                                &initramfs_tmp_fd, &initramfs_tmp_path,
                                cancellable, error))
       goto out;

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -112,12 +112,17 @@ vm_get_boot_id() {
   vm_cmd cat /proc/sys/kernel/random/boot_id
 }
 
+# Run a command in the VM that will cause a reboot
+vm_reboot_cmd() {
+    vm_cmd sync
+    bootid=$(vm_get_boot_id 2>/dev/null)
+    vm_cmd $@ || :
+    vm_ssh_wait 120 $bootid
+}
+
 # reboot the vm
 vm_reboot() {
-  vm_cmd sync
-  bootid=$(vm_get_boot_id 2>/dev/null)
-  vm_cmd systemctl reboot || :
-  vm_ssh_wait 120 $bootid
+  vm_reboot_cmd systemctl reboot
 }
 
 # check that the given files/dirs exist on the VM

--- a/tests/vmcheck/test-initramfs.sh
+++ b/tests/vmcheck/test-initramfs.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# SUMMARY: Tests for the `initramfs` functionality
+
+assert_jq() {
+    expression=$1
+    jsonfile=$2
+
+    if ! jq -e "${expression}" >/dev/null < $jsonfile; then
+        jq . < $jsonfile | sed -e 's/^/# /' >&2
+        echo 1>&2 "${expression} failed to match in $jsonfile"
+        exit 1
+    fi
+}
+
+vm_send_test_repo
+base=$(vm_get_booted_csum)
+
+vm_cmd rpm-ostree initramfs > initramfs.txt
+assert_file_has_content initramfs.txt "Initramfs regeneration.*disabled"
+echo "ok initramfs status"
+
+if vm_cmd rpm-ostree initramfs --disable 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at disabling"
+fi
+assert_file_has_content err.txt "already.*disabled"
+echo "ok initramfs state"
+
+vm_cmd rpm-ostree initramfs --enable
+vm_cmd rpm-ostree status --json > status.json
+assert_jq '.deployments[1].booted' status.json
+assert_jq '.deployments[0]["regenerate-initramfs"]' status.json
+assert_jq '.deployments[1]["regenerate-initramfs"]|not' status.json
+
+vm_reboot
+
+assert_not_streq $base $(vm_get_booted_csum)
+vm_cmd rpm-ostree status --json > status.json
+assert_jq '.deployments[0].booted' status.json
+assert_jq '.deployments[0]["regenerate-initramfs"]' status.json
+assert_jq '.deployments[0]["initramfs-args"]|length == 0' status.json
+assert_jq '.deployments[1]["regenerate-initramfs"]|not' status.json
+assert_jq '.deployments[1]["initramfs-args"]|not' status.json
+
+if vm_cmd rpm-ostree initramfs --enable 2>err.txt; then
+    assert_not_reached "Unexpectedly succeeded at enabling"
+fi
+assert_file_has_content err.txt "already.*enabled"
+echo "ok initramfs enabled"
+
+vm_cmd rpm-ostree initramfs --disable
+vm_reboot
+
+vm_cmd rpm-ostree status --json > status.json
+assert_jq '.deployments[0].booted' status.json
+assert_jq '.deployments[0]["regenerate-initramfs"]|not' status.json
+assert_jq '.deployments[1]["regenerate-initramfs"]' status.json
+assert_streq $base $(vm_get_booted_csum)
+
+echo "ok initramfs disabled"
+
+for file in first second; do
+    vm_cmd touch /etc/rpmostree-initramfs-testing-$file
+    vm_cmd rpm-ostree initramfs --enable --arg="-I" --arg="/etc/rpmostree-initramfs-testing-$file"
+    vm_reboot
+    vm_cmd rpm-ostree status --json > status.json
+    assert_jq '.deployments[0].booted' status.json
+    assert_jq '.deployments[0]["regenerate-initramfs"]' status.json
+    assert_jq '.deployments[0]["initramfs-args"]|index("-I") == 0' status.json
+    assert_jq '.deployments[0]["initramfs-args"]|index("/etc/rpmostree-initramfs-testing-'${file}'") == 1' status.json
+    assert_jq '.deployments[0]["initramfs-args"]|length == 2' status.json
+    initramfs=$(vm_cmd grep ^initrd /boot/loader/entries/ostree-fedora-atomic-0.conf | sed -e 's,initrd ,/boot/,')
+    test -n "${initramfs}"
+    vm_cmd lsinitrd $initramfs > lsinitrd.txt
+    assert_file_has_content lsinitrd.txt /etc/rpmostree-initramfs-testing-${file}
+done
+
+vm_cmd rpm-ostree initramfs --disable
+
+initramfs=$(vm_cmd grep ^initrd /boot/loader/entries/ostree-fedora-atomic-0.conf | sed -e 's,initrd ,/boot/,')
+test -n "${initramfs}"
+vm_cmd lsinitrd $initramfs > lsinitrd.txt
+assert_not_file_has_content lsinitrd.txt /etc/rpmostree-initramfs-testing
+
+echo "ok initramfs args"

--- a/tests/vmcheck/test-initramfs.sh
+++ b/tests/vmcheck/test-initramfs.sh
@@ -40,18 +40,18 @@ assert_jq() {
 vm_send_test_repo
 base=$(vm_get_booted_csum)
 
-vm_cmd rpm-ostree initramfs > initramfs.txt
+vm_rpmostree initramfs > initramfs.txt
 assert_file_has_content initramfs.txt "Initramfs regeneration.*disabled"
 echo "ok initramfs status"
 
-if vm_cmd rpm-ostree initramfs --disable 2>err.txt; then
+if vm_rpmostree initramfs --disable 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at disabling"
 fi
 assert_file_has_content err.txt "already.*disabled"
 echo "ok initramfs state"
 
-vm_cmd rpm-ostree initramfs --enable
-vm_cmd rpm-ostree status --json > status.json
+vm_rpmostree initramfs --enable
+vm_rpmostree status --json > status.json
 assert_jq '.deployments[1].booted' status.json
 assert_jq '.deployments[0]["regenerate-initramfs"]' status.json
 assert_jq '.deployments[1]["regenerate-initramfs"]|not' status.json
@@ -59,23 +59,23 @@ assert_jq '.deployments[1]["regenerate-initramfs"]|not' status.json
 vm_reboot
 
 assert_not_streq $base $(vm_get_booted_csum)
-vm_cmd rpm-ostree status --json > status.json
+vm_rpmostree status --json > status.json
 assert_jq '.deployments[0].booted' status.json
 assert_jq '.deployments[0]["regenerate-initramfs"]' status.json
 assert_jq '.deployments[0]["initramfs-args"]|length == 0' status.json
 assert_jq '.deployments[1]["regenerate-initramfs"]|not' status.json
 assert_jq '.deployments[1]["initramfs-args"]|not' status.json
 
-if vm_cmd rpm-ostree initramfs --enable 2>err.txt; then
+if vm_rpmostree initramfs --enable 2>err.txt; then
     assert_not_reached "Unexpectedly succeeded at enabling"
 fi
 assert_file_has_content err.txt "already.*enabled"
 echo "ok initramfs enabled"
 
-vm_cmd rpm-ostree initramfs --disable
+vm_rpmostree initramfs --disable
 vm_reboot
 
-vm_cmd rpm-ostree status --json > status.json
+vm_rpmostree status --json > status.json
 assert_jq '.deployments[0].booted' status.json
 assert_jq '.deployments[0]["regenerate-initramfs"]|not' status.json
 assert_jq '.deployments[1]["regenerate-initramfs"]' status.json
@@ -85,9 +85,9 @@ echo "ok initramfs disabled"
 
 for file in first second; do
     vm_cmd touch /etc/rpmostree-initramfs-testing-$file
-    vm_cmd rpm-ostree initramfs --enable --arg="-I" --arg="/etc/rpmostree-initramfs-testing-$file"
+    vm_rpmostree initramfs --enable --arg="-I" --arg="/etc/rpmostree-initramfs-testing-$file"
     vm_reboot
-    vm_cmd rpm-ostree status --json > status.json
+    vm_rpmostree status --json > status.json
     assert_jq '.deployments[0].booted' status.json
     assert_jq '.deployments[0]["regenerate-initramfs"]' status.json
     assert_jq '.deployments[0]["initramfs-args"]|index("-I") == 0' status.json
@@ -99,7 +99,7 @@ for file in first second; do
     assert_file_has_content lsinitrd.txt /etc/rpmostree-initramfs-testing-${file}
 done
 
-vm_cmd rpm-ostree initramfs --disable
+vm_rpmostree initramfs --disable
 
 initramfs=$(vm_cmd grep ^initrd /boot/loader/entries/ostree-fedora-atomic-0.conf | sed -e 's,initrd ,/boot/,')
 test -n "${initramfs}"


### PR DESCRIPTION
Currently we push for a model where the initramfs is
generated (in non-hostonly mode), and merely replicated.

However, to support a few unfortunate corner cases like dm-multipath which wants
to inject a config file into the initramfs, we need to support regenerating it
client side too.

Down the line, we'll need this to support overriding the kernel too.
