### PR TITLE
core: invalidate pkgcache based on RPM checksum

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1426,7 +1426,7 @@ rpmostree_dnf_add_checksum_goal (GChecksum   *checksum,
     {
       DnfPackage *pkg = pkglist->pdata[i];
       g_autofree char* chksum_repr = NULL;
-      g_assert (rpmostree_get_pkg_chksum_repr (pkg, &chksum_repr, NULL));
+      g_assert (rpmostree_get_repodata_chksum_repr (pkg, &chksum_repr, NULL));
       g_ptr_array_add (pkg_checksums, g_steal_pointer (&chksum_repr));
     }
 

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -468,7 +468,7 @@ rpmostree_context_set_repos (RpmOstreeContext *self,
 static OstreeRepo *
 get_pkgcache_repo (RpmOstreeContext *self)
 {
-  return self->pkgcache_repo ? self->pkgcache_repo : self->ostreerepo;
+  return self->pkgcache_repo ?: self->ostreerepo;
 }
 
 /* I debated making this part of the treespec. Overall, I think it makes more
@@ -702,6 +702,15 @@ get_commit_header_sha256 (GVariant *commit,
                           GError  **error)
 {
   return get_commit_metadata_string (commit, "rpmostree.metadata_sha256",
+                                     out_csum, error);
+}
+
+static gboolean
+get_commit_pkg_chksum_repr (GVariant *commit,
+                            char    **out_csum,
+                            GError  **error)
+{
+  return get_commit_metadata_string (commit, "rpmostree.pkg_chksum_repr",
                                      out_csum, error);
 }
 
@@ -997,8 +1006,39 @@ commit_has_matching_sepolicy (OstreeRepo     *repo,
   if (!get_commit_sepolicy_csum (commit, &sepolicy_csum, error))
     return FALSE;
 
-  *out_matches = strcmp (sepolicy_csum, sepolicy_csum_wanted) == 0;
+  *out_matches = g_str_equal (sepolicy_csum, sepolicy_csum_wanted);
 
+  return TRUE;
+}
+
+static gboolean
+commit_has_matching_pkg_chksum_repr (OstreeRepo  *repo,
+                                     const char  *rev,
+                                     const char  *expected,
+                                     gboolean    *out_matches,
+                                     GError     **error)
+{
+  g_autoptr(GVariant) commit = NULL;
+  if (!ostree_repo_load_commit (repo, rev, &commit, NULL, error))
+    return FALSE;
+
+  g_assert (commit);
+
+  g_autofree char *actual = NULL;
+  g_autoptr(GError) tmp_error = NULL;
+  if (!get_commit_pkg_chksum_repr (commit, &actual, &tmp_error))
+    {
+      /* never match pkgs unpacked with older versions that didn't embed csum */
+      if (g_error_matches (tmp_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+        {
+          *out_matches = FALSE;
+          return TRUE;
+        }
+      g_propagate_error (error, g_steal_pointer (&tmp_error));
+      return FALSE;
+    }
+
+  *out_matches = g_str_equal (expected, actual);
   return TRUE;
 }
 
@@ -1026,31 +1066,57 @@ find_pkg_in_ostree (OstreeRepo     *repo,
                     gboolean       *out_selinux_match,
                     GError        **error)
 {
-  *out_in_ostree = FALSE;
-  *out_selinux_match = FALSE;
+  g_assert (repo);
 
-  if (repo != NULL)
+  g_autofree char *cached_rev = NULL;
+  g_autofree char *cachebranch = rpmostree_get_cache_branch_pkg (pkg);
+  if (!ostree_repo_resolve_rev (repo, cachebranch, TRUE,
+                                &cached_rev, error))
+    return FALSE;
+
+  if (!cached_rev)
+    { /* NB: not in tree; happy early return */
+      *out_in_ostree = FALSE;
+      *out_selinux_match = FALSE;
+      return TRUE;
+    }
+
+  /* NB: we do an exception for LocalPackages here; we've already checked that
+   * its cache is valid and matches what's in the origin. We never want to fetch
+   * newer versions of LocalPackages from the repos. But we do want to check
+   * whether a relabel will be necessary. */
+
+  const char *reponame = dnf_package_get_reponame (pkg);
+  if (g_strcmp0 (reponame, HY_CMDLINE_REPO_NAME) != 0)
     {
-      g_autofree char *cachebranch = rpmostree_get_cache_branch_pkg (pkg);
-      g_autofree char *cached_rev = NULL;
-
-      if (!ostree_repo_resolve_rev (repo, cachebranch, TRUE,
-                                    &cached_rev, error))
+      g_autofree char *expected_chksum_repr = NULL;
+      if (!rpmostree_get_pkg_chksum_repr (pkg, &expected_chksum_repr, error))
         return FALSE;
 
-      if (cached_rev)
-        {
-          *out_in_ostree = TRUE;
+      gboolean same_pkg_chksum = FALSE;
+      if (!commit_has_matching_pkg_chksum_repr (repo, cached_rev,
+                                                expected_chksum_repr,
+                                                &same_pkg_chksum, error))
+        return FALSE;
 
-          if (sepolicy)
-            {
-              if (!commit_has_matching_sepolicy (repo, cached_rev, sepolicy,
-                                                 out_selinux_match, error))
-                return FALSE;
-            }
+      if (!same_pkg_chksum)
+        { /* NB: chksum mismatch; happy early return */
+          *out_in_ostree = FALSE;
+          *out_selinux_match = FALSE;
+          return TRUE;
         }
     }
 
+  gboolean selinux_match = FALSE;
+  if (sepolicy)
+    {
+      if (!commit_has_matching_sepolicy (repo, cached_rev, sepolicy,
+                                         &selinux_match, error))
+        return FALSE;
+    }
+
+  *out_in_ostree = TRUE;
+  *out_selinux_match = selinux_match;
   return TRUE;
 }
 

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -43,6 +43,7 @@
 #define RPMOSTREE_MESSAGE_COMMIT_STATS SD_ID128_MAKE(e6,37,2e,38,41,21,42,a9,bc,13,b6,32,b3,f8,93,44)
 #define RPMOSTREE_MESSAGE_SELINUX_RELABEL SD_ID128_MAKE(5a,e0,56,34,f2,d7,49,3b,b1,58,79,b7,0c,02,e6,5d)
 #define RPMOSTREE_MESSAGE_PKG_REPOS SD_ID128_MAKE(0e,ea,67,9b,bf,a3,4d,43,80,2d,ec,99,b2,74,eb,e7)
+#define RPMOSTREE_MESSAGE_PKG_IMPORT SD_ID128_MAKE(df,8b,b5,4f,04,fa,47,08,ac,16,11,1b,bf,4b,a3,52)
 
 #define RPMOSTREE_DIR_CACHE_REPOMD "repomd"
 #define RPMOSTREE_DIR_CACHE_SOLV "solv"
@@ -1272,7 +1273,7 @@ rpmostree_context_prepare_install (RpmOstreeContext    *self,
     }
 
   { GPtrArray *repos = dnf_context_get_repos (hifctx);
-    g_autoptr(GString) enabled_repos = g_string_new ("[");
+    g_autoptr(GString) enabled_repos = g_string_new ("");
     g_autoptr(GString) enabled_repos_solvables = g_string_new ("");
     guint total_solvables = 0;
     gboolean first = TRUE;
@@ -1285,19 +1286,21 @@ rpmostree_context_prepare_install (RpmOstreeContext    *self,
         if (first)
           first = FALSE;
         else
-          g_string_append_c (enabled_repos, ' ');
+          {
+            g_string_append (enabled_repos, ", ");
+            g_string_append (enabled_repos_solvables, ", ");
+          }
         g_autofree char *quoted = g_shell_quote (dnf_repo_get_id (repo));
         g_string_append (enabled_repos, quoted);
         total_solvables += dnf_repo_get_n_solvables (repo);
-        g_string_append_printf (enabled_repos_solvables, "%u ", dnf_repo_get_n_solvables (repo));
+        g_string_append_printf (enabled_repos_solvables, "%u", dnf_repo_get_n_solvables (repo));
       }
-    g_string_append_c (enabled_repos, ']');
 
     sd_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(RPMOSTREE_MESSAGE_PKG_REPOS),
-                     "MESSAGE=Preparing pkg txn; enabled repos: %s solvables: %u", enabled_repos->str, total_solvables,
+                     "MESSAGE=Preparing pkg txn; enabled repos: [%s] solvables: %u", enabled_repos->str, total_solvables,
                      "SACK_N_SOLVABLES=%i", dnf_sack_count (dnf_context_get_sack (hifctx)),
-                     "ENABLED_REPOS=%s", enabled_repos->str,
-                     "ENABLED_REPOS_SOLVABLES=%s", enabled_repos_solvables->str,
+                     "ENABLED_REPOS=[%s]", enabled_repos->str,
+                     "ENABLED_REPOS_SOLVABLES=[%s]", enabled_repos_solvables->str,
                      NULL);
   }
 
@@ -1583,6 +1586,11 @@ rpmostree_context_import (RpmOstreeContext *self,
     g_signal_handler_disconnect (hifstate, progress_sigid);
     rpmostree_output_percent_progress_end ();
   }
+
+  sd_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR,
+                   SD_ID128_FORMAT_VAL(RPMOSTREE_MESSAGE_PKG_IMPORT),
+                   "MESSAGE=Imported %u pkg%s", n, n > 1 ? "s" : "",
+                   "IMPORTED_N_PKGS=%u", n, NULL);
 
   ret = TRUE;
  out:

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1360,12 +1360,9 @@ rpmostree_dnf_add_checksum_goal (GChecksum   *checksum,
   for (i = 0; i < pkglist->len; i++)
     {
       DnfPackage *pkg = pkglist->pdata[i];
-      int pkg_checksum_type;
-      const unsigned char *pkg_checksum_bytes = dnf_package_get_chksum (pkg, &pkg_checksum_type);
-      g_autofree char *pkg_checksum = hy_chksum_str (pkg_checksum_bytes, pkg_checksum_type);
-      char *pkg_checksum_with_type = g_strconcat (hy_chksum_name (pkg_checksum_type), ":", pkg_checksum, NULL);
-
-      g_ptr_array_add (pkg_checksums, pkg_checksum_with_type);
+      g_autofree char* chksum_repr = NULL;
+      g_assert (rpmostree_get_pkg_chksum_repr (pkg, &chksum_repr, NULL));
+      g_ptr_array_add (pkg_checksums, g_steal_pointer (&chksum_repr));
     }
 
   g_ptr_array_sort (pkg_checksums, rpmostree_ptrarray_sort_compare_strings);

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -1058,10 +1058,15 @@ rpmostree_fcap_to_xattr_variant (const char *fcap)
   return g_variant_ref_sink (g_variant_builder_end (&builder));
 }
 
+/* Returns the checksum of the RPM we retrieved from the repodata XML. The
+ * actual checksum type used depends on how the repodata was created. Thus, the
+ * output is a string representation of the form "TYPE:HASH" where TYPE is the
+ * name of the checksum employed. In most cases, it will be "sha256" (the
+ * current default for `createrepo_c`). */
 gboolean
-rpmostree_get_pkg_chksum_repr (DnfPackage *pkg,
-                               char      **out_chksum_repr,
-                               GError    **error)
+rpmostree_get_repodata_chksum_repr (DnfPackage *pkg,
+                                    char      **out_chksum_repr,
+                                    GError    **error)
 {
   int chksum_type;
   g_autofree char *chksum = NULL;

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -1057,3 +1057,25 @@ rpmostree_fcap_to_xattr_variant (const char *fcap)
                                                    vfsbytes, FALSE));
   return g_variant_ref_sink (g_variant_builder_end (&builder));
 }
+
+gboolean
+rpmostree_get_pkg_chksum_repr (DnfPackage *pkg,
+                               char      **out_chksum_repr,
+                               GError    **error)
+{
+  int chksum_type;
+  g_autofree char *chksum = NULL;
+  const unsigned char *chksum_raw = NULL;
+
+  chksum_raw = dnf_package_get_chksum (pkg, &chksum_type);
+  if (chksum_raw)
+    chksum = hy_chksum_str (chksum_raw, chksum_type);
+
+  if (chksum == NULL)
+    return glnx_throw (error, "Couldn't get chksum for pkg %s",
+                       dnf_package_get_nevra(pkg));
+
+  *out_chksum_repr =
+    g_strconcat (hy_chksum_name (chksum_type), ":", chksum, NULL);
+  return TRUE;
+}

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -168,6 +168,6 @@ char *
 rpmostree_pkg_custom_nevra_strdup (Header h, RpmOstreePkgNevraFlags flags);
 
 gboolean
-rpmostree_get_pkg_chksum_repr (DnfPackage *pkg,
-                               char      **out_chksum_repr,
-                               GError    **error);
+rpmostree_get_repodata_chksum_repr (DnfPackage *pkg,
+                                    char      **out_chksum_repr,
+                                    GError    **error);

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -166,3 +166,8 @@ typedef enum {
 
 char *
 rpmostree_pkg_custom_nevra_strdup (Header h, RpmOstreePkgNevraFlags flags);
+
+gboolean
+rpmostree_get_pkg_chksum_repr (DnfPackage *pkg,
+                               char      **out_chksum_repr,
+                               GError    **error);

--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -431,7 +431,7 @@ get_lead_sig_header_as_bytes (RpmOstreeUnpacker *self,
                    bytes_remaining);
       goto out;
     }
-  
+
   ret = TRUE;
   *out_metadata = g_bytes_new_take (g_steal_pointer (&buf), self->cpio_offset);
  out:
@@ -464,10 +464,13 @@ build_metadata_variant (RpmOstreeUnpacker *self,
   g_auto(GVariantBuilder) metadata_builder;
   g_variant_builder_init (&metadata_builder, (GVariantType*)"a{sv}");
 
-  /* NB: We store the full header of the RPM in the commit for two reasons:
-   * first, it holds the file security capabilities, and secondly, we'll need to
-   * provide it to librpm when it updates the rpmdb (see
-   * rpmostree_context_assemble_commit()). */
+  /* NB: We store the full header of the RPM in the commit for three reasons:
+   *   1. it holds the file security capabilities, which we need during checkout
+   *   2. we'll need to provide it to librpm when it updates the rpmdb (see
+   *      rpmostree_context_assemble_commit())
+   *   3. it's needed in the local pkgs paths to fool the libdnf stack (see
+   *      rpmostree_context_prepare_install())
+   */
   {
     g_autoptr(GBytes) metadata = NULL;
 
@@ -478,8 +481,6 @@ build_metadata_variant (RpmOstreeUnpacker *self,
                            g_variant_new_from_bytes ((GVariantType*)"ay",
                                                      metadata, TRUE));
 
-    /* NB: the header also includes checksums for every entry in the (cut-off)
-     * archive, so there's no need to also bring that in */
     g_checksum_update (pkg_checksum, g_bytes_get_data (metadata, NULL),
                                      g_bytes_get_size (metadata));
 
@@ -506,7 +507,7 @@ build_metadata_variant (RpmOstreeUnpacker *self,
    * compatible increments.
    */
   g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.unpack_minor_version",
-                         g_variant_new_uint32 (2));
+                         g_variant_new_uint32 (3));
 
   if (self->pkg)
     {
@@ -516,6 +517,16 @@ build_metadata_variant (RpmOstreeUnpacker *self,
           g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.repo",
                                  repo_metadata_to_variant (repo));
         }
+
+      /* include a checksum of the RPM as a whole; the actual algo used depends
+       * on how the repodata was created, so just keep a repr */
+      g_autofree char* chksum_repr = NULL;
+      if (!rpmostree_get_pkg_chksum_repr (self->pkg, &chksum_repr, error))
+        return FALSE;
+
+      g_variant_builder_add (&metadata_builder, "{sv}",
+                             "rpmostree.pkg_chksum_repr",
+                             g_variant_new_string (chksum_repr));
     }
 
   *out_variant = g_variant_builder_end (&metadata_builder);

--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -521,11 +521,11 @@ build_metadata_variant (RpmOstreeUnpacker *self,
       /* include a checksum of the RPM as a whole; the actual algo used depends
        * on how the repodata was created, so just keep a repr */
       g_autofree char* chksum_repr = NULL;
-      if (!rpmostree_get_pkg_chksum_repr (self->pkg, &chksum_repr, error))
+      if (!rpmostree_get_repodata_chksum_repr (self->pkg, &chksum_repr, error))
         return FALSE;
 
       g_variant_builder_add (&metadata_builder, "{sv}",
-                             "rpmostree.pkg_chksum_repr",
+                             "rpmostree.repodata_checksum",
                              g_variant_new_string (chksum_repr));
     }
 


### PR DESCRIPTION
Closes: https://github.com/projectatomic/rpm-ostree/issues/649