### PR TITLE
upgrader: Avoid "Freed 0 pkgcache branch" pluralization failure

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1388,8 +1388,7 @@ clean_pkgcache_orphans (OstreeSysroot            *sysroot,
   if (n_freed > 0 || freed_space > 0)
     {
       char *freed_space_str = g_format_size_full (freed_space, 0);
-      g_print ("Freed %u pkgcache branch%s: %s\n", n_freed,
-               n_freed > 1 ? "es" : "", freed_space_str);
+      g_print ("Freed pkgcache branches: %u size: %s\n", n_freed, freed_space_str);
     }
 
   return TRUE;


### PR DESCRIPTION
Let's not hardcode a broken English-only version of `ngettext` here; rework the
message to avoid requiring pluralization.

