### PR TITLE
core: Add rpmostree.repo metadata to imported packages

### DIFF
--- a/src/app/rpmostree-internals-builtin-unpack.c
+++ b/src/app/rpmostree-internals-builtin-unpack.c
@@ -94,7 +94,7 @@ rpmostree_internals_builtin_unpack (int             argc,
   if (opt_ostree_convention)
     flags |= RPMOSTREE_UNPACKER_FLAGS_OSTREE_CONVENTION;
 
-  unpacker = rpmostree_unpacker_new_at (AT_FDCWD, rpmpath, flags, error);
+  unpacker = rpmostree_unpacker_new_at (AT_FDCWD, rpmpath, NULL, flags, error);
   if (!unpacker)
     goto out;
 

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1169,7 +1169,7 @@ import_one_package (RpmOstreeContext *self,
     flags |= RPMOSTREE_UNPACKER_FLAGS_UNPRIVILEGED;
 
   /* TODO - tweak the unpacker flags for containers */
-  unpacker = rpmostree_unpacker_new_at (AT_FDCWD, pkg_path, flags, error);
+  unpacker = rpmostree_unpacker_new_at (AT_FDCWD, pkg_path, pkg, flags, error);
   if (!unpacker)
     goto out;
 

--- a/src/libpriv/rpmostree-unpacker.h
+++ b/src/libpriv/rpmostree-unpacker.h
@@ -24,6 +24,7 @@
 
 #include "libglnx.h"
 #include <rpm/rpmlib.h>
+#include <libdnf/libdnf.h>
 
 typedef struct RpmOstreeUnpacker RpmOstreeUnpacker;
 
@@ -45,12 +46,14 @@ typedef enum {
 
 RpmOstreeUnpacker*
 rpmostree_unpacker_new_fd (int fd,
+                           DnfPackage *pkg,
                            RpmOstreeUnpackerFlags flags,
                            GError **error);
 
 RpmOstreeUnpacker*
 rpmostree_unpacker_new_at (int dfd,
                            const char *path,
+                           DnfPackage *pkg, /* for metadata */
                            RpmOstreeUnpackerFlags flags,
                            GError **error);
 

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -41,6 +41,11 @@ if vm_cmd "runuser -u bin rpm-ostree pkg-add foo-1.0"; then
 fi
 
 vm_rpmostree pkg-add foo-1.0
+vm_cmd ostree --repo=/sysroot/ostree/repo/extensions/rpmostree/pkgcache refs |grep /foo/> refs.txt
+pkgref=$(head -1 refs.txt)
+vm_cmd ostree --repo=/sysroot/ostree/repo/extensions/rpmostree/pkgcache show --print-metadata-key rpmostree.repo ${pkgref} >refdata.txt
+assert_file_has_content refdata.txt 'id.*test-repo'
+rm -f refs.txt refdata.txt
 echo "ok pkg-add foo"
 
 vm_reboot


### PR DESCRIPTION
I'm watching https://github.com/rpm-software-management/libdnf/pull/199 and I
really don't like it. We already have a place to put out-of-rpmdb metadata,
which is in the ostree commit for imported packages. No need to involve a
relational database for this (and further, one that would need to learn about
multiple ostrees).

We're not yet *using* this information in the UI, but we could; imagine
changing the `status` `Packages:` to show packages-per-repo or so.  We
could also expose an `rpm-ostree pkg-info foo`.

But for now, let's just start recording this.
