### PR TITLE
[merged] Move SIGINT handling into transaction helper

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -193,15 +193,6 @@ rpmostree_print_gpg_verify_result (OstreeGpgVerifyResult *result)
 }
 
 
-static gboolean
-on_sigint (gpointer user_data)
-{
-  GCancellable *cancellable = user_data;
-  g_debug ("Caught signal. Canceling");
-  g_cancellable_cancel (cancellable);
-  return FALSE;
-}
-
 static RpmOstreeCommand *
 lookup_command_of_type (RpmOstreeCommand *commands,
                         const char *name,
@@ -274,10 +265,6 @@ main (int    argc,
     }
 
   argc = out;
-
-  g_unix_signal_add (SIGINT, on_sigint, cancellable);
-  g_unix_signal_add (SIGTERM, on_sigint, cancellable);
-  g_unix_signal_add (SIGHUP, on_sigint, cancellable);
 
   /* Keep the "rpm" command working for backward-compatibility. */
   if (g_strcmp0 (command_name, "rpm") == 0)


### PR DESCRIPTION
Not being able to `Ctrl-C` treecompose kept irritating me and I
finally looked it into it.  I'd thought it was rpm or librepo's
fault, but nope, it's ours!

We had `SIG{INT,HUP,TERM}` handling globally, but unfortunately
right now some things in libdnf don't respect the cancellable
(It's hard to do without threading it down all the way into libcurl
 and rpm).

Really for treecompose we don't need a `SIGINT` (or other) handlers - we should
just take the default action of immediate process exit.

Now, for the command line dbus calls, *only* when we go to execute a txn should
we catch `SIGINT` so that we can forward it to the daemon to cancel there.

Closes: https://github.com/projectatomic/rpm-ostree/issues/489
