### PR TITLE
core: Sort input pkglist for state-sha512

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1004,6 +1004,13 @@ rpmostree_context_prepare_install (RpmOstreeContext    *self,
   return ret;
 }
 
+static gint
+pkg_array_compare (DnfPackage **p_pkg1,
+                   DnfPackage **p_pkg2)
+{
+  return dnf_package_cmp (*p_pkg1, *p_pkg2);
+}
+
 /* Generate a checksum from a goal in a repeatable fashion -
  * we checksum an ordered array of the checksums of individual
  * packages.  We *used* to just checksum the NEVRAs but that
@@ -1022,6 +1029,7 @@ rpmostree_dnf_add_checksum_goal (GChecksum *checksum,
 
   pkglist = hy_goal_list_installs (goal, NULL);
   g_assert (pkglist);
+  g_ptr_array_sort (pkglist, (GCompareFunc)pkg_array_compare);
   for (i = 0; i < pkglist->len; i++)
     {
       DnfPackage *pkg = pkglist->pdata[i];


### PR DESCRIPTION
I am seeing the [Atomic WS](https://pagure.io/atomic-ws) treecompose
often now shipping "null" commits where nothing changed in the
inputs.

Looking at the code here...I think we were likely getting lucky
before - we weren't sorting the packagelist explicitly.  I couldn't
get it to randomly change in local tests, but reading the source of
`hy_goal_list_installs()` this looks subject to libsolv internals.

Trapping in `gdb` and printing the first package to the checksum, before this I
got `NetworkManager-pptp-gnome-1:1.2.4-1.fc25.x86_64` which seems random enough.
After I get `GConf2-3.2.6-16.fc24.x86_64` which is the same as the first package
in the transaction list (as expected).
