### PR TITLE
ux: improve package diff outputs

### DIFF
--- a/src/lib/rpmostree-package.c
+++ b/src/lib/rpmostree-package.c
@@ -135,35 +135,7 @@ rpm_ostree_package_get_arch (RpmOstreePackage *p)
 int
 rpm_ostree_package_cmp (RpmOstreePackage *p1, RpmOstreePackage *p2)
 {
-  /* XXX This is equivalent to hy_package_cmp(), but works
-   *     for comparing packages from different memory pools.
-   *
-   *     See https://github.com/rpm-software-management/hawkey/pull/90
-   */
-
-  const char *str1, *str2;
-  gint ret;
-
-  str1 = rpm_ostree_package_get_name (p1);
-  str2 = rpm_ostree_package_get_name (p2);
-  ret = strcmp (str1, str2);
-
-  if (ret != 0)
-    return ret;
-
-  str1 = rpm_ostree_package_get_evr (p1);
-  str2 = rpm_ostree_package_get_evr (p2);
-
-  /* This assumes both pools (if they are different)
-   * have identical configuration for epoch handling. */
-  ret = dnf_sack_evr_cmp (p1->sack->sack, str1, str2);
-
-  if (ret != 0)
-    return ret;
-
-  str1 = rpm_ostree_package_get_arch (p1);
-  str2 = rpm_ostree_package_get_arch (p2);
-  return strcmp (str1, str2);
+  return dnf_package_cmp (p1->hypkg, p2->hypkg);
 }
 
 RpmOstreePackage *


### PR DESCRIPTION
This patch makes the diff outputs generated by deploy commands (like
`upgrade`/`deploy`/`rebase`) and `db diff` commands the same. They were both
tweaked in different ways. The former gained the ability to discern
between upgrades and downgrades, the latter gained the ability the print
package version transitions.

Of course, the best way to make them the same would be to make them use
the same code, though I'm not sure it's worth the pain to gain ratio at
this point...

Closes: #575