### PR TITLE
build: Always recurse build into libdnf/

### DIFF
--- a/Makefile-decls.am
+++ b/Makefile-decls.am
@@ -53,3 +53,6 @@ include $(top_srcdir)/buildutil/glib-tap.mk
 # This is a special facility to chain together hooks easily
 INSTALL_DATA_HOOKS =
 install-data-hook: $(INSTALL_DATA_HOOKS)
+
+ALL_LOCAL_HOOKS =
+all-local: $(ALL_LOCAL_HOOKS)

--- a/Makefile-libdnf.am
+++ b/Makefile-libdnf.am
@@ -17,9 +17,12 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-libdnf.so.1:
+# Recurse into libdnf
+ALL_LOCAL_HOOKS += libdnf-local
+libdnf-local:
 	cd libdnf-build && $(MAKE)
 	ln -sf libdnf-build/libdnf/libdnf.so.1 .
+libdnf.so.1: libdnf-local
 CLEANFILES += libdnf.so.1
 GITIGNOREFILES += libdnf-build/
 


### PR DESCRIPTION
This has bitten me many times already; switching libdnf submodule (or just
editing the code directly in the submodule dir to add debug prints) didn't
rebuild libdnf.

Recursing the build: cheap ¢.  Not spending a half hour figuring out
the code you're debugging isn't what you typed: priceless 💸.
