### PR TITLE
Release 2017.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rpm-ostree], [2017.2], [walters@verbum.org])
+AC_INIT([rpm-ostree], [2017.3], [walters@verbum.org])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
This release includes a fix for [CVE-2017-2623](https://bugzilla.redhat.com/show_bug.cgi?id=1422157).

There are a few new features, such as `systemctl reload rpm-ostreed` now being
supported. Some bugfixes such as memory leak fixes. Besides that, there's a lot
of internal refactoring going on in preparation for work on local RPM
installation.

```
Chen Fan (1):
      remove duplicate words in comment

Colin Walters (12):
      build: Deal with gperf 3.1 changing to size_t
      upgrader: Avoid "Freed 0 pkgcache branch" pluralization failure
      ci: Install ostree too
      ci: Hotfix ostree temporarily
      tree-wide: Use autoptr cleanup for HyQuery
      daemon: Squash a memleak of parent commit
      scripts: Bind rather than symlink /usr/etc → /etc
      daemon: Implement "reload"
      scripts: Use tmpfs for /var/tmp, not the host's /tmp
      core: Plug leak of pkgcache repo
      build: Depend on ostree 2017.2, drop check for gpg symbol
      Release 2017.3

Eduardo Mayorga (2):
      libpriv: Reduce scope of variables
      README.md: libhif is now called libdnf

Jonathan Lebon (15):
      Makefile.am: add rpm-ostreed stub to GITIGNOREFILES
      test-initramfs.sh: fix for centos
      package_diff: make use of apply_revision_override
      upgrader: drop support for ignore scripts
      upgrader: move origin mutation outside of the upgrader
      RpmOstreeOrigin: don't error on unconfigured state
      util: drop custom set_prefix_error_from_errno
      libvm: don't call rpm-ostree status on first time
      vmcheck/test.sh: output reboot details to log
      RpmOstreeOrigin: remove is_locally_assembled()
      RpmOstreeOrigin: also cache initramfs args
      upgrader: switch to stateless model
      vmcheck: adjust for new behaviour
      origin: fix indentation
      core: no longer embed treespec
```
