### PR TITLE
libbuild.sh: pass arguments to make

### DIFF
--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -6,9 +6,9 @@ set -xeuo pipefail
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
 ${dn}/build.sh
-# NB: override parallel builds because our RPM building
-# doesn't # support that right now
-make check -j1
+# NB: avoid make function because our RPM building doesn't
+# support parallel runs right now
+/usr/bin/make check
 make install
 gnome-desktop-testing-runner rpm-ostree
 sudo --user=testuser gnome-desktop-testing-runner rpm-ostree

--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -6,7 +6,9 @@ set -xeuo pipefail
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
 ${dn}/build.sh
-make check
+# NB: override parallel builds because our RPM building
+# doesn't # support that right now
+make check -j1
 make install
 gnome-desktop-testing-runner rpm-ostree
 sudo --user=testuser gnome-desktop-testing-runner rpm-ostree

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 make() {
-    /usr/bin/make -j $(getconf _NPROCESSORS_ONLN)
+    /usr/bin/make -j $(getconf _NPROCESSORS_ONLN) "$@"
 }
 
 build() {


### PR DESCRIPTION
Otherwise, e.g. `make check` && `make install` won't actually do
anything.

Noticed this while looking at the test outputs in #764:

```
+ make check
++ getconf _NPROCESSORS_ONLN
+ /usr/bin/make -j 8
...
+ make install
++ getconf _NPROCESSORS_ONLN
+ /usr/bin/make -j 8
...
+ gnome-desktop-testing-runner rpm-ostree
SUMMARY: total=0; passed=0; skipped=0; failed=0; user=0.0s; system=0.0s; maxrss=0
+ sudo --user=testuser gnome-desktop-testing-runner rpm-ostree
SUMMARY: total=0; passed=0; skipped=0; failed=0; user=0.0s; system=0.0s; maxrss=0
```

Ouch!