### PR TITLE
core: Also apply mode overrides to symlinks

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2244,6 +2244,14 @@ apply_rpmfi_overrides (int            tmp_metadata_dfd,
           g_str_equal (group, "root"))
         continue;
 
+      /* In theory, RPMs could contain block devices or FIFOs; we would normally
+       * have rejected that at the import time, but let's also be sure here.
+       */
+      if (!(S_ISREG (mode) ||
+            S_ISLNK (mode) ||
+            S_ISDIR (mode)))
+        continue;
+
       g_assert (fn != NULL);
       fn += strspn (fn, "/");
       g_assert (fn[0]);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2244,10 +2244,6 @@ apply_rpmfi_overrides (int            tmp_metadata_dfd,
           g_str_equal (group, "root"))
         continue;
 
-      if (!S_ISREG (mode) &&
-          !S_ISDIR (mode))
-        continue;
-
       g_assert (fn != NULL);
       fn += strspn (fn, "/");
       g_assert (fn[0]);
@@ -2288,8 +2284,7 @@ apply_rpmfi_overrides (int            tmp_metadata_dfd,
           return FALSE;
         }
 
-      /* TODO - this is broken since https://github.com/ostreedev/ostree/pull/521 */
-      if (S_ISREG (mode))
+      if (!S_ISDIR (stbuf.st_mode))
         {
           if (!break_single_hardlink_at (tmprootfs_dfd, fn, cancellable, error))
             return FALSE;

--- a/tests/common/compose/yum/nonrootcap.spec
+++ b/tests/common/compose/yum/nonrootcap.spec
@@ -36,8 +36,10 @@ useradd -r nrcuser -g nrcgroup -s /sbin/nologin
 
 %install
 install -D nrc.conf %{buildroot}/etc/nrc.conf
+ln -sr %{buildroot}/etc/nrc.conf %{buildroot}/etc/nrc-link.conf
 mkdir -p %{buildroot}/usr/bin
 install *.sh %{buildroot}/usr/bin
+ln -sr %{buildroot}/usr/bin/{nrc-user.sh,nrc-user-link.sh}
 mkdir -p %{buildroot}/var/lib/nonrootcap
 mkdir -p %{buildroot}/run/nonrootcap
 mkdir -p %{buildroot}/var/lib/nonrootcap-rootowned
@@ -49,7 +51,9 @@ rm -rf %{buildroot}
 %files
 /usr/bin/nrc-none.sh
 %attr(-, nrcuser, -) /etc/nrc.conf
+%attr(-, nrcuser, -) /etc/nrc-link.conf
 %attr(-, nrcuser, -) /usr/bin/nrc-user.sh
+%attr(-, nrcuser, -) /usr/bin/nrc-user-link.sh
 %attr(-, -, nrcgroup) /usr/bin/nrc-group.sh
 %caps(cap_net_bind_service=ep) /usr/bin/nrc-caps.sh
 %attr(4775, -, -) %caps(cap_net_bind_service=ep) /usr/bin/nrc-caps-setuid.sh

--- a/tests/vmcheck/test-layering-non-root-caps.sh
+++ b/tests/vmcheck/test-layering-non-root-caps.sh
@@ -102,4 +102,8 @@ check_file /run/nonrootcap nrcuser nrcgroup
 check_file /var/lib/nonrootcap-rootowned root root
 check_file /run/nonrootcap-rootowned root root
 check_file /etc/nrc.conf nrcuser root
+check_file /etc/nrc-link.conf nrcuser root
 echo "ok correct user/group and fcaps"
+
+ostree fsck
+echo "ok fsck"

--- a/tests/vmcheck/test-layering-non-root-caps.sh
+++ b/tests/vmcheck/test-layering-non-root-caps.sh
@@ -89,6 +89,7 @@ check_file() {
 
 check_file /usr/bin/nrc-none.sh root root ""
 check_file /usr/bin/nrc-user.sh nrcuser root ""
+check_file /usr/bin/nrc-user-link.sh nrcuser root ""
 check_file /usr/bin/nrc-group.sh root nrcgroup ""
 check_file /usr/bin/nrc-caps.sh root root "cap_net_bind_service+ep"
 check_file /usr/bin/nrc-caps-setuid.sh root root "cap_net_bind_service+ep"

--- a/tests/vmcheck/test-layering-non-root-caps.sh
+++ b/tests/vmcheck/test-layering-non-root-caps.sh
@@ -105,5 +105,5 @@ check_file /etc/nrc.conf nrcuser root
 check_file /etc/nrc-link.conf nrcuser root
 echo "ok correct user/group and fcaps"
 
-ostree fsck
+vm_cmd ostree fsck
 echo "ok fsck"


### PR DESCRIPTION
I'm not sure offhand why we had the `S_ISREG` here, we call into
libglnx which does have symlink copying code.

I added the TODO earlier here while fixing something else, but anyways AFAICS
it's safe to just delete this conditional. It's not going to be worse than
before, where we'd potentially corrupt the object store.
