### PR TITLE
start-daemon: make hidden

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -27,12 +27,13 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-builtin-rollback.c \
 	src/app/rpmostree-builtin-deploy.c \
 	src/app/rpmostree-builtin-rebase.c \
-  src/app/rpmostree-builtin-initramfs.c \
+	src/app/rpmostree-builtin-initramfs.c \
 	src/app/rpmostree-pkg-builtins.c \
 	src/app/rpmostree-builtin-status.c \
 	src/app/rpmostree-builtin-internals.c \
 	src/app/rpmostree-builtin-container.c \
 	src/app/rpmostree-builtin-db.c \
+	src/app/rpmostree-builtin-start-daemon.c \
 	src/app/rpmostree-db-builtin-diff.c \
 	src/app/rpmostree-db-builtin-list.c \
 	src/app/rpmostree-db-builtin-version.c \
@@ -41,7 +42,6 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-container-builtins.h \
 	src/app/rpmostree-container-builtins.c \
 	src/app/rpmostree-internals-builtin-unpack.c \
-	src/app/rpmostree-internals-builtin-start-daemon.c \
 	src/app/rpmostree-libbuiltin.c \
 	src/app/rpmostree-libbuiltin.h \
 	$(NULL)

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -65,6 +65,11 @@ static RpmOstreeCommand experimental_commands[] = {
   { NULL }
 };
 
+static RpmOstreeCommand hidden_commands[] = {
+  { "start-daemon", rpmostree_builtin_start_daemon },
+  { NULL }
+};
+
 static gboolean opt_version;
 static gboolean opt_force_peer;
 static char *opt_sysroot;
@@ -283,6 +288,9 @@ main (int    argc,
 
   if (!command)
     command = lookup_command_of_type (experimental_commands, command_name, "an experimental");
+
+  if (!command)
+    command = lookup_command_of_type (hidden_commands, command_name, NULL);
 
   if (!command)
     {

--- a/src/app/rpmostree-builtin-internals.c
+++ b/src/app/rpmostree-builtin-internals.c
@@ -30,7 +30,6 @@ typedef struct {
 
 static RpmOstreeInternalsCommand internals_subcommands[] = {
   { "unpack", rpmostree_internals_builtin_unpack },
-  { "start-daemon", rpmostree_internals_builtin_start_daemon },
   { NULL, NULL }
 };
 

--- a/src/app/rpmostree-builtin-start-daemon.c
+++ b/src/app/rpmostree-builtin-start-daemon.c
@@ -298,13 +298,13 @@ out:
 
 
 int
-rpmostree_internals_builtin_start_daemon (int             argc,
-                                          char          **argv,
-                                          GCancellable   *cancellable,
-                                          GError        **error)
+rpmostree_builtin_start_daemon (int             argc,
+                                char          **argv,
+                                GCancellable   *cancellable,
+                                GError        **error)
 {
   int ret = 1;
-  g_autoptr(GOptionContext) opt_context = g_option_context_new ("rpm-ostreed -- rpm-ostree daemon");
+  g_autoptr(GOptionContext) opt_context = g_option_context_new (" - start the daemon process");
   GIOChannel *channel;
   guint name_owner_id = 0;
 

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -54,6 +54,7 @@ BUILTINPROTO(internals);
 BUILTINPROTO(container);
 BUILTINPROTO(pkg_add);
 BUILTINPROTO(pkg_remove);
+BUILTINPROTO(start_daemon);
 
 #undef BUILTINPROTO
 

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -610,7 +610,7 @@ rpmostree_compose_builtin_tree (int             argc,
 {
   int exit_status = EXIT_FAILURE;
   GError *temp_error = NULL;
-  g_autoptr(GOptionContext) context = g_option_context_new ("TREEFILE - Run yum and commit the result to an OSTree repository");
+  g_autoptr(GOptionContext) context = g_option_context_new ("TREEFILE - Install packages and commit the result to an OSTree repository");
   RpmOstreeTreeComposeContext selfdata = { NULL, };
   RpmOstreeTreeComposeContext *self = &selfdata;
   JsonNode *treefile_rootval = NULL;

--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -53,7 +53,6 @@ get_connection_for_path (gchar *sysroot,
 
   const gchar *args[] = {
     "rpm-ostree",
-    "internals",
     "start-daemon",
     "--sysroot", sysroot,
     "--dbus-peer", buffer,

--- a/src/daemon/org.projectatomic.rpmostree1.service.in
+++ b/src/daemon/org.projectatomic.rpmostree1.service.in
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=org.projectatomic.rpmostree1
-Exec=@bindir@/rpm-ostree internals start-daemon
+Exec=@bindir@/rpm-ostree start-daemon
 User=root
 SystemdService=@primaryname@d.service

--- a/src/daemon/rpm-ostreed-stub.sh.in
+++ b/src/daemon/rpm-ostreed-stub.sh.in
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec @bindir@/rpm-ostree internals start-daemon "$@"
+exec @bindir@/rpm-ostree start-daemon "$@"

--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -6,4 +6,4 @@ ConditionPathExists=/ostree
 Type=dbus
 BusName=org.projectatomic.rpmostree1
 @SYSTEMD_ENVIRON@
-ExecStart=@bindir@/rpm-ostree internals start-daemon
+ExecStart=@bindir@/rpm-ostree start-daemon

--- a/tests/utils/setup-session.sh
+++ b/tests/utils/setup-session.sh
@@ -56,7 +56,7 @@ EOF
 cat > session-services/rpmostree.service <<EOF
 [D-BUS Service]
 Name=org.projectatomic.rpmostree1
-Exec=${exec_binary} internals start-daemon --debug --sysroot=${test_tmpdir}/sysroot
+Exec=${exec_binary} start-daemon --debug --sysroot=${test_tmpdir}/sysroot
 EOF
 
 # Tell rpm-ostree to connect to the session bus instead of system


### PR DESCRIPTION
I debated just putting this in the supported list, but decided against
it in the end. This really should be something that happens
transparently, and if it doesn't then something else is probably wrong.