### PR TITLE
all: Conditionally use new ostree_sepolicy_new_at()

### DIFF
--- a/src/app/rpmostree-ex-builtin-unpack.c
+++ b/src/app/rpmostree-ex-builtin-unpack.c
@@ -102,9 +102,14 @@ rpmostree_ex_builtin_unpack (int             argc,
 
   /* just use current policy */
   if (opt_selinux)
-    if (!rpmostree_prepare_rootfs_get_sepolicy (AT_FDCWD, "/", &sepolicy,
-                                                cancellable, error))
-      goto out;
+    {
+      glnx_fd_close int rootfs_dfd = -1;
+      if (!glnx_opendirat (AT_FDCWD, "/", TRUE, &rootfs_dfd, error))
+        goto out;
+      if (!rpmostree_prepare_rootfs_get_sepolicy (rootfs_dfd, &sepolicy,
+                                                  cancellable, error))
+        goto out;
+    }
 
   {
     const char *branch = rpmostree_unpacker_get_ostree_branch (unpacker);

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -709,7 +709,7 @@ do_final_local_assembly (RpmOstreeSysrootUpgrader *self,
   /* load the sepolicy to use during import */
   {
     glnx_unref_object OstreeSePolicy *sepolicy = NULL;
-    if (!rpmostree_prepare_rootfs_get_sepolicy (self->tmprootfs_dfd, ".", &sepolicy,
+    if (!rpmostree_prepare_rootfs_get_sepolicy (self->tmprootfs_dfd, &sepolicy,
                                                 cancellable, error))
       goto out;
 

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -54,7 +54,6 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
 
 gboolean
 rpmostree_prepare_rootfs_get_sepolicy (int            dfd,
-                                       const char    *path,
                                        OstreeSePolicy **out_sepolicy,
                                        GCancellable  *cancellable,
                                        GError       **error);

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -25,6 +25,10 @@
 #include <sys/wait.h>
 #include <ostree.h>
 
+#ifndef OSTREE_CHECK_VERSION
+#define OSTREE_CHECK_VERSION(year,minor) 0
+#endif
+
 int
 rpmostree_ptrarray_sort_compare_strings (gconstpointer ap,
                                          gconstpointer bp);


### PR DESCRIPTION
Depends: https://github.com/ostreedev/ostree/pull/766

If available, using the also-new `OSTREE_CHECK_VERSION`. I dropped the `path`
argument from one of the internal APIs since it made the code simpler, and every
caller except one was passing `.`.
