### PR TITLE
util: fix potential overflow in var substitution

### DIFF
--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -138,9 +138,10 @@ _rpmostree_varsubst_string (const char *instr,
       s = varend+1;
     }
 
+  /* Append trailing bytes */
   if (s != instr)
     {
-      g_string_append_len (result, s, p - s);
+      g_string_append (result, s);
       /* Steal the C string, NULL out the GString since we freed it */
       return g_string_free (g_steal_pointer (&result), FALSE);
     }


### PR DESCRIPTION
When appending the trailing bytes, we were passing `(p - s)`, but `p` by
definition is always `NULL` at that point. Chaos ensues. 💥 

The really evil part about this is that the `len` is passed signed and
glib treats negative values to mean it should lookup the length itself,
so this worked *most of the time*. Though I'm guessing if the address at
`s` is large enough, `(p - s)` can wrap around and become positive again,
thus causing a massive allocation. Anyway, I didn't actually check this
(esp. since the report was for ARM), but the patch is clearly right.

I think this may be the cause for
https://bugzilla.redhat.com/show_bug.cgi?id=1381357.