### PR TITLE
vmcheck: add support for parallel runs

### DIFF
--- a/.redhat-ci.ssh-config
+++ b/.redhat-ci.ssh-config
@@ -1,4 +1,0 @@
-Host vmcheck
-     UserKnownHostsFile /dev/null
-     StrictHostKeyChecking no
-     PasswordAuthentication no

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -64,17 +64,20 @@ required: true
 
 cluster:
   hosts:
-    - name: vmcheck
+    - name: vmcheck1
+      distro: fedora/25/atomic
+    - name: vmcheck2
+      distro: fedora/25/atomic
+    - name: vmcheck3
       distro: fedora/25/atomic
   container:
     image: projectatomic/rpm-ostree-tester
 
 tests:
-  - make vmcheck
+  - make vmcheck HOSTS="vmcheck1 vmcheck2 vmcheck3"
 
 artifacts:
-  - vmcheck.log
-  - vmcheck-journal.txt
+  - vmcheck
 
 # We really need to work on getting this down:
 # https://github.com/projectatomic/rpm-ostree/issues/662

--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -70,7 +70,6 @@ cluster:
     image: projectatomic/rpm-ostree-tester
 
 tests:
-  - cp .redhat-ci.ssh-config ssh-config
   - make vmcheck
 
 artifacts:

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -111,6 +111,7 @@ HOSTS := "vmcheck"
 
 vmoverlay:
 	@if [ -z "$(SKIP_VMOVERLAY)" ]; then \
+	  rm -rf $(abs_top_srcdir)/insttree
 	  echo -n "$(HOSTS)" | xargs -P 0 -n 1 -d ' ' -I {} \
 	    env $(BASE_TESTS_ENVIRONMENT) VM={} \
 	      ./tests/vmcheck/overlay.sh; \

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -109,7 +109,13 @@ vmsync:
 
 vmoverlay:
 	@if [ -z "$(SKIP_VMOVERLAY)" ]; then \
-	  env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/overlay.sh; \
+	  if [ -n "$(HOSTS)" ]; then \
+	    echo -n "$(HOSTS)" | xargs -P 0 -n 1 -d ' ' -I {} \
+	      env $(BASE_TESTS_ENVIRONMENT) VM={} PYTHONUNBUFFERED=1 \
+	        ./tests/vmcheck/overlay.sh; \
+	  else \
+	    env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/overlay.sh; \
+	  fi \
 	fi
 
 vmshell: vmsync
@@ -117,8 +123,15 @@ vmshell: vmsync
 
 # set up test environment to somewhat resemble uninstalled tests
 vmcheck: vmoverlay tests/common/compose/yum/repo/repodata/repomd.xml
-	@env VMTESTS=1 $(BASE_TESTS_ENVIRONMENT) \
-	   sh tests/vmcheck/test.sh
+	@if [ -z "$(HOSTS)" ]; then \
+	  echo "running test.sh"; \
+	  env VMTESTS=1 $(BASE_TESTS_ENVIRONMENT) \
+	    sh tests/vmcheck/test.sh; \
+	else \
+	  echo "running multitest.py"; \
+	  env VMTESTS=1 $(BASE_TESTS_ENVIRONMENT) \
+	    tests/vmcheck/multitest.py $(HOSTS); \
+	fi
 
 testenv:
 	@echo "===== ENTERING TESTENV ====="

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -107,15 +107,13 @@ check-local:
 vmsync:
 	@env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/sync.sh
 
+HOSTS := "vmcheck"
+
 vmoverlay:
 	@if [ -z "$(SKIP_VMOVERLAY)" ]; then \
-	  if [ -n "$(HOSTS)" ]; then \
-	    echo -n "$(HOSTS)" | xargs -P 0 -n 1 -d ' ' -I {} \
-	      env $(BASE_TESTS_ENVIRONMENT) VM={} PYTHONUNBUFFERED=1 \
-	        ./tests/vmcheck/overlay.sh; \
-	  else \
-	    env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/overlay.sh; \
-	  fi \
+	  echo -n "$(HOSTS)" | xargs -P 0 -n 1 -d ' ' -I {} \
+	    env $(BASE_TESTS_ENVIRONMENT) VM={} \
+	      ./tests/vmcheck/overlay.sh; \
 	fi
 
 vmshell: vmsync
@@ -123,15 +121,8 @@ vmshell: vmsync
 
 # set up test environment to somewhat resemble uninstalled tests
 vmcheck: vmoverlay tests/common/compose/yum/repo/repodata/repomd.xml
-	@if [ -z "$(HOSTS)" ]; then \
-	  echo "running test.sh"; \
-	  env VMTESTS=1 $(BASE_TESTS_ENVIRONMENT) \
-	    sh tests/vmcheck/test.sh; \
-	else \
-	  echo "running multitest.py"; \
-	  env VMTESTS=1 $(BASE_TESTS_ENVIRONMENT) \
-	    tests/vmcheck/multitest.py $(HOSTS); \
-	fi
+	@env VMTESTS=1 $(BASE_TESTS_ENVIRONMENT) PYTHONUNBUFFERED=1 \
+	  tests/vmcheck/multitest.py $(HOSTS)
 
 testenv:
 	@echo "===== ENTERING TESTENV ====="

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -111,7 +111,7 @@ HOSTS := "vmcheck"
 
 vmoverlay:
 	@if [ -z "$(SKIP_VMOVERLAY)" ]; then \
-	  rm -rf $(abs_top_srcdir)/insttree
+	  rm -rf $(abs_top_srcdir)/insttree \
 	  echo -n "$(HOSTS)" | xargs -P 0 -n 1 -d ' ' -I {} \
 	    env $(BASE_TESTS_ENVIRONMENT) VM={} \
 	      ./tests/vmcheck/overlay.sh; \

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -111,7 +111,7 @@ HOSTS := "vmcheck"
 
 vmoverlay:
 	@if [ -z "$(SKIP_VMOVERLAY)" ]; then \
-	  rm -rf $(abs_top_srcdir)/insttree \
+	  rm -rf $(abs_top_srcdir)/insttree; \
 	  echo -n "$(HOSTS)" | xargs -P 0 -n 1 -d ' ' -I {} \
 	    env $(BASE_TESTS_ENVIRONMENT) VM={} \
 	      ./tests/vmcheck/overlay.sh; \

--- a/tests/vmcheck/fetch-journal.sh
+++ b/tests/vmcheck/fetch-journal.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+. ${commondir}/libvm.sh
+
+vm_setup
+
+if ! vm_ssh_wait 30; then
+    echo "WARNING: Failed to wait for VM to fetch journal" > ${JOURNAL_LOG}
+else
+    echo "Saving ${JOURNAL_LOG}"
+    vm_cmd 'journalctl --no-pager || true' > ${JOURNAL_LOG}
+fi

--- a/tests/vmcheck/multitest.py
+++ b/tests/vmcheck/multitest.py
@@ -76,7 +76,7 @@ class Host:
 
     def flush(self):
         if not self._p:
-            return
+            return 0
         rc = self._p.wait()
 
         # just merge the two files

--- a/tests/vmcheck/multitest.py
+++ b/tests/vmcheck/multitest.py
@@ -1,0 +1,104 @@
+#!/bin/env python
+
+import os
+import sys
+import glob
+import subprocess
+
+
+def main():
+
+    failed = False
+    hosts = []
+    for host in sys.argv[1:]:
+        hosts.append(Host(host))
+
+    for test in glob.iglob(os.path.join(sys.path[0], "test-*.sh")):
+        host = wait_for_next_available_host(hosts)
+        rc = host.flush()
+        failed = failed or rc != 0
+        host.dispatch(test)
+
+    for host in hosts:
+        rc = host.flush()
+        failed = failed or rc != 0
+
+    # fetch the journal from all the hosts which had a failure
+    fetcher = os.path.join(sys.path[0], "fetch-journal.sh")
+    for host in hosts:
+        if host.saw_fail:
+            fetcher_env = dict(os.environ)
+            fetcher_env.update({'VM': host.hostname,
+                                'JOURNAL_LOG':
+                                "vmcheck/%s.journal.log" % host.hostname})
+            subprocess.check_call([fetcher], env=fetcher_env)
+
+    return 1 if failed else 0
+
+
+def wait_for_next_available_host(hosts):
+    while True:
+        for host in hosts:
+            if host.is_done():
+                return host
+        os.wait()
+
+
+class Host:
+
+    def __init__(self, hostname):
+        self.hostname = hostname
+        self.test = ""
+        self._p = None
+        self.saw_fail = False
+
+    def is_done(self):
+        if not self._p:
+            return True
+        return self._p.poll() is not None
+
+    def dispatch(self, test):
+        assert self.is_done()
+        test = self._strip_test(test)
+        env = dict(os.environ)
+        env.update({'TESTS': test,
+                    'VM': self.hostname,
+                    'JOURNAL_LOG': "",  # we fetch the journal at the end
+                    'LOG': "vmcheck/%s.out" % test})
+        if not os.path.isdir("vmcheck"):
+            os.mkdir("vmcheck")
+        testsh = os.path.join(sys.path[0], "test.sh")
+        self._p = subprocess.Popen([testsh], env=env,
+                                   stdout=open("vmcheck/%s.log" % test, 'wb'),
+                                   stderr=subprocess.STDOUT)
+        self.test = test
+        print "INFO: scheduled", self.test, "on host", self.hostname
+
+    def flush(self):
+        if not self._p:
+            return
+        rc = self._p.wait()
+
+        # just merge the two files
+        with open("vmcheck/%s.out" % self.test) as f:
+            with open("vmcheck/%s.log" % self.test, 'a') as j:
+                j.write(f.read())
+        os.remove("vmcheck/%s.out" % self.test)
+
+        rcs = "PASS" if rc == 0 else ("FAIL (rc %d)" % rc)
+        print("%s: %s" % (rcs, self.test))
+
+        self.test = ""
+        self._p = None
+        self.saw_fail = self.saw_fail or rc != 0
+        return rc
+
+    @staticmethod
+    def _strip_test(test):
+        test = os.path.basename(test)
+        assert test.startswith('test-') and test.endswith('.sh')
+        return test[5:-3]
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -14,18 +14,23 @@ if test -z "${INSIDE_VM:-}"; then
     set -x
 
     cd ${topsrcdir}
-    rm insttree-$VM -rf
-    DESTDIR=$(pwd)/insttree-$VM
-    make install DESTDIR=${DESTDIR}
-    for san in a t ub; do
-        if eu-readelf -d ${DESTDIR}/usr/bin/rpm-ostree | grep -q "NEEDED.*lib${san}san"; then
-            echo "Installing extra sanitizier: lib${san}san"
-            cp /usr/lib64/lib${san}san*.so.* ${DESTDIR}/usr/lib64
-        fi
-    done
+
+    # Use a lock in case we're called in parallel (make install might fail).
+    # Plus, we can just share the same install tree, and sharing is caring!
+    flock insttree.lock sh -c \
+      '[ ! -d insttree ] || exit 0
+       DESTDIR=$(pwd)/insttree
+       make install DESTDIR=${DESTDIR}
+       for san in a t ub; do
+         if eu-readelf -d ${DESTDIR}/usr/bin/rpm-ostree | \
+              grep -q \"NEEDED.*lib${san}san\"; then
+           echo \"Installing extra sanitizier: lib${san}san\"
+           cp /usr/lib64/lib${san}san*.so.* ${DESTDIR}/usr/lib64
+         fi
+       done'
     vm_rsync
 
-    $SSH "env INSIDE_VM=1 VM=$VM /var/roothome/sync/tests/vmcheck/overlay.sh"
+    $SSH "env INSIDE_VM=1 /var/roothome/sync/tests/vmcheck/overlay.sh"
     vm_reboot
     exit 0
 fi
@@ -51,7 +56,7 @@ fi
 cd /ostree/repo/tmp
 rm vmcheck -rf
 ostree checkout $commit vmcheck --fsync=0
-rsync -rlv /var/roothome/sync/insttree-$VM/usr/ vmcheck/usr/
+rsync -rlv /var/roothome/sync/insttree/usr/ vmcheck/usr/
 # ✀✀✀ BEGIN hack for https://github.com/projectatomic/rpm-ostree/pull/642 ✀✀✀
 ostree admin unlock || true
 for url in https://kojipkgs.fedoraproject.org//packages/ostree/2017.2/3.fc25/x86_64/ostree-{,libs-,grub2-}2017.2-3.fc25.x86_64.rpm; do

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -17,7 +17,7 @@ if test -z "${INSIDE_VM:-}"; then
 
     # Use a lock in case we're called in parallel (make install might fail).
     # Plus, we can just share the same install tree, and sharing is caring!
-    flock insttree.lock sh -c \
+    flock insttree.lock sh -ec \
       '[ ! -d insttree ] || exit 0
        DESTDIR=$(pwd)/insttree
        make install DESTDIR=${DESTDIR}
@@ -27,7 +27,10 @@ if test -z "${INSIDE_VM:-}"; then
            echo \"Installing extra sanitizier: lib${san}san\"
            cp /usr/lib64/lib${san}san*.so.* ${DESTDIR}/usr/lib64
          fi
-       done'
+       done
+       touch ${DESTDIR}/.completed'
+    [ -f insttree/.completed ]
+
     vm_rsync
 
     $SSH "env INSIDE_VM=1 /var/roothome/sync/tests/vmcheck/overlay.sh"

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -14,8 +14,8 @@ if test -z "${INSIDE_VM:-}"; then
     set -x
 
     cd ${topsrcdir}
-    rm insttree -rf
-    DESTDIR=$(pwd)/insttree
+    rm insttree-$VM -rf
+    DESTDIR=$(pwd)/insttree-$VM
     make install DESTDIR=${DESTDIR}
     for san in a t ub; do
         if eu-readelf -d ${DESTDIR}/usr/bin/rpm-ostree | grep -q "NEEDED.*lib${san}san"; then
@@ -25,7 +25,7 @@ if test -z "${INSIDE_VM:-}"; then
     done
     vm_rsync
 
-    $SSH "env INSIDE_VM=1 /var/roothome/sync/tests/vmcheck/overlay.sh"
+    $SSH "env INSIDE_VM=1 VM=$VM /var/roothome/sync/tests/vmcheck/overlay.sh"
     vm_reboot
     exit 0
 fi
@@ -51,7 +51,7 @@ fi
 cd /ostree/repo/tmp
 rm vmcheck -rf
 ostree checkout $commit vmcheck --fsync=0
-rsync -rlv /var/roothome/sync/insttree/usr/ vmcheck/usr/
+rsync -rlv /var/roothome/sync/insttree-$VM/usr/ vmcheck/usr/
 # ✀✀✀ BEGIN hack for https://github.com/projectatomic/rpm-ostree/pull/642 ✀✀✀
 ostree admin unlock || true
 for url in https://kojipkgs.fedoraproject.org//packages/ostree/2017.2/3.fc25/x86_64/ostree-{,libs-,grub2-}2017.2-3.fc25.x86_64.rpm; do


### PR DESCRIPTION
This should help a bit until we move to a more scalable model (discussion in https://github.com/projectatomic/rpm-ostree/issues/662).

I initially wrote `multitest.py` in bash... boy, what a mistake that was.

This should cut down `vmcheck` to about 20-25 mins! (Depending on how the jobs are scheduled in a particular run).