### PR TITLE
rpmostreed-os.c: remove unused variable

### DIFF
--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -1206,7 +1206,6 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
 
   if (booted)
     {
-      g_autoptr(OstreeDeployment) pending = NULL;
       g_autoptr(OstreeDeployment) rollback = NULL;
 
       rpmostree_syscore_query_deployments (ot_sysroot, ostree_deployment_get_osname (booted),


### PR DESCRIPTION
Not sure why the clang tester didn't pick this up.