### PR TITLE
libpriv: Reduce scope of variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 rpm-ostree is a hybrid image/package system.  It uses
 [OSTree](https://ostree.readthedocs.io/en/latest/) as a base image
 format, and supports RPM on both the client and server side using
-[libhif](https://github.com/rpm-software-management/libhif).
+[libdnf](https://github.com/rpm-software-management/libdnf).
 
 For more information, see the online manual: [Read The Docs (rpm-ostree)](https://rpm-ostree.readthedocs.org/en/latest/)
 

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -508,9 +508,6 @@ rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff)
           uint64_t    ochange_date = 0;
           const char *ochange_name = NULL;
           const char *ochange_text = NULL;
-          uint64_t    nchange_date = 0;
-          const char *nchange_name = NULL;
-          const char *nchange_text = NULL;
 
           g_assert (!header_name_cmp (ho, hn));
           if (rpmVersionCompare (ho, hn) > 0)
@@ -559,6 +556,9 @@ rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff)
 
           while (ncnum > 0)
             {
+              uint64_t    nchange_date = 0;
+              const char *nchange_name = NULL;
+              const char *nchange_text = NULL;
               GDateTime *dt = NULL;
               g_autofree char *date_time_str = NULL;
 


### PR DESCRIPTION
nchange_date, nchange_name, and nchange_text are declared in a larger
scope in rpmostree-rpm-util.c. Reduce the scope to satisfy cppcheck.