### PR TITLE
core: Plug leak of pkgcache repo

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -285,6 +285,7 @@ rpmostree_context_finalize (GObject *object)
       g_clear_pointer (&rctx->dummy_instroot_path, g_free);
     }
 
+  g_clear_object (&rctx->pkgcache_repo);
   g_clear_object (&rctx->ostreerepo);
 
   g_clear_object (&rctx->sepolicy);


### PR DESCRIPTION
This showed up as a number of duplicate fds to the pkgcache root in
`/proc/<pid>/fd` for the daemon.
