### PR TITLE
remove buildrequired package libgsystem

### DIFF
--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -13,7 +13,6 @@ BuildRequires: autoconf automake libtool
 BuildRequires: gtk-doc
 BuildRequires: gnome-common
 BuildRequires: pkgconfig(ostree-1)
-BuildRequires: pkgconfig(libgsystem)
 BuildRequires: pkgconfig(libarchive)
 BuildRequires: pkgconfig(libhif)
 BuildRequires: pkgconfig(librepo)


### PR DESCRIPTION
libgsystem does not required any more since c8e7c63ab22608e67ca5512f060c78ae461afdd9
   Final removal of libgsystem dependency
    
    Just like ostree.  Now we can consider it dead.
    
    Closes: #511
    Approved by: jlebon

