### PR TITLE
status: always include the packages entries

### DIFF
--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -236,15 +236,18 @@ rpmostreed_deployment_generate_variant (OstreeDeployment *deployment,
     }
 
   g_variant_dict_insert (&dict, "origin", "s", refspec);
-  if (g_hash_table_size (rpmostree_origin_get_packages (origin)) > 0)
-    {
-      g_autofree char **pkgs =
-        (char**)g_hash_table_get_keys_as_array (rpmostree_origin_get_packages (origin), NULL);
-      g_variant_dict_insert (&dict, "requested-packages", "^as", pkgs);
-    }
+
+  g_autofree char **requested_pkgs =
+    (char**)g_hash_table_get_keys_as_array (rpmostree_origin_get_packages (origin), NULL);
+  g_variant_dict_insert (&dict, "requested-packages", "^as", requested_pkgs);
 
   if (is_layered && g_strv_length (layered_pkgs) > 0)
     g_variant_dict_insert (&dict, "packages", "^as", layered_pkgs);
+  else
+    {
+      const char *const p[] = { NULL };
+      g_variant_dict_insert (&dict, "packages", "^as", p);
+    }
 
   if (sigs != NULL)
     g_variant_dict_insert_value (&dict, "signatures", sigs);

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -37,6 +37,12 @@ vm_assert_status_jq \
   '.deployments[0]["base-checksum"]|not' \
   '.deployments[0]["pending-base-checksum"]|not'
 
+# make sure that package-related entries are always present,
+# even when they're empty
+vm_assert_status_jq \
+  '.deployments[0]["packages"]' \
+  '.deployments[0]["requested-packages"]'
+
 # Be sure an unprivileged user exists
 vm_cmd getent passwd bin
 if vm_cmd "runuser -u bin rpm-ostree pkg-add foo-1.0"; then


### PR DESCRIPTION
Pull #646 introduced a subtle regression: we went from always including
a "packages" entry to only including it if there are packages present.
Albeit it's easy to guard against, though to be nice, let's make it
easier for consumers by always including it.

Reported-by: Micah Abbott <miabbott@redhat.com>