### PR TITLE
compose: Delete /usr/etc/passwd- (and the other variants)

### DIFF
--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -63,6 +63,10 @@ rpmostree_generate_passwd_from_previous (OstreeRepo      *repo,
                                          GCancellable    *cancellable,
                                          GError         **error);
 
+
+gboolean
+rpmostree_passwd_cleanup (int rootfs_dfd, GCancellable *cancellable, GError **error);
+
 gboolean
 rpmostree_passwd_prepare_rpm_layering (int       rootfs_dfd,
                                        const char        *merge_passwd_dir,

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1190,6 +1190,7 @@ rpmostree_rootfs_prepare_links (int           rootfs_fd,
  *
  *  - Move /etc to /usr/etc
  *  - Clean up RPM db leftovers
+ *  - Clean /usr/etc/passwd- backup files and such
  */
 gboolean
 rpmostree_rootfs_postprocess_common (int           rootfs_fd,
@@ -1235,6 +1236,9 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
           goto out;
         }
     }
+
+  if (!rpmostree_passwd_cleanup (rootfs_fd, cancellable, error))
+    goto out;
 
   ret = TRUE;
  out:

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -18,6 +18,9 @@ cat > metadata.json <<EOF
 EOF
 runcompose --add-metadata-from-json metadata.json
 ostree --repo=${repobuild} ls -R ${treeref} /usr/lib/ostree-boot > bootls.txt
+if ostree --repo=${repobuild} ls -R ${treeref} /usr/etc/passwd-; then
+    assert_not_reached "Found /usr/etc/passwd- backup file in tree"
+fi
 echo "ok compose"
 
 ostree --repo=${repobuild} show --print-metadata-key exampleos.gitrepo ${treeref} > meta.txt


### PR DESCRIPTION
There's no point to shipping these backup files in the base tree. We already had
code to delete them for the package layering case where they caused active harm.
At the point we added that code we really should have *also* changed treecompose
to delete them. Better late than never.

The reason I'm doing this now is because having them in the base tree causes `ex
livefs` to spuriously think that layering a package that *doesn't* change `/etc`
as if it does, because the layering code deletes the backup files.