### PR TITLE
core: Ignore %pretrans

### DIFF
--- a/src/libpriv/rpmostree-script-gperf.gperf
+++ b/src/libpriv/rpmostree-script-gperf.gperf
@@ -16,11 +16,8 @@ glibc.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE
 glibc-headers.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE /* Legacy workaround */
 coreutils.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE  /* workaround for old bug? */
 ca-certificates.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE  /* Looks like legacy... */
-filesystem.pretrans, RPMOSTREE_SCRIPT_ACTION_IGNORE
 libgcc.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
 setup.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
-java-1.8.0-openjdk-headless.pretrans, RPMOSTREE_SCRIPT_ACTION_IGNORE  /* https://bugzilla.redhat.com/show_bug.cgi?id=1038092 Upgrade compat, shouldn't be needed */
-copy-jdk-configs.pretrans, RPMOSTREE_SCRIPT_ACTION_IGNORE  /* See above */
 pinentry.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE
 fedora-release.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
 fedora-release.posttrans, RPMOSTREE_SCRIPT_ACTION_IGNORE

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -49,6 +49,14 @@ static const KnownRpmScriptKind ignored_scripts[] = {
     RPMTAG_TRIGGERUN, 0, 0 },
   { "%triggerpostun", RPMSENSE_TRIGGERPOSTUN,
     RPMTAG_TRIGGERPOSTUN, 0, 0 },
+
+  /* In practice, %pretrans are hack-arounds for broken upgrades.
+   * Again, since we always assemble a new root, there's no point
+   * to running them.
+   * http://lists.rpm.org/pipermail/rpm-ecosystem/2016-August/000391.html
+   */
+  { "%pretrans", 0,
+    RPMTAG_PRETRANS, RPMTAG_PRETRANSPROG, RPMTAG_PRETRANSFLAGS },
 };
 #endif
 
@@ -66,8 +74,6 @@ static const KnownRpmScriptKind posttrans_scripts[] = {
 };
 
 static const KnownRpmScriptKind unsupported_scripts[] = {
-  { "%pretrans", 0,
-    RPMTAG_PRETRANS, RPMTAG_PRETRANSPROG, RPMTAG_PRETRANSFLAGS },
   { "%triggerprein", RPMSENSE_TRIGGERPREIN,
     RPMTAG_TRIGGERPREIN, 0, 0 },
   { "%triggerin", RPMSENSE_TRIGGERIN,

--- a/tests/common/compose/yum/scriptpkg1.spec
+++ b/tests/common/compose/yum/scriptpkg1.spec
@@ -23,6 +23,10 @@ chmod a+x scriptpkg1
 # Test our /etc/passwd handling
 groupadd -r scriptpkg1
 
+%pretrans
+# http://lists.rpm.org/pipermail/rpm-ecosystem/2016-August/000391.html
+echo "I'm a workaround for a bug" >/dev/null
+
 %posttrans
 # Firewalld; https://github.com/projectatomic/rpm-ostree/issues/638
 . /etc/os-release || :


### PR DESCRIPTION
This was argued on list a while ago: http://lists.rpm.org/pipermail/rpm-ecosystem/2016-August/000391.html
Basically, every use of `%pretrans` is a workaround for some in-place
upgrade problem.  But we never do inplace updates, we always assemble
a new tree.  Hence, there is no point for us to ever execute these.

Let's stop erroring out on them. If there does turn out to be some problem with
a particular package (e.g. the `openjdk-copy-configs` or whatever), we would
likely end up needing to fix that package's `%post`, not start executing its
`%pretrans`.
