### PR TITLE
daemon: Fix `systemctl reload rpm-ostreed`

### DIFF
--- a/src/daemon/rpm-ostreed.service.in
+++ b/src/daemon/rpm-ostreed.service.in
@@ -8,4 +8,4 @@ BusName=org.projectatomic.rpmostree1
 NotifyAccess=main
 @SYSTEMD_ENVIRON@
 ExecStart=@bindir@/rpm-ostree start-daemon
-ExecReload=@libexecdir@/@primaryname@ reload
+ExecReload=@bindir@/rpm-ostree reload


### PR DESCRIPTION
I think this was a conceptual merge conflict from
https://github.com/projectatomic/rpm-ostree/pull/292
and
https://github.com/projectatomic/rpm-ostree/pull/598

Also I noticed we weren't consistently using `@primaryname@`...
will fix that when we get back to the renaming PR.
