### PR TITLE
[merged] tests: Actually install the new binaries

### DIFF
--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -51,7 +51,7 @@ fi
 cd /ostree/repo/tmp
 rm vmcheck -rf
 ostree checkout $commit vmcheck --fsync=0
-rsync -rv /var/roothome/sync/insttree/usr/ vmcheck/usr/
+rsync -rlv /var/roothome/sync/insttree/usr/ vmcheck/usr/
 ostree refs --delete vmcheck || true
 ostree commit -b vmcheck -s '' --tree=dir=vmcheck --link-checkout-speedup
 ostree admin deploy vmcheck

--- a/tests/vmcheck/sync.sh
+++ b/tests/vmcheck/sync.sh
@@ -26,7 +26,7 @@ else
     # then do this in the VM
     set -x
     ostree admin unlock || :
-    rsync -rv /var/roothome/sync/insttree/usr/ /usr/
+    rsync -rlv /var/roothome/sync/insttree/usr/ /usr/
     restorecon /usr/libexec/rpm-ostreed
     systemctl restart rpm-ostreed
 fi


### PR DESCRIPTION
I think since I landed a change to `--enable-new-name`, `/usr/bin/rpm-ostree`
became a symlink, and without the `-l` switch, rsync skips over them.

Hence, we have only been testing in vmcheck the old binaries, not new ones.
Oops.
