### PR TITLE
 ci: Use FAHC for build container

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -6,18 +6,17 @@ set -xeuo pipefail
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
 
+# Use the latest ostree by default
+echo -e '[fahc]\nbaseurl=https://ci.centos.org/artifacts/sig-atomic/fahc/rdgo/build/\ngpgcheck=0\n' > /etc/yum.repos.d/fahc.repo
+# See also tests/vmcheck/overlay.sh
+
 install_builddeps rpm-ostree
 
-# ⚠ Pull latest ostree for https://github.com/ostreedev/ostree/issues/758
-# And we now depend on 2017.4
-# Also, there's a copy of this below in the compose context
-# And also in tests/vmcheck/overlay.sh
-yum -y install https://kojipkgs.fedoraproject.org//packages/ostree/2017.5/2.fc25/x86_64/ostree-{,libs-,devel-,grub2-}2017.5-2.fc25.x86_64.rpm
-
-dnf install -y createrepo_c /usr/bin/jq PyYAML clang \
+dnf install -y ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML clang \
     libubsan libasan libtsan elfutils fuse sudo gnome-desktop-testing
 
 # create an unprivileged user for testing
 adduser testuser
 
+rpm -q ostree{,-devel,-grub2}
 build --enable-installed-tests --enable-gtk-doc

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -24,6 +24,20 @@ if test -z "${INSIDE_VM:-}"; then
     flock insttree.lock sh -ec \
       '[ ! -d ${VMCHECK_INSTTREE} ] || exit 0
        DESTDIR=${VMCHECK_INSTTREE}
+       mkdir -p ${DESTDIR}
+       # Always pull ostree from the build container; we assume development and testing
+       # is against git master.  See also build.sh.
+       ostree --version
+       for pkg in ostree{,-libs,-grub2}; do
+          rpm -q $pkg
+          # We do not have perms to read /etc/grub2 as non-root
+          rpm -ql $pkg |grep -v '^/etc/'>  list.txt
+          # In the prebuilt container case, manpages are missing.  Ignore that.
+          # Also chown everything to writable, due to https://bugzilla.redhat.com/show_bug.cgi?id=517575
+          chmod -R u+w ${DESTDIR}/
+          rsync -l --ignore-missing-args --files-from=list.txt / ${DESTDIR}/
+          rm -f list.txt
+       done
        make install DESTDIR=${DESTDIR}
        touch ${DESTDIR}/.completed'
     [ -f ${VMCHECK_INSTTREE}/.completed ]
@@ -59,16 +73,8 @@ ostree checkout $commit vmcheck --fsync=0
 # ✀✀✀ BEGIN hack for https://github.com/projectatomic/rpm-ostree/pull/693 ✀✀✀
 rm -f vmcheck/usr/etc/{.pwd.lock,passwd-,group-,shadow-,gshadow-,subuid-,subgid-}
 # ✀✀✀ END hack for https://github.com/projectatomic/rpm-ostree/pull/693 ✀✀✀
-# ✀✀✀ BEGIN update ostree; see redhat-ci.sh ✀✀✀
-for url in https://kojipkgs.fedoraproject.org//packages/ostree/2017.5/2.fc25/x86_64/ostree-{,libs-,grub2-}2017.5-2.fc25.x86_64.rpm; do
-    curl -sSL -O $url
-done
-for x in *.rpm; do
-    rpm2cpio $x | (cd vmcheck && cpio -div)
-done
 rm vmcheck/etc -rf
-rm -f *.rpm
-# ✀✀✀ END update ostree; see redhat-ci.sh ✀✀✀
+# END update ostree
 # Now, overlay our built binaries
 rsync -rlv /var/roothome/sync/insttree/usr/ vmcheck/usr/
 ostree refs --delete vmcheck || true

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -74,7 +74,6 @@ ostree checkout $commit vmcheck --fsync=0
 rm -f vmcheck/usr/etc/{.pwd.lock,passwd-,group-,shadow-,gshadow-,subuid-,subgid-}
 # ✀✀✀ END hack for https://github.com/projectatomic/rpm-ostree/pull/693 ✀✀✀
 rm vmcheck/etc -rf
-# END update ostree
 # Now, overlay our built binaries
 rsync -rlv /var/roothome/sync/insttree/usr/ vmcheck/usr/
 ostree refs --delete vmcheck || true


### PR DESCRIPTION

Conceptually: we're going to move rpm-ostree and ostree at the same
cadence most of the time; for both releases *and* for git master.
The problem so far has been the latter part.  Reusing FAHC
for the build gets us half of the problem.  The other half is using FAHC
for host tests.