### PR TITLE
Release 2017.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rpm-ostree], [2017.4], [walters@verbum.org])
+AC_INIT([rpm-ostree], [2017.5], [walters@verbum.org])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
A very minor release, but better than backporting more patches. This rolls in
the `RegisterClient` fix as non-root, plus the arm32 crasher.

The syscore refactoring is the only risky part, but I'm pretty confident in it.
