### PR TITLE
build: Depend on ostree 2017.2, drop check for gpg symbol

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,18 +81,13 @@ AC_SEARCH_LIBS([rpmsqSetInterruptSafety], [rpmio],
 # Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 >= 2.40.0 json-glib-1.0
-				     ostree-1 >= 2016.7
+				     ostree-1 >= 2017.2
 				     libsystemd
 				     rpm librepo
 				     libarchive])
 dnl bundled libdnf
 PKGDEP_RPMOSTREE_CFLAGS="-I $(pwd)/libdnf -I $(pwd)/libdnf-build $PKGDEP_RPMOSTREE_CFLAGS"
 PKGDEP_RPMOSTREE_LIBS="-L$(pwd)/libdnf-build/libdnf -ldnf $PKGDEP_RPMOSTREE_LIBS"
-
-save_LIBS=$LIBS
-LIBS=$PKGDEP_RPMOSTREE_LIBS
-AC_CHECK_FUNCS(ostree_repo_verify_commit_for_remote)
-LIBS=$save_LIBS
 
 AC_PATH_PROG([XSLTPROC], [xsltproc])
 

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -98,11 +98,7 @@ rpmostreed_deployment_gpg_results (OstreeRepo *repo,
   if (!gpg_verify)
     goto out;
 
-#ifdef HAVE_OSTREE_REPO_VERIFY_COMMIT_FOR_REMOTE
   result = ostree_repo_verify_commit_for_remote (repo, csum, remote, NULL, &error);
-#else
-  result = ostree_repo_verify_commit_ext (repo, csum, NULL, NULL, NULL, &error);
-#endif
   if (!result)
       goto out;
 


### PR DESCRIPTION
Since somehow it's breaking in [Fedora's Koji](https://kojipkgs.fedoraproject.org//packages/rpm-ostree/2017.2/2.fc25/data/logs/x86_64/build.log)
and I don't feel like debugging it.  Let's just take a hard dependency
now and kill the conditional.

Closes: https://github.com/projectatomic/rpm-ostree/issues/653
