### PR TITLE
rpm-ostree install: pass local packages by fd

### DIFF
--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -73,7 +73,9 @@ pkg_change (RPMOSTreeSysroot *sysroot_proxy,
                                           get_args_variant (),
                                           packages_to_add,
                                           packages_to_remove,
+                                          NULL, /* fd_list */
                                           &transaction_address,
+                                          NULL, /* out_fd_list */
                                           cancellable,
                                           error))
     goto out;

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -27,6 +27,8 @@
 
 #include <libglnx.h>
 
+#include <gio/gunixfdlist.h>
+
 static char *opt_osname;
 static gboolean opt_reboot;
 static gboolean opt_dry_run;
@@ -39,12 +41,23 @@ static GOptionEntry option_entries[] = {
 };
 
 static GVariant *
-get_args_variant (void)
+get_args_variant (GPtrArray *handles)
 {
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
   g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
   g_variant_dict_insert (&dict, "dry-run", "b", opt_dry_run);
+
+  if (handles != NULL && handles->len > 0)
+    {
+      g_auto(GVariantBuilder) builder;
+      g_variant_builder_init (&builder, G_VARIANT_TYPE ("ah"));
+      for (guint i = 0; i < handles->len; i++)
+        g_variant_builder_add (&builder, "h", handles->pdata[i]);
+      g_variant_dict_insert_value (&dict, "local-packages",
+                                   g_variant_new ("ah", &builder));
+    }
+
   return g_variant_dict_end (&dict);
 }
 
@@ -52,6 +65,7 @@ static int
 pkg_change (RPMOSTreeSysroot *sysroot_proxy,
             const char *const* packages_to_add,
             const char *const* packages_to_remove,
+            GPtrArray     *local_pkgs,
             GCancellable  *cancellable,
             GError       **error)
 {
@@ -59,6 +73,8 @@ pkg_change (RPMOSTreeSysroot *sysroot_proxy,
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   g_autofree char *transaction_address = NULL;
   const char *const strv_empty[] = { NULL };
+  glnx_unref_object GUnixFDList *fdl = NULL;
+  g_autoptr(GPtrArray) handles = NULL;
 
   if (!packages_to_add)
     packages_to_add = strv_empty;
@@ -69,11 +85,26 @@ pkg_change (RPMOSTreeSysroot *sysroot_proxy,
                                 cancellable, &os_proxy, error))
     goto out;
 
+  if (local_pkgs != NULL && local_pkgs->len > 0)
+    {
+      handles = g_ptr_array_new ();
+      fdl = g_unix_fd_list_new ();
+      for (guint i = 0; i < local_pkgs->len; i++)
+        {
+          int fd = GPOINTER_TO_INT (local_pkgs->pdata[i]);
+          int idx = g_unix_fd_list_append (fdl, fd, error);
+          if (idx < 0)
+            goto out;
+          close (fd);
+          g_ptr_array_add (handles, GINT_TO_POINTER (idx));
+        }
+    }
+
   if (!rpmostree_os_call_pkg_change_sync (os_proxy,
-                                          get_args_variant (),
+                                          get_args_variant (handles),
                                           packages_to_add,
                                           packages_to_remove,
-                                          NULL, /* fd_list */
+                                          fdl,
                                           &transaction_address,
                                           NULL, /* out_fd_list */
                                           cancellable,
@@ -125,6 +156,7 @@ rpmostree_builtin_pkg_add (int            argc,
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autoptr(GPtrArray) packages_to_add =
     g_ptr_array_new_with_free_func (g_free);
+  g_autoptr(GPtrArray) local_packages_to_add = g_ptr_array_new ();
 
   context = g_option_context_new ("PACKAGE [PACKAGE...] - Download and install layered RPM packages");
 
@@ -146,38 +178,29 @@ rpmostree_builtin_pkg_add (int            argc,
   for (int i = 1; i < argc; i++)
     {
       const char *pkgspec = argv[i];
-      g_autofree char *abspath = NULL;
 
-      if (!g_str_has_suffix (pkgspec, ".rpm") || /* repo install */
-           g_str_has_prefix (pkgspec, "/"))      /* local install */
+      if (!g_str_has_suffix (pkgspec, ".rpm")) /* repo install */
         {
           g_ptr_array_add (packages_to_add, g_strdup (pkgspec));
           continue;
         }
-
-      /* OK, it's a relative path, we need to check that it
-       * exists and canonicalize it for the daemon. */
-
-      if (access (pkgspec, R_OK) != 0)
+      else /* local RPM install */
         {
-          glnx_set_prefix_error_from_errno (error,
-                                            "can't read package '%s': ",
-                                            pkgspec);
-          return EXIT_FAILURE;
-        }
+          int fd = open (pkgspec, O_RDONLY);
+          if (fd < 0)
+            {
+              glnx_set_prefix_error_from_errno (error, "can't open '%s'",
+                                                pkgspec);
+              return EXIT_FAILURE;
+            }
 
-      abspath = realpath (pkgspec, NULL);
-      if (abspath == NULL)
-        {
-          glnx_set_prefix_error_from_errno (error, "%s", "realpath");
-          return EXIT_FAILURE;
+          g_ptr_array_add (local_packages_to_add, GINT_TO_POINTER (fd));
         }
-
-      g_ptr_array_add (packages_to_add, g_steal_pointer (&abspath));
     }
   g_ptr_array_add (packages_to_add, NULL);
 
-  return pkg_change (sysroot_proxy, (const char *const*)packages_to_add->pdata, NULL, cancellable, error);
+  return pkg_change (sysroot_proxy, (const char *const*)packages_to_add->pdata,
+                     NULL, local_packages_to_add, cancellable, error);
 }
 
 int
@@ -212,5 +235,6 @@ rpmostree_builtin_pkg_remove (int            argc,
     g_ptr_array_add (packages_to_remove, argv[i]);
   g_ptr_array_add (packages_to_remove, NULL);
 
-  return pkg_change (sysroot_proxy, NULL, (const char *const*)packages_to_remove->pdata, cancellable, error);
+  return pkg_change (sysroot_proxy, NULL, (const char *const*)packages_to_remove->pdata,
+                     NULL, cancellable, error);
 }

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -196,6 +196,11 @@
       <arg type="s" name="transaction_address" direction="out"/>
     </method>
 
+    <!-- Available options:
+         "reboot" (type 'b')
+         "dry-run" (type 'b')
+         "local-packages" (type 'ah')
+    -->
     <method name="PkgChange">
       <arg type="a{sv}" name="options" direction="in"/>
       <arg type="as" name="packages_added"/>

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -201,6 +201,7 @@
       <arg type="as" name="packages_added"/>
       <arg type="as" name="packages_removed"/>
       <arg type="s" name="transaction_address" direction="out"/>
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true"/>
     </method>
 
     <method name="SetInitramfsState">

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -685,6 +685,7 @@ out:
 static gboolean
 os_handle_pkg_change (RPMOSTreeOS *interface,
 		      GDBusMethodInvocation *invocation,
+		      GUnixFDList *fdlist,
 		      GVariant *arg_options,
 		      const char * const *arg_packages_added,
 		      const char * const *arg_packages_removed)
@@ -734,7 +735,7 @@ out:
     {
       const char *client_address;
       client_address = rpmostreed_transaction_get_client_address (transaction);
-      rpmostree_os_complete_pkg_change (interface, invocation, client_address);
+      rpmostree_os_complete_pkg_change (interface, invocation, NULL, client_address);
     }
 
   return TRUE;
@@ -794,7 +795,7 @@ out:
     {
       const char *client_address;
       client_address = rpmostreed_transaction_get_client_address (transaction);
-      rpmostree_os_complete_pkg_change (interface, invocation, client_address);
+      rpmostree_os_complete_pkg_change (interface, invocation, NULL, client_address);
     }
 
   return TRUE;
@@ -866,7 +867,7 @@ out:
     {
       const char *client_address;
       client_address = rpmostreed_transaction_get_client_address (transaction);
-      rpmostree_os_complete_pkg_change (interface, invocation, client_address);
+      rpmostree_os_complete_pkg_change (interface, invocation, NULL, client_address);
     }
 
   return TRUE;

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -724,8 +724,6 @@ os_handle_pkg_change (RPMOSTreeOS *interface,
                                      G_VARIANT_TYPE ("ah"));
       g_assert (fds);
       n_local_pkgs = g_variant_n_children (fds);
-      g_assert (g_unix_fd_list_get_length (fdlist) ==
-                g_variant_n_children (fds));
     }
 
   if (g_unix_fd_list_get_length (fdlist) != n_local_pkgs)

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -879,7 +879,8 @@ rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
       self->revision = g_strdup (revision);
       self->packages_added = strdupv_canonicalize (packages_added);
       self->packages_removed = strdupv_canonicalize (packages_removed);
-      self->local_packages_added = g_object_ref (local_packages_added);
+      if (local_packages_added != NULL)
+        self->local_packages_added = g_object_ref (local_packages_added);
     }
 
   return (RpmostreedTransaction *) self;

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -734,6 +734,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
       if (!rpmostree_origin_add_packages (origin, self->packages_added,
                                           FALSE, cancellable, error))
         goto out;
+
+      changed = TRUE;
     }
 
   if (self->local_packages_added != NULL)
@@ -744,7 +746,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
 
       gint nfds = 0;
       const gint *fds =
-        g_unix_fd_list_steal_fds (self->local_packages_added, &nfds);
+        g_unix_fd_list_peek_fds (self->local_packages_added, &nfds);
       for (guint i = 0; i < nfds; i++)
         {
           g_autofree char *sha256_nevra = NULL;

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -20,6 +20,8 @@
 
 #include "rpmostreed-types.h"
 
+#include <gio/gunixfdlist.h>
+
 RpmostreedTransaction *
                 rpmostreed_transaction_new_package_diff    (GDBusMethodInvocation *invocation,
                                                             OstreeSysroot *sysroot,
@@ -64,6 +66,7 @@ RpmostreedTransaction *
                                                             const char *revision,
                                                             const char *const *packages_added,
                                                             const char *const *packages_removed,
+                                                            GUnixFDList *local_packages_added,
                                                             GCancellable *cancellable,
                                                             GError **error);
 


### PR DESCRIPTION
This is a follow-up to commit 81c43e8 (#657). That commit extended the
definition of "packages_added" to also support local RPMs. We revert
that here, and instead open the RPM file ourselves and send the fd over
D-Bus. We add support for a "local-packages" option containing the fd
indices to process.

It's just cleaner and safer overall; the daemon and client might not
even be sharing the same view of the filesystem!

Requires: https://github.com/projectatomic/rpm-ostree/pull/695