### PR TITLE
Require ostree 2017.5 📆

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -10,6 +10,15 @@ required: true
 container:
     image: projectatomic/rpm-ostree-tester
 
+# ⚠ Pull latest ostree for https://github.com/ostreedev/ostree/issues/758
+# And we now depend on 2017.4
+# Also, there's a copy of this below in the compose context
+# And also in tests/vmcheck/overlay.sh
+packages:
+  - https://kojipkgs.fedoraproject.org//packages/ostree/2017.5/2.fc25/x86_64/ostree-2017.5-2.fc25.x86_64.rpm
+  - https://kojipkgs.fedoraproject.org//packages/ostree/2017.5/2.fc25/x86_64/ostree-devel-2017.5-2.fc25.x86_64.rpm
+  - https://kojipkgs.fedoraproject.org//packages/ostree/2017.5/2.fc25/x86_64/ostree-libs-2017.5-2.fc25.x86_64.rpm
+
 env:
     CFLAGS: '-fsanitize=undefined'
 
@@ -20,9 +29,7 @@ build:
       --enable-installed-tests
       --enable-gtk-doc
 
-# ⚠ Build ostree from git for https://github.com/ostreedev/ostree/issues/758
 tests:
-    - sudo dnf -y builddep ostree && git clone --depth=1 https://github.com/ostreedev/ostree ostree-git && (cd ostree-git && ./autogen.sh --prefix=/usr --libdir=/usr/lib64 && make -j 8 && sudo make install) && rm ostree-git -rf
     - make check
     - gnome-desktop-testing-runner rpm-ostree
     - sudo --user=testuser gnome-desktop-testing-runner rpm-ostree
@@ -101,6 +108,7 @@ tests:
   - >
       docker run --privileged -v $(pwd):/srv/code --rm
       projectatomic/rpm-ostree-tester /bin/sh -c "
+      yum -y install https://kojipkgs.fedoraproject.org//packages/ostree/2017.5/2.fc25/x86_64/ostree-{,libs-,devel-,grub2-}2017.5-2.fc25.x86_64.rpm &&
       cd /srv/code &&
       env NOCONFIGURE=1 ./autogen.sh &&
       ./configure --prefix=/usr --libdir=/usr/lib64 &&

--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,7 @@ AC_SEARCH_LIBS([rpmsqSetInterruptSafety], [rpmio],
 # Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 >= 2.40.0 json-glib-1.0
-				     ostree-1 >= 2017.2
+				     ostree-1 >= 2017.4
 				     libsystemd
 				     rpm librepo
 				     libarchive])

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -626,15 +626,10 @@ import_local_rpm (OstreeRepo    *parent,
 
   /* let's just use the current sepolicy -- we'll just relabel it if the new
    * base turns out to have a different one */
-#if OSTREE_CHECK_VERSION(2017,4)
   glnx_fd_close int rootfs_dfd = -1;
   if (!glnx_opendirat (AT_FDCWD, "/", TRUE, &rootfs_dfd, error))
     return FALSE;
   policy = ostree_sepolicy_new_at (rootfs_dfd, cancellable, error);
-#else
-  { glnx_unref_object GFile *root = g_file_new_for_path ("/");
-    policy = ostree_sepolicy_new (root, cancellable, error); }
-  #endif
   if (policy == NULL)
     return FALSE;
 

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -495,13 +495,7 @@ rpmostree_prepare_rootfs_get_sepolicy (int            dfd,
         goto out;
     }
 
-#if OSTREE_CHECK_VERSION(2017,4)
   ret_sepolicy = ostree_sepolicy_new_at (dfd, cancellable, error);
-#else
-  { g_autofree char *abspath = glnx_fdrel_abspath (dfd, ".");
-    glnx_unref_object GFile *root = g_file_new_for_path (abspath);
-    ret_sepolicy = ostree_sepolicy_new (root, cancellable, error); }
-#endif
   if (ret_sepolicy == NULL)
     goto out;
 
@@ -1893,9 +1887,7 @@ rpmostree_commit (int            rootfs_fd,
    * unlabeled content, but I think the fix for that is to ensure that policy is
    * labeling it.
    */
-#if OSTREE_CHECK_VERSION(2017,4)
   modifier_flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_ERROR_ON_UNLABELED;
-#endif
   /* If changing this, also look at changing rpmostree-unpacker.c */
   commit_modifier = ostree_repo_commit_modifier_new (modifier_flags, NULL, NULL, NULL);
   ostree_repo_commit_modifier_set_xattr_callback (commit_modifier,

--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -714,9 +714,7 @@ import_rpm_to_repo (RpmOstreeUnpacker *self,
     filter = compose_filter_cb;
 
   /* If changing this, also look at changing rpmostree-postprocess.c */
-#if OSTREE_CHECK_VERSION(2017,4)
   modifier_flags |= OSTREE_REPO_COMMIT_MODIFIER_FLAGS_ERROR_ON_UNLABELED;
-#endif
   modifier = ostree_repo_commit_modifier_new (modifier_flags, filter, &fdata, NULL);
   ostree_repo_commit_modifier_set_xattr_callback (modifier, xattr_cb,
                                                   NULL, self);

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -25,10 +25,6 @@
 #include <sys/wait.h>
 #include <ostree.h>
 
-#ifndef OSTREE_CHECK_VERSION
-#define OSTREE_CHECK_VERSION(year,minor) 0
-#endif
-
 int
 rpmostree_ptrarray_sort_compare_strings (gconstpointer ap,
                                          gconstpointer bp);

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -59,6 +59,16 @@ ostree checkout $commit vmcheck --fsync=0
 # ✀✀✀ BEGIN hack for https://github.com/projectatomic/rpm-ostree/pull/693 ✀✀✀
 rm -f vmcheck/usr/etc/{.pwd.lock,passwd-,group-,shadow-,gshadow-,subuid-,subgid-}
 # ✀✀✀ END hack for https://github.com/projectatomic/rpm-ostree/pull/693 ✀✀✀
+# ✀✀✀ BEGIN update ostree; see redhat-ci.sh ✀✀✀
+for url in https://kojipkgs.fedoraproject.org//packages/ostree/2017.5/2.fc25/x86_64/ostree-{,libs-,grub2-}2017.5-2.fc25.x86_64.rpm; do
+    curl -sSL -O $url
+done
+for x in *.rpm; do
+    rpm2cpio $x | (cd vmcheck && cpio -div)
+done
+rm vmcheck/etc -rf
+rm -f *.rpm
+# ✀✀✀ END update ostree; see redhat-ci.sh ✀✀✀
 # Now, overlay our built binaries
 rsync -rlv /var/roothome/sync/insttree/usr/ vmcheck/usr/
 ostree refs --delete vmcheck || true


### PR DESCRIPTION
This is preparatory for future changes which will make use the newer sysroot
writing API. But in this change, we can drop all of our version ifdef'd code.

(Breaking this out of since it's harder than I thought https://github.com/projectatomic/rpm-ostree/pull/709 - in fact astonishing levels of pain 😢 )