### PR TITLE
compose: Add --add-metadata-from-json

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -730,7 +730,7 @@ rpmostree_compose_builtin_tree (int             argc,
       { char *key;
         GVariant *value;
         while (g_variant_iter_loop (&viter, "{sv}", &key, &value))
-          g_hash_table_replace (metadata_hash, g_strdup (key), g_variant_ref (value);
+          g_hash_table_replace (metadata_hash, g_strdup (key), g_variant_ref (value));
       }
     }
 

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -51,6 +51,7 @@ static gboolean opt_cache_only;
 static char *opt_proxy;
 static char *opt_output_repodata_dir;
 static char **opt_metadata_strings;
+static char *opt_metadata_json;
 static char *opt_repo;
 static char *opt_touch_if_changed;
 static gboolean opt_dry_run;
@@ -59,6 +60,7 @@ static char *opt_write_commitid_to;
 
 static GOptionEntry option_entries[] = {
   { "add-metadata-string", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_metadata_strings, "Append given key and value (in string format) to metadata", "KEY=VALUE" },
+  { "add-metadata-from-json", 0, 0, G_OPTION_ARG_STRING, &opt_metadata_json, "Parse the given JSON file as object, convert to GVariant, append to OSTree commit", "JSON" },
   { "workdir", 0, 0, G_OPTION_ARG_STRING, &opt_workdir, "Working directory", "WORKDIR" },
   { "workdir-tmpfs", 0, 0, G_OPTION_ARG_NONE, &opt_workdir_tmpfs, "Use tmpfs for working state", NULL },
   { "output-repodata-dir", 0, 0, G_OPTION_ARG_STRING, &opt_output_repodata_dir, "Save downloaded repodata in DIR", "DIR" },
@@ -703,6 +705,33 @@ rpmostree_compose_builtin_tree (int             argc,
           glnx_set_error_from_errno (error);
           goto out;
         }
+    }
+
+  if (opt_metadata_json)
+    {
+      glnx_unref_object JsonParser *jparser = json_parser_new ();
+      JsonNode *metarootval = NULL; /* unowned */
+      g_autoptr(GVariant) jsonmetav = NULL;
+      GVariantIter viter;
+
+      if (!json_parser_load_from_file (jparser, opt_metadata_json, error))
+        goto out;
+
+      metarootval = json_parser_get_root (jparser);
+
+      jsonmetav = json_gvariant_deserialize (metarootval, "a{sv}", error);
+      if (!jsonmetav)
+        {
+          g_prefix_error (error, "Parsing %s: ", opt_metadata_json);
+          goto out;
+        }
+
+      g_variant_iter_init (&viter, jsonmetav);
+      { char *key;
+        GVariant *value;
+        while (g_variant_iter_loop (&viter, "{sv}", &key, &value))
+          g_hash_table_replace (metadata_hash, g_strdup (key), g_variant_ref (value);
+      }
     }
 
   if (opt_metadata_strings)


### PR DESCRIPTION
I'd like to embed structured metadata about the originating git
repository.  See [this example](https://pagure.io/fedora-atomic-host-continuous/c/142b12020d7efe18b56d039304efea102a210790?branch=master).  However, I think what we really
want here is a *single* value which has subkeys.

One thing in the back of my mind too is...we could use this to
enhance our "change detection".  Right now we checksum the sack,
treefile, and treecompose-post.  But down the line, I'd
like to support more sophisticated postprocessing, where the
script might reference external files or the like.

In that case, we could stop checksumming the post script, and rely on whether or
not the git repo changed. (This would conversely mean we would do a build even
if e.g. the repo's `README.md` changed, but we can address that with a
post-assemble content check).

Anyways though, for now, this gets us the ability to more easily drop more
structured metadata in the commit, whether it's input git repos, tests that
passed, etc.

Note a trap that bit me here: since the metadata we write here is *host* endian,
but `ostree show --raw` byteswaps (it needs to since the core ostree variant
is always big endian), we get inverted numbers if the host is little.

I think we should probably canonicalize our metadata to big endian; this should
be pretty backwards compatible since I doubt anyone has been adding raw numbers
so far.
