### PR TITLE
treecompose: Print enabled repositories and their timestamps 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://git.gnome.org/browse/libglnx
 [submodule "libdnf"]
 	path = libdnf
-	url = https://github.com/rpm-software-management/libhif
+	url = https://github.com/rpm-software-management/libdnf


### PR DESCRIPTION
In particular, I want to start using the repo timestamp as a poor man's
versioning. Knowing when the last time a repo was updated is pretty important if
you're potentially expecting security updates for example.

(I plan to also do something like this on the client side, but let's do it here
 first since we already dump lots of crud to stdout. Client side would require
 structure/design/thought)