### PR TITLE
importer: Error importing RPMs which install to /opt (outside of /usr)

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -31,6 +31,7 @@ testpackages = \
 	tests/common/compose/yum/repo/packages/x86_64/scriptpkg1-1.0-1.x86_64.rpm \
 	tests/common/compose/yum/repo/packages/x86_64/nonrootcap-1.0-1.x86_64.rpm \
 	tests/common/compose/yum/repo/packages/x86_64/test-post-rofiles-violation-1.0-1.x86_64.rpm \
+	tests/common/compose/yum/repo/packages/x86_64/test-opt-1.0-1.x86_64.rpm \
 	$(NULL)
 
 # Create a rule for each testpkg with their respective spec file as dep.

--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -721,6 +721,13 @@ import_rpm_to_repo (RpmOstreeUnpacker *self,
       if (!ostree_repo_write_dfd_to_mtree (repo, tmpdir_dfd, ".", mtree, modifier,
                                            cancellable, error))
         goto out;
+
+      /* check if any of the cbs set an error */
+      if (cb_error != NULL)
+        {
+          *error = cb_error;
+          goto out;
+        }
     }
     
   if (!ostree_repo_write_mtree (repo, mtree, &root, cancellable, error))

--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -609,6 +609,17 @@ compose_filter_cb (OstreeRepo         *repo,
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                        "RPM had unexpected non-root owned path \"%s\", marked as %u:%u)", path, uid, gid);
+          return OSTREE_REPO_COMMIT_FILTER_SKIP;
+        }
+      /* And ensure the RPM installs into supported paths */
+      else if (!(g_str_has_prefix (path, "/usr/") || g_str_has_prefix (path, "/bin/") ||
+                 g_str_has_prefix (path, "/sbin/") || g_str_has_prefix (path, "/lib/") ||
+                 g_str_has_prefix (path, "/lib64/")))
+        {
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Unsupported path: %s; See %s",
+                       path, "https://github.com/projectatomic/rpm-ostree/issues/233");
+          return OSTREE_REPO_COMMIT_FILTER_SKIP;
         }
     }
 

--- a/tests/common/compose/yum/test-opt.spec
+++ b/tests/common/compose/yum/test-opt.spec
@@ -1,0 +1,22 @@
+Summary: Test package which installs in /opt
+Name: test-opt
+Version: 1.0
+Release: 1
+License: GPLv2+
+Group: Development/Tools
+URL: http://example.com
+BuildArch: x86_64
+
+%description
+%{summary}
+
+%prep
+
+%build
+
+%install
+mkdir -p %{buildroot}/opt/app/bin
+touch %{buildroot}/opt/app/bin/foo
+
+%files
+/opt/app

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -43,6 +43,14 @@ if vm_cmd "runuser -u bin rpm-ostree pkg-add foo-1.0"; then
     assert_not_reached "Was able to install a package as non-root!"
 fi
 
+# Be sure an unprivileged user exists
+if vm_rpmostree install test-opt-1.0 2>err.txt; then
+    assert_not_reached "Was able to install a package in /opt"
+fi
+assert_file_has_content err.txt "See https://github.com/projectatomic/rpm-ostree/issues/233"
+
+echo "ok failed to install in opt"
+
 vm_rpmostree pkg-add foo-1.0
 vm_cmd ostree --repo=/sysroot/ostree/repo/extensions/rpmostree/pkgcache refs |grep /foo/> refs.txt
 pkgref=$(head -1 refs.txt)


### PR DESCRIPTION
See https://github.com/projectatomic/rpm-ostree/issues/233 - for RPMs which
place files in e.g. `/opt`, we have different behavior in the treecompose case
(silently drop it) versus package layering (does the wrong thing).

Since the unpacker right now is only used in the layering case, this just
ensures we'll get a consistent error there.
