### PR TITLE
status: Rename OSName → StateRoot in the human-readable text

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -35,10 +35,12 @@
 #include <libglnx.h>
 
 static gboolean opt_pretty;
+static gboolean opt_verbose;
 static gboolean opt_json;
 
 static GOptionEntry option_entries[] = {
   { "pretty", 'p', 0, G_OPTION_ARG_NONE, &opt_pretty, "This option is deprecated and no longer has any effect", NULL },
+  { "verbose", 'v', 0, G_OPTION_ARG_NONE, &opt_verbose, "Print additional fields (e.g. StateRoot)", NULL },
   { "json", 0, 0, G_OPTION_ARG_NONE, &opt_json, "Output JSON", NULL },
   { NULL }
 };
@@ -267,7 +269,7 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
 
       if (is_locally_assembled)
         print_kv ("BaseCommit", max_key_len, base_checksum);
-      else
+      if (opt_verbose || !is_locally_assembled)
         print_kv ("Commit", max_key_len, checksum);
 
       /* Show any difference between the baseref vs head, but only for the
@@ -304,7 +306,8 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
         }
 
       /* This used to be OSName; see https://github.com/ostreedev/ostree/pull/794 */
-      print_kv ("StateRoot", max_key_len, os_name);
+      if (opt_verbose)
+        print_kv ("StateRoot", max_key_len, os_name);
 
       if (!g_variant_dict_lookup (dict, "gpg-enabled", "b", &gpg_enabled))
         gpg_enabled = FALSE;

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -303,7 +303,8 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
             }
         }
 
-      print_kv ("OSName", max_key_len, os_name);
+      /* This used to be OSName; see https://github.com/ostreedev/ostree/pull/794 */
+      print_kv ("StateRoot", max_key_len, os_name);
 
       if (!g_variant_dict_lookup (dict, "gpg-enabled", "b", &gpg_enabled))
         gpg_enabled = FALSE;

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -24,7 +24,7 @@ export RPMOSTREE_SUPPRESS_REQUIRES_ROOT_CHECK=yes
 
 ensure_dbus
 
-echo "1..18"
+echo "1..19"
 
 setup_os_repository "archive-z2" "syslinux"
 
@@ -48,6 +48,13 @@ ostree admin --sysroot=sysroot deploy --karg=root=LABEL=MOO --karg=quiet --os=te
 
 assert_status_jq '.deployments[0].version == "1.0.10"'
 echo "ok status shows right version"
+
+rpm-ostree status > status.txt
+assert_file_has_content status.txt 'Version: 1.0.10'
+assert_not_file_has_content status.txt StateRoot:
+rpm-ostree status -v > status.txt
+assert_file_has_content status.txt StateRoot:
+echo "ok status text"
 
 dbus-send --session --dest=org.projectatomic.rpmostree1 --print-reply=literal /org/projectatomic/rpmostree1/testos org.projectatomic.rpmostree1.OSExperimental.Moo boolean:true > moo.txt
 assert_file_has_content moo.txt '🐄'


### PR DESCRIPTION
See: https://github.com/ostreedev/ostree/pull/794

I originally tried to do this ~a year ago in:
https://github.com/projectatomic/rpm-ostree/pull/295

But Micah pushed back at the time.  I'd still like to do this
though, since I personally find `OSName` *more* confusing
than `StateRoot`.

One specific rationale I have for making this change is that
I rebased a home server from CentOSAH to FAH - and I feel
it's just saner to see `StateRoot: centos-atomic-host` instead
of `OSName: centos-atomic-host` underneath the fedora refspec.
