### PR TITLE
core: no longer embed treespec

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2483,10 +2483,6 @@ rpmostree_context_commit_tmprootfs (RpmOstreeContext      *self,
                               spec_v);
 
         g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.serverbase",
-                               g_variant_new_boolean (TRUE));
-
-        g_variant_builder_add (&metadata_builder, "{sv}",
-                               "rpmostree.serverbase_version",
                                g_variant_new_uint32 (1));
       }
     else

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2463,7 +2463,7 @@ rpmostree_context_commit_tmprootfs (RpmOstreeContext      *self,
           }
         else
           {
-            const char *const* p = { NULL };
+            const char *const p[] = { NULL };
             g_variant_builder_add (&metadata_builder, "{sv}",
                                    "rpmostree.packages",
                                    g_variant_new_strv (p, -1));

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2428,11 +2428,8 @@ rpmostree_context_commit_tmprootfs (RpmOstreeContext      *self,
     g_autoptr(GFile) root = NULL;
     g_auto(GVariantBuilder) metadata_builder;
     g_autofree char *state_checksum = NULL;
-    g_autoptr(GVariant) spec_v = g_variant_ref_sink (rpmostree_treespec_to_variant (self->spec));
 
     g_variant_builder_init (&metadata_builder, (GVariantType*)"a{sv}");
-
-    g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.spec", spec_v);
 
     if (assemble_type == RPMOSTREE_ASSEMBLE_TYPE_CLIENT_LAYERING)
       {
@@ -2455,11 +2452,48 @@ rpmostree_context_commit_tmprootfs (RpmOstreeContext      *self,
         g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.clientlayer",
                                g_variant_new_boolean (TRUE));
 
+        if (!self->empty)
+          {
+            g_autoptr(GVariant) pkgs =
+              g_variant_dict_lookup_value (self->spec->dict, "packages",
+                                           G_VARIANT_TYPE ("as"));
+            g_assert (pkgs);
+            g_variant_builder_add (&metadata_builder, "{sv}",
+                                   "rpmostree.packages", pkgs);
+          }
+        else
+          {
+            const char *const* p = { NULL };
+            g_variant_builder_add (&metadata_builder, "{sv}",
+                                   "rpmostree.packages",
+                                   g_variant_new_strv (p, -1));
+          }
+
         /* be nice to our future selves */
         g_variant_builder_add (&metadata_builder, "{sv}",
                                "rpmostree.clientlayer_version",
-                               g_variant_new_uint32 (0));
+                               g_variant_new_uint32 (1));
       }
+    else if (assemble_type == RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE)
+      {
+        g_autoptr(GVariant) spec_v =
+          g_variant_ref_sink (rpmostree_treespec_to_variant (self->spec));
+
+        g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.spec",
+                              spec_v);
+
+        g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.serverbase",
+                               g_variant_new_boolean (TRUE));
+
+        g_variant_builder_add (&metadata_builder, "{sv}",
+                               "rpmostree.serverbase_version",
+                               g_variant_new_uint32 (1));
+      }
+    else
+      {
+        g_assert_not_reached ();
+      }
+
 
     state_checksum = rpmostree_context_get_state_sha512 (self);
 


### PR DESCRIPTION
In the case of client layering, we hackily use the treespec because
that's what the core understands (for now), but it really shouldn't be
part of the final commit, nor should we rely on it.

This patch starts the path towards moving us away from the treespec by
not embedding it in client layers, and instead directly inserting
layered packages under the "rpmostree.packages" key.

The SERVER_BASE case still embeds the treespec, since only the container
path uses it for now and it needs it.

Down the line, we'll want to make the treespec just one of the methods
by which we initialize RpmOstreeContext. But nothing stops us from
hiding that detail already.