### PR TITLE
daemon: Do tmprootfs checkout just-in-time if possible

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -43,6 +43,11 @@ commit_get_parent_csum (OstreeRepo  *repo,
                         const char  *child,
                         char       **out_csum,
                         GError     **error);
+static gboolean
+get_base_commit_for_deployment (OstreeRepo                *repo,
+                                OstreeDeployment          *deployment,
+                                char                     **out_base,
+                                GError                   **error);
 
 /**
  * SECTION:rpmostree-sysroot-upgrader
@@ -76,6 +81,7 @@ struct RpmOstreeSysrootUpgrader {
 
   /* Used during tree construction */
   OstreeRepoDevInoCache *devino_cache;
+  int overlay_rootfs_dfd;
   int tmprootfs_dfd;
   char *tmprootfs;
 
@@ -244,6 +250,10 @@ rpmostree_sysroot_upgrader_finalize (GObject *object)
 {
   RpmOstreeSysrootUpgrader *self = RPMOSTREE_SYSROOT_UPGRADER (object);
 
+  /* The overlay_rootfs_dfd may just be an alias for tmprootfs_dfd */
+  if (self->overlay_rootfs_dfd != -1 &&
+      self->overlay_rootfs_dfd != self->tmprootfs_dfd)
+    (void) close (self->overlay_rootfs_dfd);
   if (self->tmprootfs_dfd != -1)
     {
       (void)glnx_shutil_rm_rf_at (AT_FDCWD, self->tmprootfs, NULL, NULL);
@@ -362,6 +372,7 @@ static void
 rpmostree_sysroot_upgrader_init (RpmOstreeSysrootUpgrader *self)
 {
   self->tmprootfs_dfd = -1;
+  self->overlay_rootfs_dfd = -1;
 }
 
 
@@ -893,7 +904,7 @@ finalize_requested_packages (RpmOstreeSysrootUpgrader *self,
       g_hash_table_add (pkgset, g_strdup (itkey));
   }
 
-  if (!find_pkgs_in_rpmdb (self->tmprootfs_dfd, pkgset, pkg_find_cb,
+  if (!find_pkgs_in_rpmdb (self->overlay_rootfs_dfd, pkgset, pkg_find_cb,
                            cancellable, self, error))
     goto out;
 
@@ -970,7 +981,7 @@ overlay_final_pkgset (RpmOstreeSysrootUpgrader *self,
   g_autoptr(RpmOstreeTreespec) treespec = NULL;
   g_autoptr(RpmOstreeInstall) install = {0,};
   g_autoptr(GHashTable) pkgset = hashset_from_strv (rpmostree_origin_get_packages (self->origin));
-  g_autofree char *tmprootfs_abspath = glnx_fdrel_abspath (self->tmprootfs_dfd, ".");
+  g_autofree char *tmprootfs_abspath = glnx_fdrel_abspath (self->overlay_rootfs_dfd, ".");
   const gboolean have_packages = g_hash_table_size (pkgset) > 0;
   glnx_unref_object OstreeRepo *pkgcache_repo = NULL;
 
@@ -1002,9 +1013,16 @@ overlay_final_pkgset (RpmOstreeSysrootUpgrader *self,
   /* load the sepolicy to use during import */
   {
     glnx_unref_object OstreeSePolicy *sepolicy = NULL;
-    if (!rpmostree_prepare_rootfs_get_sepolicy (self->tmprootfs_dfd, ".", &sepolicy,
+    /* FIXME - at this point the overlay rootfs should be read-only, but this
+     * function may mutate files in /etc.  We should see if we can drop the cross-labeling
+     * hack.
+     */
+    if (!rpmostree_prepare_rootfs_get_sepolicy (self->overlay_rootfs_dfd, ".", &sepolicy,
                                                 cancellable, error))
-      goto out;
+      {
+        g_prefix_error (error, "Loading sepolicy: ");
+        goto out;
+      }
 
     rpmostree_context_set_sepolicy (ctx, sepolicy);
   }
@@ -1018,7 +1036,10 @@ overlay_final_pkgset (RpmOstreeSysrootUpgrader *self,
 
   if (!rpmostree_context_setup (ctx, tmprootfs_abspath, NULL, treespec,
                                 cancellable, error))
-    goto out;
+    {
+      g_prefix_error (error, "Initializing context: ");
+      goto out;
+    }
 
   if (self->ignore_scripts)
     rpmostree_context_set_ignore_scripts (ctx, self->ignore_scripts);
@@ -1063,7 +1084,14 @@ overlay_final_pkgset (RpmOstreeSysrootUpgrader *self,
       if (!rpmostree_context_relabel (ctx, install, cancellable, error))
         goto out;
 
-      /* --- Overlay and commit --- */
+      /* --- Overlay and commit ---
+       * We may have not allocated a tmprootfs yet; do so now if necessary.
+       */
+      if (self->tmprootfs_dfd == -1)
+        {
+          if (!checkout_base_tree (self, cancellable, error))
+            goto out;
+        }
 
       g_clear_pointer (&self->final_revision, g_free);
       if (!rpmostree_context_assemble_tmprootfs (ctx, self->tmprootfs_dfd, self->devino_cache,
@@ -1130,10 +1158,38 @@ overlay_packages (RpmOstreeSysrootUpgrader *self,
                   GCancellable             *cancellable,
                   GError                  **error)
 {
+  OstreeDeployment *booted_deployment;
+  g_autofree char *booted_base_checksum = NULL;
   self->devino_cache = ostree_repo_devino_cache_new ();
 
-  if (!checkout_base_tree (self, cancellable, error))
-    return FALSE;
+  g_assert_cmpint (self->overlay_rootfs_dfd, ==, -1);
+
+  booted_deployment = ostree_sysroot_get_booted_deployment (self->sysroot);
+  if (booted_deployment)
+    {
+      if (!get_base_commit_for_deployment (self->repo, booted_deployment, &booted_base_checksum, error))
+        return FALSE;
+      if (!booted_base_checksum)
+        booted_base_checksum = g_strdup (ostree_deployment_get_csum (booted_deployment));
+    }
+
+  fprintf (stderr, "booteddep %p base %s booted %s\n", booted_deployment, self->base_revision, booted_base_checksum);
+
+  /* If the booted base is the same as our target, reuse that. This avoids
+   * paying the price of doing the checkout as the very first thing; we may not
+   * need it if the operation would result in an error for example.
+   */
+  if (booted_base_checksum && strcmp (booted_base_checksum, self->base_revision) == 0)
+    {
+      if (!glnx_opendirat (AT_FDCWD, "/", TRUE, &self->overlay_rootfs_dfd, error))
+        return FALSE;
+    }
+  else
+    {
+      if (!checkout_base_tree (self, cancellable, error))
+        return FALSE;
+      self->overlay_rootfs_dfd = self->tmprootfs_dfd;
+    }
 
   /* check if there are any items in requested_packages or pkgs_to_add that are
    * already installed in base_rev */

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1173,8 +1173,6 @@ overlay_packages (RpmOstreeSysrootUpgrader *self,
         booted_base_checksum = g_strdup (ostree_deployment_get_csum (booted_deployment));
     }
 
-  fprintf (stderr, "booteddep %p base %s booted %s\n", booted_deployment, self->base_revision, booted_base_checksum);
-
   /* If the booted base is the same as our target, reuse that. This avoids
    * paying the price of doing the checkout as the very first thing; we may not
    * need it if the operation would result in an error for example.


### PR DESCRIPTION
It annoyed me that e.g. `rpm-ostree install nosuchpackage` would spend time
doing a tmprootfs checkout, only to discard it. If the booted deployment's base
is the same as what we would check out, reuse it as long as possible. Only if
everything else succeeded (dependency resolution, downloads, imports), do we go
to check out a copy.

However in the rebase (or upgrade + layering simultaneously) case, we do need to
do a checkout immediately, as the rebase may have changed the OS major version
in `/usr/lib/os-release` which would affect our layering.
