### PR TITLE
scripts: Bind rather than symlink /usr/etc → /etc

### DIFF
--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -192,7 +192,7 @@ run_script_in_bwrap_container (int rootfs_fd,
                                /* But no need to access persistent /tmp, so make it /tmp */
                                "--bind", "/tmp", "/var/tmp",
                                /* Allow RPM scripts to change the /etc defaults */
-                               "--symlink", "usr/etc", "/etc",
+                               "--bind", "/usr/etc", "/etc",
                                NULL);
   if (!bwrap)
     goto out;

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -191,7 +191,8 @@ run_script_in_bwrap_container (int rootfs_fd,
                                "--ro-bind", "./var", "/var",
                                /* But no need to access persistent /tmp, so make it /tmp */
                                "--bind", "/tmp", "/var/tmp",
-                               /* Allow RPM scripts to change the /etc defaults */
+                               /* Allow RPM scripts to change the /etc defaults; note we use bind
+                                * to ensure symlinks work, see https://github.com/projectatomic/rpm-ostree/pull/640 */
                                "--bind", "/usr/etc", "/etc",
                                NULL);
   if (!bwrap)

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -193,7 +193,7 @@ run_script_in_bwrap_container (int rootfs_fd,
                                "--bind", "/tmp", "/var/tmp",
                                /* Allow RPM scripts to change the /etc defaults; note we use bind
                                 * to ensure symlinks work, see https://github.com/projectatomic/rpm-ostree/pull/640 */
-                               "--bind", "/usr/etc", "/etc",
+                               "--bind", "./usr/etc", "/etc",
                                NULL);
   if (!bwrap)
     goto out;

--- a/tests/common/compose/yum/scriptpkg1.spec
+++ b/tests/common/compose/yum/scriptpkg1.spec
@@ -20,7 +20,12 @@ EOF
 chmod a+x scriptpkg1
 
 %pre
+# Test our /etc/passwd handling
 groupadd -r scriptpkg1
+
+%posttrans
+# Firewalld; https://github.com/projectatomic/rpm-ostree/issues/638
+. /etc/os-release || :
 
 %install
 mkdir -p %{buildroot}/usr/bin


### PR DESCRIPTION
This fixes resolution of relative symlinks, which fixes installation
of `firewalld` in Fedora 25.

Closes: https://github.com/projectatomic/rpm-ostree/issues/638
