### PR TITLE
 core: Port a few functions to new style

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1737,16 +1737,18 @@ break_hardlinks_at (int             dfd,
 {
   gboolean ret = FALSE;
   g_auto(GLnxDirFdIterator) dfd_iter = { FALSE, };
-  struct dirent *dent = NULL;
 
   if (!glnx_dirfd_iterator_init_at (dfd, dirpath, TRUE, &dfd_iter, error))
     goto out;
 
-  while (glnx_dirfd_iterator_next_dent (&dfd_iter, &dent, cancellable, error))
+  while (TRUE)
     {
+      struct dirent *dent = NULL;
+      if (!glnx_dirfd_iterator_next_dent (&dfd_iter, &dent, cancellable, error))
+        goto out;
       if (dent == NULL)
         break;
-      if (!break_single_hardlink_at (dfd_iter.fd, dent->d_name, 
+      if (!break_single_hardlink_at (dfd_iter.fd, dent->d_name,
                                      cancellable, error))
         goto out;
     }


### PR DESCRIPTION

I was looking at livefs executing scripts, realized I may need to
do some refactoring here, and decided to do some style updates.

Also, we make use of the `g_autoptr()` for ostree types in a few
places.