### PR TITLE
 daemon: Avoid erroring out on startup/status with origin unconfigured-state

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1335,7 +1335,8 @@ clean_pkgcache_orphans (OstreeSysroot            *sysroot,
       OstreeDeployment *deployment = deployments->pdata[i];
       g_autoptr(RpmOstreeOrigin) origin = NULL;
 
-      origin = rpmostree_origin_parse_deployment (deployment, error);
+      origin = rpmostree_origin_parse_deployment_ex (deployment, RPMOSTREE_ORIGIN_PARSE_FLAGS_IGNORE_UNCONFIGURED,
+                                                     error);
       if (!origin)
         return FALSE;
 

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -261,8 +261,8 @@ rpmostree_sysroot_upgrader_finalize (GObject *object)
   g_clear_object (&self->origin_merge_deployment);
   g_clear_pointer (&self->original_origin, (GDestroyNotify)rpmostree_origin_unref);
   g_clear_pointer (&self->origin, (GDestroyNotify)rpmostree_origin_unref);
-  g_hash_table_unref (self->packages_to_add);
-  g_hash_table_unref (self->packages_to_delete);
+  g_clear_pointer (&self->packages_to_add, (GDestroyNotify)g_hash_table_unref);
+  g_clear_pointer (&self->packages_to_delete, (GDestroyNotify)g_hash_table_unref);
   g_free (self->base_revision);
   g_free (self->final_revision);
 

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -191,7 +191,8 @@ rpmostreed_deployment_generate_variant (OstreeDeployment *deployment,
   
   id = rpmostreed_deployment_generate_id (deployment);
 
-  origin = rpmostree_origin_parse_deployment (deployment, error);
+  origin = rpmostree_origin_parse_deployment_ex (deployment, RPMOSTREE_ORIGIN_PARSE_FLAGS_IGNORE_UNCONFIGURED,
+                                                 error);
   if (!origin)
     return NULL;
 
@@ -281,7 +282,8 @@ rpmostreed_commit_generate_cached_details_variant (OstreeDeployment *deployment,
     {
       g_autoptr(RpmOstreeOrigin) origin = NULL;
   
-      origin = rpmostree_origin_parse_deployment (deployment, error);
+      origin = rpmostree_origin_parse_deployment_ex (deployment, RPMOSTREE_ORIGIN_PARSE_FLAGS_IGNORE_UNCONFIGURED,
+                                                     error);
       if (!origin)
         return NULL;
       origin_refspec = g_strdup (rpmostree_origin_get_refspec (origin));

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -1214,7 +1214,8 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
       g_autoptr(RpmOstreeOrigin) origin = NULL;
 
       /* Don't fail here for unknown origin types */
-      origin = rpmostree_origin_parse_deployment (merge_deployment, NULL);
+      origin = rpmostree_origin_parse_deployment_ex (merge_deployment, RPMOSTREE_ORIGIN_PARSE_FLAGS_IGNORE_UNCONFIGURED,
+                                                     NULL);
       if (origin)
         {
           cached_update = rpmostreed_commit_generate_cached_details_variant (merge_deployment,


### PR DESCRIPTION
As part of an earlier cleanup of origin parsing, we started checking
the origin `unconfigured-state` even just starting the daemon, which
is kind of bad.

It's tempting to flip the default for the parser so that we *only* check
unconfigured state if we go to upgrade, but let's not do that in this patch.