### PR TITLE
ci/container: Use updates-testing

### DIFF
--- a/.redhat-ci.Dockerfile
+++ b/.redhat-ci.Dockerfile
@@ -5,7 +5,7 @@ FROM fedora:25
 # updates repo.  Though we do explicitly use updates-testing
 # so our CI coverage indirectly tests that.
 
-RUN dnf config-manager --set-enabled updates-testing \
+RUN dnf config-manager --set-enabled updates-testing && \
     dnf install -y @buildsys-build && \
     dnf install -y 'dnf-command(builddep)' && \
     dnf builddep -y rpm-ostree && \

--- a/.redhat-ci.Dockerfile
+++ b/.redhat-ci.Dockerfile
@@ -2,9 +2,11 @@ FROM fedora:25
 
 # We could use the upstream spec file here, but anyway for
 # runtime reqs, we're at the mercy of whatever in the
-# updates repo.
+# updates repo.  Though we do explicitly use updates-testing
+# so our CI coverage indirectly tests that.
 
-RUN dnf install -y @buildsys-build && \
+RUN dnf config-manager --set-enabled updates-testing \
+    dnf install -y @buildsys-build && \
     dnf install -y 'dnf-command(builddep)' && \
     dnf builddep -y rpm-ostree && \
     dnf install -y rpm-ostree && \


### PR DESCRIPTION
This is another way to partially address
https://github.com/projectatomic/rpm-ostree/pull/740
We should also likely have a `fedora/25/atomic/testing` image.
