### PR TITLE
daemon: Don't log "start-daemon is experimental" into the journal

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -214,7 +214,7 @@ lookup_command_of_type (RpmOstreeCommand *commands,
     {
       if (g_strcmp0 (name, command->name) == 0)
         {
-          if (type)
+          if (type && g_getenv ("RPMOSTREE_SUPPRESS_EXPERIMENTAL_WARNING") == NULL)
             g_printerr ("%snotice%s: %s is %s command and subject to change.\n",
                         bold_prefix, bold_suffix, name, type);
           return command;

--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -5,5 +5,6 @@ ConditionPathExists=/ostree
 [Service]
 Type=dbus
 BusName=org.projectatomic.rpmostree1
+Environment=RPMOSTREE_SUPPRESS_EXPERIMENTAL_WARNING=1
 @SYSTEMD_ENVIRON@
 ExecStart=@bindir@/rpm-ostree internals start-daemon


### PR DESCRIPTION
Looks embarassing. Tempting to move start-daemon to its own thing outside of
`internals` or something but this works for now.
