### PR TITLE
core: handle enabled_metadata repos

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -374,7 +374,7 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
     for (guint i = 0; i < repos->len; i++)
       {
         DnfRepo *repo = repos->pdata[i];
-        if (dnf_repo_get_enabled (repo))
+        if (dnf_repo_get_enabled (repo) & DNF_REPO_ENABLED_PACKAGES)
           {
             g_autoptr(GDateTime) ts = g_date_time_new_from_unix_utc (dnf_repo_get_timestamp_generated (repo));
             g_autofree char *formatted = g_date_time_format (ts, "%Y-%m-%d %T");

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1279,7 +1279,7 @@ rpmostree_context_prepare_install (RpmOstreeContext    *self,
     for (guint i = 0; i < repos->len; i++)
       {
         DnfRepo *repo = repos->pdata[i];
-        if (!dnf_repo_get_enabled (repo))
+        if ((dnf_repo_get_enabled (repo) & DNF_REPO_ENABLED_PACKAGES) == 0)
           continue;
         if (first)
           first = FALSE;


### PR DESCRIPTION
In #728, we started querying enabled repos using get_n_solvables().
However, there are different kinds of enabled repos, and
`dnf_repo_get_enabled()` reflects that through the bitmask it returns:
  - DNF_REPO_ENABLED_NONE: repo disabled
  - DNF_REPO_ENABLED_PACKAGES: repo enabled for package installs
  - DNF_REPO_ENABLED_METADATA: repo enabled for metadata

We were treating it as a boolean, though really, we should only print
data about repos with ENABLED_PACKAGES on, which are the actual repos
libdnf can fetch packages from. Repos with only ENABLED_METADATA on are
not fetched by default, and thus will cause SIGSEGV when trying to
get_n_solvables().

I ran into this while trying to debug #720 on F25 AH, which has this
repo by default:

  [fedora-cisco-openh264]
  name=Fedora $releasever openh264 (From Cisco) - $basearch
  baseurl=https://codecs.fedoraproject.org/openh264/$releasever/$basearch/
  enabled=0
  enabled_metadata=1
