### PR TITLE
postprocess: Handle f26 /etc/nsswitch.conf configuration

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -75,6 +75,10 @@ tests_check_cache_branch_to_nevra_CPPFLAGS = $(AM_CPPFLAGS) -I $(srcdir)/src/lib
 tests_check_cache_branch_to_nevra_CFLAGS = $(AM_CFLAGS) $(PKGDEP_RPMOSTREE_CFLAGS)
 tests_check_cache_branch_to_nevra_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la
 
+tests_check_postprocess_CPPFLAGS = $(AM_CPPFLAGS) -I $(srcdir)/src/libpriv -I $(srcdir)/libglnx
+tests_check_postprocess_CFLAGS = $(AM_CFLAGS) $(PKGDEP_RPMOSTREE_CFLAGS)
+tests_check_postprocess_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la
+
 tests/check/test-compose.sh: tests/common/compose/test-repo.repo
 
 tests/check/test-ucontainer.sh: tests/common/compose/test-repo.repo
@@ -82,6 +86,7 @@ tests/check/test-ucontainer.sh: tests/common/compose/test-repo.repo
 uninstalled_test_programs = \
 	tests/check/jsonutil			\
 	tests/check/cache_branch_to_nevra			\
+	tests/check/postprocess			\
 	$(NULL)
 
 uninstalled_test_scripts = \

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -23,6 +23,11 @@
 #include <ostree.h>
 #include "rpmostree-json-parsing.h"
 
+/* "public" for unit tests */
+char *
+rpmostree_postprocess_replace_nsswitch (const char *buf,
+                                        GError    **error);
+
 gboolean
 rpmostree_treefile_postprocessing (int            rootfs_fd,
                                    GFile         *context_directory,

--- a/tests/check/postprocess.c
+++ b/tests/check/postprocess.c
@@ -1,0 +1,93 @@
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <glib-unix.h>
+#include "libglnx.h"
+#include "rpmostree-postprocess.h"
+
+typedef struct {
+  const char *input;
+  const char *output;
+} AltfilesTest;
+
+static AltfilesTest altfiles_tests[] = {
+  {
+    /* F25 */
+  .input = "# An nsswitch.conf\n" \
+  "\npasswd: files sss\n" \
+  "\ngroup: files sss\n" \
+  "\nhosts:      files mdns4_minimal [NOTFOUND=return] dns myhostname\n",
+  .output = "# An nsswitch.conf\n" \
+  "\npasswd: files altfiles sss\n" \
+  "\ngroup: files altfiles sss\n" \
+  "\nhosts:      files mdns4_minimal [NOTFOUND=return] dns myhostname\n"
+  },
+  {
+    /* F26 */
+  .input = "# An nsswitch.conf\n" \
+  "\npasswd: sss files systemd\n" \
+  "\ngroup: sss files systemd\n" \
+  "\nhosts:      files mdns4_minimal [NOTFOUND=return] dns myhostname\n",
+  .output = "# An nsswitch.conf\n" \
+  "\npasswd: sss files altfiles systemd\n" \
+  "\ngroup: sss files altfiles systemd\n" \
+  "\nhosts:      files mdns4_minimal [NOTFOUND=return] dns myhostname\n"
+  },
+  {
+    /* Already have altfiles, input/output identical */
+  .input = "# An nsswitch.conf\n" \
+  "\npasswd: sss files altfiles systemd\n" \
+  "\ngroup: sss files altfiles systemd\n" \
+  "\nhosts:      files mdns4_minimal [NOTFOUND=return] dns myhostname\n",
+  .output = "# An nsswitch.conf\n" \
+  "\npasswd: sss files altfiles systemd\n" \
+  "\ngroup: sss files altfiles systemd\n" \
+  "\nhosts:      files mdns4_minimal [NOTFOUND=return] dns myhostname\n",
+  },
+  {
+    /* Test having `files` as a substring */
+  .input = "# An nsswitch.conf\n" \
+  "\npasswd: sss foofiles files systemd\n" \
+  "\ngroup: sss foofiles files systemd\n" \
+  "\nhosts:      files mdns4_minimal [NOTFOUND=return] dns myhostname\n",
+  .output = "# An nsswitch.conf\n" \
+  "\npasswd: sss foofiles files altfiles systemd\n" \
+  "\ngroup: sss foofiles files altfiles systemd\n" \
+  "\nhosts:      files mdns4_minimal [NOTFOUND=return] dns myhostname\n",
+  }
+};
+
+static void
+test_postprocess_altfiles (void)
+{
+  g_autoptr(GError) local_error = NULL;
+  GError **error = &local_error;
+
+  for (guint i = 0; i < G_N_ELEMENTS(altfiles_tests); i++)
+    {
+      AltfilesTest *test = &altfiles_tests[i];
+      g_autofree char *newbuf = rpmostree_postprocess_replace_nsswitch (test->input, error);
+
+      if (!newbuf)
+        goto out;
+
+      g_assert_cmpstr (newbuf, ==, test->output);
+    }
+
+ out:
+  g_assert_no_error (local_error);
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/altfiles", test_postprocess_altfiles);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
F26 put sss first, which broke our regexp. When we switch to sysusers, man it'll
be nice to dump ♲ this.

Closes: https://github.com/projectatomic/rpm-ostree/issues/685
