### PR TITLE
Add a cleanup command and DBus API

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -27,6 +27,7 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-builtin-rollback.c \
 	src/app/rpmostree-builtin-deploy.c \
 	src/app/rpmostree-builtin-rebase.c \
+	src/app/rpmostree-builtin-cleanup.c \
 	src/app/rpmostree-builtin-initramfs.c \
 	src/app/rpmostree-pkg-builtins.c \
 	src/app/rpmostree-builtin-status.c \

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -335,6 +335,35 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
+        <term><command>cleanup</command></term>
+
+        <listitem>
+          <para>
+            Commands such as <command>upgrade</command> create new deployments,
+            which affect the next boot, and take up additional storage space. In
+            some cases, you may want to undo and clean up these operations. This
+            command supports both removing additional deployments such as the
+            "pending" deployment (the next boot) as well as the default rollback
+            deployment. Use <option>-p/--pending</option> to remove the pending
+            deployment, and <option>-r/--rollback</option> to remove the
+            rollback.
+          </para>
+
+          <para>
+            The <option>-b/--base</option> option does not affect finished
+            deployments, but will clean up any transient allocated space that
+            may result from interrupted operations. If you want to free up disk
+            space safely, use this option first.
+          </para>
+
+          <para>
+            The <option>-m/--repomd</option> option cleans up cached RPM
+            repodata and any partially downloaded (but not imported) packages.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><command>initramfs</command></term>
 
         <listitem>

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -37,6 +37,7 @@ static RpmOstreeCommand supported_commands[] = {
 #ifdef HAVE_COMPOSE_TOOLING
   { "compose", rpmostree_builtin_compose },
 #endif
+  { "cleanup", rpmostree_builtin_cleanup },
   { "db", rpmostree_builtin_db },
   { "deploy", rpmostree_builtin_deploy },
   { "rebase", rpmostree_builtin_rebase },

--- a/src/app/rpmostree-builtin-cleanup.c
+++ b/src/app/rpmostree-builtin-cleanup.c
@@ -1,0 +1,113 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Colin Walters <walters@verbum.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <glib-unix.h>
+
+#include "rpmostree-builtins.h"
+#include "rpmostree-util.h"
+#include "rpmostree-libbuiltin.h"
+#include "rpmostree-dbus-helpers.h"
+
+#include <libglnx.h>
+
+static char *opt_osname;
+static gboolean opt_base;
+static gboolean opt_pending;
+static gboolean opt_rollback;
+static gboolean opt_repomd;
+
+static GOptionEntry option_entries[] = {
+  { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+  { "base", 'b', 0, G_OPTION_ARG_NONE, &opt_base, "Clear all cached/pending state except pending/rollback and repodata", NULL },
+  { "pending", 'p', 0, G_OPTION_ARG_NONE, &opt_pending, "Remove pending deployment", NULL },
+  { "rollback", 'r', 0, G_OPTION_ARG_NONE, &opt_rollback, "Remove rollback deployment", NULL },
+  { "repomd", 'm', 0, G_OPTION_ARG_NONE, &opt_repomd, "Delete cached rpm repo metadata", NULL },
+  { NULL }
+};
+
+int
+rpmostree_builtin_cleanup (int             argc,
+                          char          **argv,
+                          GCancellable   *cancellable,
+                          GError        **error)
+{
+  int exit_status = EXIT_FAILURE;
+  g_autoptr(GOptionContext) context = g_option_context_new ("- Clear cached/pending data");
+  g_autoptr(GPtrArray) cleanup_types = g_ptr_array_new ();
+  glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
+  glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
+  g_autofree char *transaction_address = NULL;
+
+  if (!rpmostree_option_context_parse (context,
+                                       option_entries,
+                                       &argc, &argv,
+                                       RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
+                                       cancellable,
+                                       &sysroot_proxy,
+                                       error))
+    goto out;
+
+  if (argc < 1 || argc > 2)
+    {
+      rpmostree_usage_error (context, "Too few or too many arguments", error);
+      goto out;
+    }
+
+  if (opt_base)
+    g_ptr_array_add (cleanup_types, "base");
+  if (opt_pending)
+    g_ptr_array_add (cleanup_types, "pending-deploy");
+  if (opt_rollback)
+    g_ptr_array_add (cleanup_types, "rollback-deploy");
+  if (opt_repomd)
+    g_ptr_array_add (cleanup_types, "repomd");
+  if (cleanup_types->len == 0)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED, "At least one cleanup option must be specified");
+      goto out;
+    }
+  g_ptr_array_add (cleanup_types, NULL);
+
+  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
+                                cancellable, &os_proxy, error))
+    goto out;
+
+  if (!rpmostree_os_call_cleanup_sync (os_proxy,
+                                       (const char *const*)cleanup_types->pdata,
+                                       &transaction_address,
+                                       cancellable,
+                                       error))
+    goto out;
+
+  if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
+                                                transaction_address,
+                                                cancellable,
+                                                error))
+    goto out;
+
+  exit_status = EXIT_SUCCESS;
+out:
+  /* Does nothing if using the message bus. */
+  rpmostree_cleanup_peer ();
+  return exit_status;
+}

--- a/src/app/rpmostree-builtin-cleanup.c
+++ b/src/app/rpmostree-builtin-cleanup.c
@@ -38,7 +38,7 @@ static gboolean opt_repomd;
 
 static GOptionEntry option_entries[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
-  { "base", 'b', 0, G_OPTION_ARG_NONE, &opt_base, "Clear all cached/pending state except pending/rollback and repodata", NULL },
+  { "base", 'b', 0, G_OPTION_ARG_NONE, &opt_base, "Clear temporary files; will leave deployments unchanged", NULL },
   { "pending", 'p', 0, G_OPTION_ARG_NONE, &opt_pending, "Remove pending deployment", NULL },
   { "rollback", 'r', 0, G_OPTION_ARG_NONE, &opt_rollback, "Remove rollback deployment", NULL },
   { "repomd", 'm', 0, G_OPTION_ARG_NONE, &opt_repomd, "Delete cached rpm repo metadata", NULL },

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -46,6 +46,7 @@ BUILTINPROTO(compose);
 BUILTINPROTO(upgrade);
 BUILTINPROTO(deploy);
 BUILTINPROTO(rebase);
+BUILTINPROTO(cleanup);
 BUILTINPROTO(rollback);
 BUILTINPROTO(initramfs);
 BUILTINPROTO(status);

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -188,6 +188,11 @@
       <arg type="s" name="transaction_address" direction="out"/>
     </method>
 
+    <method name="Cleanup">
+      <arg type="as" name="elements" direction="in"/>
+      <arg type="s" name="transaction_address" direction="out"/>
+    </method>
+
   </interface>
 
   <interface name="org.projectatomic.rpmostree1.Transaction">

--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -106,4 +106,11 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader  *self,
                                    GCancellable           *cancellable,
                                    GError                **error);
 
+gboolean
+rpmostree_sysroot_upgrader_cleanup (OstreeSysroot            *sysroot,
+                                    OstreeRepo               *repo,
+                                    GCancellable             *cancellable,
+                                    GError                  **error);
+
+
 G_END_DECLS

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -76,3 +76,18 @@ rpmostreed_transaction_new_initramfs_state       (GDBusMethodInvocation *invocat
                                                   gboolean               reboot,
                                                   GCancellable          *cancellable,
                                                   GError               **error);
+
+typedef enum {
+  RPMOSTREE_TRANSACTION_CLEANUP_BASE = (1 << 0),
+  RPMOSTREE_TRANSACTION_CLEANUP_PENDING_DEPLOY = (1 << 1),
+  RPMOSTREE_TRANSACTION_CLEANUP_ROLLBACK_DEPLOY = (1 << 2),
+  RPMOSTREE_TRANSACTION_CLEANUP_REPOMD = (1 << 3),
+} RpmOstreeTransactionCleanupFlags;
+
+RpmostreedTransaction *
+rpmostreed_transaction_new_cleanup       (GDBusMethodInvocation *invocation,
+                                          OstreeSysroot         *sysroot,
+                                          const char            *osname,
+                                          RpmOstreeTransactionCleanupFlags flags,
+                                          GCancellable          *cancellable,
+                                          GError               **error);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -340,8 +340,8 @@ rpmostree_context_new_system (GCancellable *cancellable,
    * override this for testing. */
   if (g_getenv("RPMOSTREE_USE_CACHED_METADATA") == NULL)
       dnf_context_set_cache_age (self->hifctx, 0);
-  dnf_context_set_cache_dir (self->hifctx, "/var/cache/rpm-ostree/" RPMOSTREE_DIR_CACHE_REPOMD);
-  dnf_context_set_solv_dir (self->hifctx, "/var/cache/rpm-ostree/" RPMOSTREE_DIR_CACHE_SOLV);
+  dnf_context_set_cache_dir (self->hifctx, RPMOSTREE_CORE_CACHEDIR RPMOSTREE_DIR_CACHE_REPOMD);
+  dnf_context_set_solv_dir (self->hifctx, RPMOSTREE_CORE_CACHEDIR RPMOSTREE_DIR_CACHE_SOLV);
   dnf_context_set_lock_dir (self->hifctx, "/run/rpm-ostree/" RPMOSTREE_DIR_LOCK);
   dnf_context_set_user_agent (self->hifctx, PACKAGE_NAME "/" PACKAGE_VERSION);
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -26,6 +26,8 @@
 
 #include "libglnx.h"
 
+#define RPMOSTREE_CORE_CACHEDIR "/var/cache/rpm-ostree/"
+
 #define RPMOSTREE_TYPE_CONTEXT (rpmostree_context_get_type ())
 G_DECLARE_FINAL_TYPE (RpmOstreeContext, rpmostree_context, RPMOSTREE, CONTEXT, GObject)
 

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -77,3 +77,16 @@ vm_reboot
 
 vm_assert_layered_pkg foo absent
 echo "ok pkg foo removed"
+
+vm_rpmostree cleanup -b
+vm_assert_status_jq '.deployments|length == 2'
+echo "ok baseline cleanup"
+vm_rpmostree cleanup -r
+vm_assert_status_jq '.deployments|length == 1'
+vm_rpmostree cleanup -pr
+vm_assert_status_jq '.deployments|length == 1'
+vm_rpmostree pkg-add foo-1.0
+vm_assert_status_jq '.deployments|length == 2'
+vm_rpmostree cleanup -pr
+vm_assert_status_jq '.deployments|length == 1'
+echo "ok cleanup"


### PR DESCRIPTION
We sometimes talk about using `ostree admin undeploy`, but that
doesn't know about the pkgcache, and hence space there leaks
until the next rpm-ostree operation.

Just for this, we need to expose a cleanup command (and API).  But
we also need to support cleaning:

 - repomd
 - downloads (repo/tmp)

So let's start implementing that.
