### PR TITLE
Add `pending-base-commit` to status

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -124,6 +124,7 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
       guint64 t = 0;
       int serial;
       gboolean is_booted;
+      const gboolean was_first = first;
       const guint max_key_len = strlen ("PendingBaseVersion");
       g_autoptr(GVariant) signatures = NULL;
       g_autofree char *timestamp_string = NULL;
@@ -208,8 +209,11 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
         }
       print_kv ("Commit", max_key_len, checksum);
 
-      /* Pending state, but only for the booted comit */
-      if (is_booted)
+      /* Show any difference between the baseref vs head, but only for the
+         booted commit, and only if there isn't a pending deployment. Otherwise
+         it's either unnecessary or too noisy.
+      */
+      if (is_booted && was_first)
         {
           const gchar *pending_checksum = NULL;
           const gchar *pending_version = NULL;

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -216,7 +216,6 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
 
           if (g_variant_dict_lookup (dict, "pending-base-checksum", "&s", &pending_checksum))
             {
-              g_autofree char *version_time = NULL;
               print_kv (is_locally_assembled ? "PendingBaseCommit" : "PendingCommit",
                         max_key_len, pending_checksum);
               g_assert (g_variant_dict_lookup (dict, "pending-base-timestamp", "t", &t));

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -209,13 +209,12 @@ rpmostreed_deployment_generate_variant (OstreeDeployment *deployment,
       base_checksum = ostree_commit_get_parent (commit);
       g_assert (base_checksum);
       g_variant_dict_insert (&dict, "base-checksum", "s", base_checksum);
-      sigs = rpmostreed_deployment_gpg_results (repo, refspec, base_checksum, &gpg_enabled);
     }
   else
     {
       base_checksum = csum;
-      sigs = rpmostreed_deployment_gpg_results (repo, refspec, csum, &gpg_enabled);
     }
+  sigs = rpmostreed_deployment_gpg_results (repo, refspec, base_checksum, &gpg_enabled);
   variant_add_commit_details (&dict, NULL, commit);
 
   if (!ostree_repo_resolve_rev (repo, refspec, TRUE,

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -382,3 +382,16 @@ ensure_dbus ()
         exec "$topsrcdir/tests/utils/setup-session.sh" "$self"
     fi
 }
+
+# Assert that @expression is true in @jsonfile
+assert_status_jq() {
+    vm_rpmostree status --json > status.json
+
+    for expression in $@; do
+        if ! jq -e "${expression}" >/dev/null < status.json; then
+            jq . < status.json | sed -e 's/^/# /' >&2
+            echo 1>&2 "${expression} failed to match in status.json"
+            exit 1
+        fi
+    done
+}

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -387,7 +387,7 @@ ensure_dbus ()
 assert_status_jq() {
     vm_rpmostree status --json > status.json
 
-    for expression in $@; do
+    for expression in "$@"; do
         if ! jq -e "${expression}" >/dev/null < status.json; then
             jq . < status.json | sed -e 's/^/# /' >&2
             echo 1>&2 "${expression} failed to match in status.json"

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -33,6 +33,8 @@ vm_send_test_repo
 
 # make sure the package is not already layered
 vm_assert_layered_pkg foo absent
+assert_status_jq '.deployments[0]["base-checksum"]|not' \
+                 '.deployments[0]["pending-base-checksum"]|not'
 
 # Be sure an unprivileged user exists
 vm_cmd getent passwd bin
@@ -44,6 +46,8 @@ vm_rpmostree pkg-add foo-1.0
 echo "ok pkg-add foo"
 
 vm_reboot
+assert_status_jq '.deployments[0]["base-checksum"]' \
+                 '.deployments[0]["pending-base-checksum"]|not'
 
 vm_assert_layered_pkg foo-1.0 present
 echo "ok pkg foo added"

--- a/tests/vmcheck/test-layering-relayer.sh
+++ b/tests/vmcheck/test-layering-relayer.sh
@@ -53,10 +53,18 @@ reboot_and_assert_base() {
 
 # UPGRADE
 
+assert_status_jq '.deployments[0]["base-checksum"]' \
+                 '.deployments[0]["pending-base-checksum"]|not'
 # let's synthesize an upgrade
 commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck)
 vm_rpmostree upgrade
+assert_status_jq '.deployments[1]["base-checksum"]' \
+                 '.deployments[1]["pending-base-checksum"]'
+vm_rpmostree status --json > status.json
 reboot_and_assert_base $commit
+assert_status_jq '.deployments[0]["base-checksum"]' \
+                 '.deployments[0]["pending-base-checksum"]|not' \
+                 '.deployments[1]["pending-base-checksum"]'
 echo "ok upgrade"
 
 vm_assert_layered_pkg foo present


### PR DESCRIPTION
One thing that's very confusing about OSTree is there are two layers -
deployments and the refs/commits. If one does an `rpm-ostree upgrade`, but then
e.g. `ostree admin undeploy 0`, you still have the new revision in the repo.

We don't do a good job of displaying this state, or helping people clean
it up.

Down the line, I also want to better support something like `rpm-ostree pull` to
cache updates explicitly *without* deploying.

This commit just adds a bit of information to the status display. We might want
to have better formatting, but I think this an OK start.
