### PR TITLE
upgrader: let ostree create the commit dir

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -712,7 +712,6 @@ checkout_base_tree (RpmOstreeSysrootUpgrader *self,
 {
   OstreeRepoCheckoutAtOptions checkout_options = { 0, };
   int repo_dfd = ostree_repo_get_dfd (self->repo); /* borrowed */
-  g_autofree char *tmprootfs = NULL;
 
   g_assert (!self->tmprootfs);
   g_assert_cmpint (self->tmprootfs_dfd, ==, -1);

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -36,6 +36,7 @@
 #include "ostree-repo.h"
 
 #define RPMOSTREE_TMP_BASE_REF "rpmostree/base/tmp"
+#define RPMOSTREE_TMP_ROOTFS_DIR "extensions/rpmostree/commit"
 
 static gboolean
 commit_get_parent_csum (OstreeRepo  *repo,
@@ -716,25 +717,26 @@ checkout_base_tree (RpmOstreeSysrootUpgrader *self,
   g_assert (!self->tmprootfs);
   g_assert_cmpint (self->tmprootfs_dfd, ==, -1);
 
-  tmprootfs = g_strdup ("tmp/rpmostree-commit-XXXXXX");
-
-  if (!glnx_mkdtempat (repo_dfd, tmprootfs, 00755, error))
-    return FALSE;
-
-  /* Now we'll delete it on cleanup */
-  self->tmprootfs = g_steal_pointer (&tmprootfs);
-
-  if (!glnx_opendirat (repo_dfd, self->tmprootfs, FALSE, &self->tmprootfs_dfd, error))
-    return FALSE;
-
   /* let's give the user some feedback so they don't think we're blocked */
   rpmostree_output_task_begin ("Checking out tree %.7s", self->base_revision);
 
-  /* we actually only need this here because we use "." for path */
-  checkout_options.overwrite_mode = OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES;
+  /* delete dir in case a previous run didn't finish successfully */
+  if (!glnx_shutil_rm_rf_at (repo_dfd, RPMOSTREE_TMP_ROOTFS_DIR,
+                             cancellable, error))
+    return FALSE;
+
+  /* NB: we let ostree create the dir for us so that the root dir has the
+   * correct xattrs (e.g. selinux label) */
   checkout_options.devino_to_csum_cache = self->devino_cache;
-  if (!ostree_repo_checkout_at (self->repo, &checkout_options, self->tmprootfs_dfd,
-                                ".", self->base_revision, cancellable, error))
+  if (!ostree_repo_checkout_at (self->repo, &checkout_options,
+                                repo_dfd, RPMOSTREE_TMP_ROOTFS_DIR,
+                                self->base_revision, cancellable, error))
+    return FALSE;
+
+  /* Now we'll delete it on cleanup */
+  self->tmprootfs = glnx_fdrel_abspath (repo_dfd, RPMOSTREE_TMP_ROOTFS_DIR);
+
+  if (!glnx_opendirat (repo_dfd, self->tmprootfs, FALSE, &self->tmprootfs_dfd, error))
     return FALSE;
 
   rpmostree_output_task_end ("done");

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -719,6 +719,11 @@ checkout_base_tree (RpmOstreeSysrootUpgrader *self,
   /* let's give the user some feedback so they don't think we're blocked */
   rpmostree_output_task_begin ("Checking out tree %.7s", self->base_revision);
 
+  if (!glnx_shutil_mkdir_p_at (repo_dfd,
+                               dirname (strdupa (RPMOSTREE_TMP_ROOTFS_DIR)),
+                               0755, cancellable, error))
+    return FALSE;
+
   /* delete dir in case a previous run didn't finish successfully */
   if (!glnx_shutil_rm_rf_at (repo_dfd, RPMOSTREE_TMP_ROOTFS_DIR,
                              cancellable, error))

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -53,6 +53,12 @@ if ! vm_cmd /usr/bin/foo | grep "Happy foobing!"; then
 fi
 echo "ok correct output"
 
+# check that root is a shared mount
+# https://bugzilla.redhat.com/show_bug.cgi?id=1318547
+if ! vm_cmd "findmnt / -no PROPAGATION" | grep shared; then
+    assert_not_reached "root is not mounted shared"
+fi
+
 vm_rpmostree pkg-remove foo-1.0
 echo "ok pkg-remove foo"
 


### PR DESCRIPTION
When we checked out the base tree for package layering, we would create
the directory in which ostree did the checkout. This meant however that
ostree wouldn't apply xattrs on the root directory itself. This would
cause the directory to be mislabeled (as system_conf_t instead of
root_t), which in turn cause SELinux violations on reboot when systemd
tried to make the root mount shared.

This patch fixes this by first settling on a permanent directory in
which to do checkouts -- really, we'll never have multiple package
layering operations going on at the same time. Once we know that we have
a reserved path, we can safely let ostree create it for us with the
proper xattrs.

Resolves: RHBZ#1318547