### PR TITLE
daemon: fix assertion error on exit

### DIFF
--- a/src/app/rpmostree-internals-builtin-start-daemon.c
+++ b/src/app/rpmostree-internals-builtin-start-daemon.c
@@ -304,7 +304,6 @@ rpmostree_internals_builtin_start_daemon (int             argc,
                                           GError        **error)
 {
   int ret = 1;
-  g_autoptr(GMainLoop) loop = NULL;
   g_autoptr(GOptionContext) opt_context = g_option_context_new ("rpm-ostreed -- rpm-ostree daemon");
   GIOChannel *channel;
   guint name_owner_id = 0;
@@ -379,5 +378,10 @@ rpmostree_internals_builtin_start_daemon (int             argc,
   ret = 0;
 
 out:
+  if (loop != NULL)
+    g_main_loop_unref (loop);
+
+  g_info ("rpm-ostreed exiting");
+
   return ret;
 }


### PR DESCRIPTION
We weren't exiting the intended way before because we were tripping an
assertion:
```
  GLib-CRITICAL **: g_main_loop_quit: assertion 'loop != NULL' failed
```
This was because the global loop was being shadowed by a local variable.