### PR TITLE
scripts: Use the in-container /tmp, not the host's

### DIFF
--- a/scripts/bwrap-script-shell.sh
+++ b/scripts/bwrap-script-shell.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Run a shell (or program) like how rpm-ostree would run RPM scriptlets. Useful
+# for quickly testing changes to the script environment.
+rootfs=$1
+shift
+cd ${rootfs}
+# ⚠⚠⚠ If you change this, also update src/libpriv/rpmostree-scripts.c ⚠⚠⚠
+BWRAP_ARGV="--dev /dev --proc /proc --dir /tmp --chdir / \
+     --unshare-pid --unshare-net --unshare-uts \
+     --unshare-ipc --unshare-cgroup-try \
+"
+for src in /sys/{block,bus,class,dev}; do
+    BWRAP_ARGV="$BWRAP_ARGV --ro-bind $src $src"
+done
+for src in lib{,32,64} bin sbin; do
+    if test -L $src; then
+        BWRAP_ARGV="$BWRAP_ARGV --symlink usr/$src $src"
+    fi
+done
+BWRAP_ARGV="$BWRAP_ARGV --ro-bind usr /usr --ro-bind ./var /var --bind ./usr/etc /etc --tmpfs /var/tmp"
+echo exec bwrap $BWRAP_ARGV "$@"
+exec env PS1='bwrap$ ' bwrap $BWRAP_ARGV "$@"

--- a/src/libpriv/rpmostree-bwrap.c
+++ b/src/libpriv/rpmostree-bwrap.c
@@ -192,6 +192,7 @@ rpmostree_bwrap_new (int rootfs_fd,
   ret->rootfs_fd = rootfs_fd;
   ret->argv = g_ptr_array_new_with_free_func (g_free);
 
+  /* ⚠⚠⚠ If you change this, also update scripts/bwrap-script-shell.sh ⚠⚠⚠ */
   rpmostree_bwrap_append_bwrap_argv (ret,
                                      WITH_BUBBLEWRAP_PATH,
                                      "--dev", "/dev",

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -186,11 +186,16 @@ run_script_in_bwrap_container (int rootfs_fd,
   else
     created_var_tmp = TRUE;
 
+  /* ⚠⚠⚠ If you change this, also update scripts/bwrap-script-shell.sh ⚠⚠⚠ */
+
+  /* We just did a ro bind mount over /var above. However we want a writable
+   * var/tmp, so we need to tmpfs mount on top of it. See also
+   * https://github.com/projectatomic/bubblewrap/issues/182
+   */
   bwrap = rpmostree_bwrap_new (rootfs_fd, RPMOSTREE_BWRAP_MUTATE_ROFILES, error,
                                /* Scripts can see a /var with compat links like alternatives */
                                "--ro-bind", "./var", "/var",
-                               /* But no need to access persistent /tmp, so make it /tmp */
-                               "--bind", "/tmp", "/var/tmp",
+                               "--tmpfs", "/var/tmp",
                                /* Allow RPM scripts to change the /etc defaults; note we use bind
                                 * to ensure symlinks work, see https://github.com/projectatomic/rpm-ostree/pull/640 */
                                "--bind", "./usr/etc", "/etc",

--- a/tests/common/compose/yum/scriptpkg1.spec
+++ b/tests/common/compose/yum/scriptpkg1.spec
@@ -26,6 +26,10 @@ groupadd -r scriptpkg1
 %posttrans
 # Firewalld; https://github.com/projectatomic/rpm-ostree/issues/638
 . /etc/os-release || :
+# See https://github.com/projectatomic/rpm-ostree/pull/647
+for path in /tmp /var/tmp; do
+    if test -f ${path}/file-in-host-tmp-not-for-scripts; then echo "found file from host /tmp"; exit 1; fi
+done
 
 %install
 mkdir -p %{buildroot}/usr/bin

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -31,6 +31,8 @@ vm_send_test_repo
 # make sure the package is not already layered
 vm_assert_layered_pkg scriptpkg1 absent
 
+# See scriptpkg1.spec
+vm_cmd touch /tmp/file-in-host-tmp-not-for-scripts
 vm_rpmostree pkg-add scriptpkg1
 echo "ok pkg-add scriptpkg1"
 


### PR DESCRIPTION
We don't want to expose the host's `/tmp` since that means scripts
could potentially find things like the X11 socket or whatever.

This was just a think-o.
