### PR TITLE
util: drop custom set_prefix_error_from_errno

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -686,8 +686,7 @@ rpmostree_compose_builtin_tree (int             argc,
         {
           if (mount ("tmpfs", tmpd, "tmpfs", 0, (const void*)"mode=755") != 0)
             {
-              _rpmostree_set_prefix_error_from_errno (error, errno,
-                                                      "mount(tmpfs): ");
+              glnx_set_prefix_error_from_errno (error, "%s", "mount(tmpfs)");
               goto out;
             }
         }

--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -679,7 +679,7 @@ gfopen (const char       *path,
   ret = fopen (path, mode);
   if (!ret)
     {
-      _rpmostree_set_prefix_error_from_errno (error, errno, "fopen(%s): ", path);
+      glnx_set_prefix_error_from_errno (error, "fopen(%s)", path);
       return NULL;
     }
   return ret;
@@ -692,7 +692,7 @@ gfflush (FILE         *f,
 {
   if (fflush (f) != 0)
     {
-      _rpmostree_set_prefix_error_from_errno (error, errno, "fflush: ");
+      glnx_set_prefix_error_from_errno (error, "%s", "fflush");
       return FALSE;
     }
   return TRUE;
@@ -754,7 +754,7 @@ rpmostree_passwd_migrate_except_root (GFile         *rootfs,
         {
           if (errno != 0 && errno != ENOENT)
             {
-              _rpmostree_set_prefix_error_from_errno (error, errno, "fgetpwent: ");
+              glnx_set_prefix_error_from_errno (error, "%s", "fgetpwent");
               goto out;
             }
           else
@@ -802,7 +802,7 @@ rpmostree_passwd_migrate_except_root (GFile         *rootfs,
 
       if (r == -1)
         {
-          _rpmostree_set_prefix_error_from_errno (error, errno, "putpwent: ");
+          glnx_set_prefix_error_from_errno (error, "%s", "putpwent");
           goto out;
         }
     }
@@ -814,8 +814,8 @@ rpmostree_passwd_migrate_except_root (GFile         *rootfs,
 
   if (rename (etctmp_path, src_path) != 0)
     {
-      _rpmostree_set_prefix_error_from_errno (error, errno, "rename(%s, %s): ",
-                                              etctmp_path, src_path);
+      glnx_set_prefix_error_from_errno (error, "rename(%s, %s)",
+                                        etctmp_path, src_path);
       goto out;
     }
 
@@ -905,7 +905,7 @@ concat_entries (FILE    *src_stream,
         {
           if (errno != 0 && errno != ENOENT)
             {
-              _rpmostree_set_prefix_error_from_errno (error, errno, "fgetpwent: ");
+              glnx_set_prefix_error_from_errno (error, "%s", "fgetpwent");
               goto out;
             }
           else
@@ -929,7 +929,7 @@ concat_entries (FILE    *src_stream,
 
       if (r == -1)
         {
-          _rpmostree_set_prefix_error_from_errno (error, errno, "putpwent: ");
+          glnx_set_prefix_error_from_errno (error, "%s", "putpwent");
           goto out;
         }
     }

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -29,42 +29,6 @@
 #include "rpmostree-util.h"
 #include "libglnx.h"
 
-void
-_rpmostree_set_error_from_errno (GError    **error,
-                                 gint        errsv)
-{
-  g_set_error_literal (error,
-                       G_IO_ERROR,
-                       g_io_error_from_errno (errsv),
-                       g_strerror (errsv));
-  errno = errsv;
-}
-
-void
-_rpmostree_set_prefix_error_from_errno (GError     **error,
-                                        gint         errsv,
-                                        const char  *format,
-                                        ...)
-{
-  g_autofree char *formatted = NULL;
-  va_list args;
-  
-  va_start (args, format);
-  formatted = g_strdup_vprintf (format, args);
-  va_end (args);
-  
-  _rpmostree_set_error_from_errno (error, errsv);
-  g_prefix_error (error, "%s", formatted);
-  errno = errsv;
-}
-
-void
-_rpmostree_perror_fatal (const char *message)
-{
-  perror (message);
-  exit (1);
-}
-
 int
 rpmostree_ptrarray_sort_compare_strings (gconstpointer ap,
                                          gconstpointer bp)
@@ -376,7 +340,7 @@ _rpmostree_sync_wait_on_pid (pid_t          pid,
 
   if (r == -1)
     {
-      _rpmostree_set_prefix_error_from_errno (error, errno, "waitpid: ");
+      glnx_set_prefix_error_from_errno (error, "%s", "waitpid");
       goto out;
     }
 

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -25,18 +25,6 @@
 #include <sys/wait.h>
 #include <ostree.h>
 
-void
-_rpmostree_set_error_from_errno (GError    **error,
-                                 gint        errsv);
-
-void
-_rpmostree_set_prefix_error_from_errno (GError     **error,
-                                        gint         errsv,
-                                        const char  *format,
-                                        ...) G_GNUC_PRINTF (3,4);
-
-void _rpmostree_perror_fatal (const char *message) __attribute__ ((noreturn));
-
 int
 rpmostree_ptrarray_sort_compare_strings (gconstpointer ap,
                                          gconstpointer bp);


### PR DESCRIPTION
We can use libglnx functions for this now.