### PR TITLE
daemon: Implement "reload"

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -26,6 +26,7 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-builtin-upgrade.c \
 	src/app/rpmostree-builtin-rollback.c \
 	src/app/rpmostree-builtin-deploy.c \
+	src/app/rpmostree-builtin-reload.c \
 	src/app/rpmostree-builtin-rebase.c \
 	src/app/rpmostree-builtin-cleanup.c \
 	src/app/rpmostree-builtin-initramfs.c \

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -364,6 +364,19 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
+        <term><command>reload</command></term>
+
+        <listitem>
+          <para>
+            Some configuration and state data such as
+            <literal>/etc/ostree/remotes.d</literal> changes may not be
+            reflected until a daemon reload is invoked. Use this command to
+            initiate a reload.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><command>initramfs</command></term>
 
         <listitem>

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -44,6 +44,7 @@ static RpmOstreeCommand supported_commands[] = {
   { "rollback", rpmostree_builtin_rollback },
   { "status", rpmostree_builtin_status },
   { "upgrade", rpmostree_builtin_upgrade },
+  { "reload", rpmostree_builtin_reload },
   { "initramfs", rpmostree_builtin_initramfs },
   { "install", rpmostree_builtin_pkg_add },
   { "uninstall", rpmostree_builtin_pkg_remove },

--- a/src/app/rpmostree-builtin-reload.c
+++ b/src/app/rpmostree-builtin-reload.c
@@ -1,0 +1,63 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Colin Walters <walters@verbum.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <glib-unix.h>
+#include <gio/gio.h>
+
+#include "rpmostree-builtins.h"
+#include "rpmostree-libbuiltin.h"
+
+#include <libglnx.h>
+
+static GOptionEntry option_entries[] = {
+  { NULL }
+};
+
+int
+rpmostree_builtin_reload (int             argc,
+                          char          **argv,
+                          GCancellable   *cancellable,
+                          GError        **error)
+{
+  int exit_status = EXIT_FAILURE;
+  g_autoptr(GOptionContext) context = g_option_context_new ("- Reload configuration");
+  glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
+
+  if (!rpmostree_option_context_parse (context,
+                                       option_entries,
+                                       &argc, &argv,
+                                       RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
+                                       cancellable,
+                                       &sysroot_proxy,
+                                       error))
+    goto out;
+
+  if (!rpmostree_sysroot_call_reload_config_sync (sysroot_proxy, cancellable, error))
+    goto out;
+
+  exit_status = EXIT_SUCCESS;
+out:
+  /* Does nothing if using the message bus. */
+  rpmostree_cleanup_peer ();
+  return exit_status;
+}

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -44,6 +44,7 @@ typedef struct {
 
 BUILTINPROTO(compose);
 BUILTINPROTO(upgrade);
+BUILTINPROTO(reload);
 BUILTINPROTO(deploy);
 BUILTINPROTO(rebase);
 BUILTINPROTO(cleanup);

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -26,6 +26,9 @@
     <!-- The values are (method-name, sender-name) -->
     <property name="ActiveTransaction" type="(sss)" access="read"/>
 
+    <method name="ReloadConfig">
+    </method>
+
     <method name="CreateOSName">
       <arg type="s" name="name"/>
       <arg type="o" name="result" direction="out"/>

--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -7,3 +7,4 @@ Type=dbus
 BusName=org.projectatomic.rpmostree1
 @SYSTEMD_ENVIRON@
 ExecStart=@bindir@/rpm-ostree start-daemon
+ExecReload=@libexecdir@/@primaryname@ reload

--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -36,3 +36,5 @@ void               rpmostreed_daemon_publish        (RpmostreedDaemon *self,
 void               rpmostreed_daemon_unpublish      (RpmostreedDaemon *self,
                                                      const gchar *path,
                                                      gpointer thing);
+gboolean           rpmostreed_reload_config         (RpmostreedDaemon *self,
+						     GError          **error);

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -536,6 +536,23 @@ sysroot_populate_deployments_unlocked (RpmostreedSysroot *self,
   return ret;
 }
 
+static gboolean
+handle_reload_config (RPMOSTreeSysroot *object,
+                      GDBusMethodInvocation *invocation)
+{
+  RpmostreedSysroot *self = RPMOSTREED_SYSROOT (object);
+  g_autoptr(GError) local_error = NULL;
+  GError **error = &local_error;
+
+  if (!rpmostreed_sysroot_reload (self, error))
+    goto out;
+out:
+  if (error)
+    g_dbus_method_invocation_take_error (invocation, g_steal_pointer (&local_error));
+
+  return TRUE;
+}
+
 /* ---------------------------------------------------------------------------------------------------- */
 static void
 sysroot_dispose (GObject *object)
@@ -676,6 +693,8 @@ rpmostreed_sysroot_reload (RpmostreedSysroot *self,
 
   if (!sysroot_populate_deployments_unlocked (self, &did_change, error))
     goto out;
+  if (!ostree_repo_reload_remote_config (self->repo, NULL, error))
+    goto out;
 
   ret = TRUE;
  out:
@@ -710,6 +729,7 @@ rpmostreed_sysroot_iface_init (RPMOSTreeSysrootIface *iface)
 {
   iface->handle_create_osname = handle_create_osname;
   iface->handle_get_os = handle_get_os;
+  iface->handle_reload_config = handle_reload_config;
 }
 
 /**

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -546,8 +546,10 @@ handle_reload_config (RPMOSTreeSysroot *object,
 
   if (!rpmostreed_sysroot_reload (self, error))
     goto out;
+
+  rpmostree_sysroot_complete_reload_config (object, invocation);
 out:
-  if (error)
+  if (local_error)
     g_dbus_method_invocation_take_error (invocation, g_steal_pointer (&local_error));
 
   return TRUE;

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -693,7 +693,7 @@ rpmostreed_sysroot_reload (RpmostreedSysroot *self,
 
   if (!sysroot_populate_deployments_unlocked (self, &did_change, error))
     goto out;
-  if (!ostree_repo_reload_remote_config (self->repo, NULL, error))
+  if (!ostree_repo_reload_config (self->repo, NULL, error))
     goto out;
 
   ret = TRUE;

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -24,7 +24,7 @@ export RPMOSTREE_SUPPRESS_REQUIRES_ROOT_CHECK=yes
 
 ensure_dbus
 
-echo "1..16"
+echo "1..17"
 
 setup_os_repository "archive-z2" "syslinux"
 

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -45,6 +45,9 @@ ostree admin --sysroot=sysroot deploy --karg=root=LABEL=MOO --karg=quiet --os=te
 assert_status_jq '.deployments[0].version == "1.0.10"'
 echo "ok status shows right version"
 
+rpm-ostree reload
+echo "ok reload"
+
 os_repository_new_commit
 rpm-ostree upgrade --os=testos
 

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -24,7 +24,7 @@ export RPMOSTREE_SUPPRESS_REQUIRES_ROOT_CHECK=yes
 
 ensure_dbus
 
-echo "1..17"
+echo "1..16"
 
 setup_os_repository "archive-z2" "syslinux"
 
@@ -44,9 +44,6 @@ ostree admin --sysroot=sysroot deploy --karg=root=LABEL=MOO --karg=quiet --os=te
 
 assert_status_jq '.deployments[0].version == "1.0.10"'
 echo "ok status shows right version"
-
-rpm-ostree reload
-echo "ok reload"
 
 os_repository_new_commit
 rpm-ostree upgrade --os=testos
@@ -138,9 +135,7 @@ echo "ok deploy from remote with unsigned and signed commits"
 
 originpath=$(ostree admin --sysroot=sysroot --print-current-dir).origin
 echo "unconfigured-state=Access to TestOS requires ONE BILLION DOLLARS" >> ${originpath}
-pid=$(pgrep -u $(id -u) -f 'rpm-ostree.*daemon')
-test -n "${pid}" || assert_not_reached "failed to find rpm-ostree pid"
-kill -9 ${pid}
+rpm-ostree reload
 rpm-ostree status
 if rpm-ostree upgrade --os=testos 2>err.txt; then
     assert_not_reached "Upgraded from unconfigured-state"


### PR DESCRIPTION
There are two main issues right now; first, we don't pick up manual changes to
`.origin` files, which occurs when one needs to sed it to remove `unconfigured`
for example. Second, we need to reload changes to the remotes.