### PR TITLE
unpacker: support root-owned /var & /run files

### DIFF
--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -594,7 +594,7 @@ compose_filter_cb (OstreeRepo         *repo,
 
   get_rpmfi_override (self, path, &user, &group, NULL);
 
-  /* convert /run and /var entries to tpmfiles.d */
+  /* convert /run and /var entries to tmpfiles.d */
   if (g_str_has_prefix (path, "/run/") ||
       g_str_has_prefix (path, "/var/"))
     {

--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -594,9 +594,9 @@ compose_filter_cb (OstreeRepo         *repo,
 
   get_rpmfi_override (self, path, &user, &group, NULL);
 
-  /* First, look for non-root paths in /run and /var */
-  if ((user != NULL || group != NULL) &&
-      (g_str_has_prefix (path, "/run/") || g_str_has_prefix (path, "/var/")))
+  /* convert /run and /var entries to tpmfiles.d */
+  if (g_str_has_prefix (path, "/run/") ||
+      g_str_has_prefix (path, "/var/"))
     {
       append_tmpfiles_d (self, path, file_info, user, group);
       return OSTREE_REPO_COMMIT_FILTER_SKIP;

--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -598,7 +598,8 @@ compose_filter_cb (OstreeRepo         *repo,
   if (g_str_has_prefix (path, "/run/") ||
       g_str_has_prefix (path, "/var/"))
     {
-      append_tmpfiles_d (self, path, file_info, user, group);
+      append_tmpfiles_d (self, path, file_info,
+                         user ?: "root", group ?: "root");
       return OSTREE_REPO_COMMIT_FILTER_SKIP;
     }
   else if (!error_was_set)

--- a/tests/common/compose/yum/nonrootcap.spec
+++ b/tests/common/compose/yum/nonrootcap.spec
@@ -38,6 +38,8 @@ mkdir -p %{buildroot}/usr/bin
 install *.sh %{buildroot}/usr/bin
 mkdir -p %{buildroot}/var/lib/nonrootcap
 mkdir -p %{buildroot}/run/nonrootcap
+mkdir -p %{buildroot}/var/lib/nonrootcap-rootowned
+mkdir -p %{buildroot}/run/nonrootcap-rootowned
 
 %clean
 rm -rf %{buildroot}
@@ -53,6 +55,8 @@ rm -rf %{buildroot}
 %attr(4775, nrcuser, nrcgroup) %caps(cap_net_bind_service=ep) /usr/bin/nrc-usergroupcaps-setuid.sh
 %attr(-, nrcuser, nrcgroup) /var/lib/nonrootcap
 %attr(-, nrcuser, nrcgroup) /run/nonrootcap
+/var/lib/nonrootcap-rootowned
+/run/nonrootcap-rootowned
 
 %changelog
 * Wed Jan 05 2017 Jonathan Lebon <jlebon@redhat.com> 1.0-1

--- a/tests/vmcheck/test-layering-non-root-caps.sh
+++ b/tests/vmcheck/test-layering-non-root-caps.sh
@@ -51,7 +51,9 @@ if ! vm_has_files /usr/bin/nrc-none.sh \
                   /usr/bin/nrc-usergroup.sh \
                   /usr/bin/nrc-usergroupcaps.sh \
                   /var/lib/nonrootcap \
-                  /run/nonrootcap; then
+                  /run/nonrootcap \
+                  /var/lib/nonrootcap-rootowned \
+                  /run/nonrootcap-rootowned; then
   assert_not_reached "not all files were layered"
 fi
 echo "ok all files layered"
@@ -96,4 +98,6 @@ check_file /usr/bin/nrc-usergroupcaps-setuid.sh nrcuser nrcgroup "cap_net_bind_s
 vm_cmd test -u /usr/bin/nrc-usergroupcaps-setuid.sh
 check_file /var/lib/nonrootcap nrcuser nrcgroup
 check_file /run/nonrootcap nrcuser nrcgroup
+check_file /var/lib/nonrootcap-rootowned root root
+check_file /run/nonrootcap-rootowned root root
 echo "ok correct user/group and fcaps"


### PR DESCRIPTION
I'm not sure why we weren't doing this before, but we need to also
support files in `/var` and `/run` that are owned by root.

Related: RHBZ#1421781