### PR TITLE
ci: Install ostree too

### DIFF
--- a/.redhat-ci.Dockerfile
+++ b/.redhat-ci.Dockerfile
@@ -13,6 +13,7 @@ RUN dnf install -y @buildsys-build && \
 # These are test-only reqs
 
 RUN dnf install -y \
+        ostree \
         createrepo_c \
         /usr/bin/jq \
         clang \


### PR DESCRIPTION
Since this is the second case I've seen tripping over this, maybe
we should add an rpm-ostree → ostree dependency?
