### PR TITLE
scripts: Ignore openjdk pretrans

### DIFF
--- a/src/libpriv/rpmostree-script-gperf.gperf
+++ b/src/libpriv/rpmostree-script-gperf.gperf
@@ -19,6 +19,8 @@ ca-certificates.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE  /* Looks like legacy... *
 filesystem.pretrans, RPMOSTREE_SCRIPT_ACTION_IGNORE
 libgcc.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
 setup.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
+java-1.8.0-openjdk-headless.pretrans, RPMOSTREE_SCRIPT_ACTION_IGNORE  /* https://bugzilla.redhat.com/show_bug.cgi?id=1038092 Upgrade compat, shouldn't be needed */
+copy-jdk-configs.pretrans, RPMOSTREE_SCRIPT_ACTION_IGNORE  /* See above */
 pinentry.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE
 fedora-release.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
 fedora-release.posttrans, RPMOSTREE_SCRIPT_ACTION_IGNORE


### PR DESCRIPTION
I honestly didn't really dive into this, but it looks like
this is yet another "hack upgrades in the yum case", which we
should be able to ignore since we always do reassembly.

I at least tested `java -version` works with this.

This is a band-aid for the bigger issue of:
https://github.com/projectatomic/rpm-ostree/issues/749

(Doing this one since an AtomicWS user reported it)
