### PR TITLE
ci: Ensure fahc builds win over base

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -8,6 +8,8 @@ dn=$(dirname $0)
 
 # Use the latest ostree by default
 echo -e '[fahc]\nbaseurl=https://ci.centos.org/artifacts/sig-atomic/fahc/rdgo/build/\ngpgcheck=0\n' > /etc/yum.repos.d/fahc.repo
+# Until we fix https://github.com/rpm-software-management/libdnf/pull/149
+sed -i -e 's,metadata_expire=6h,exclude=ostree ostree-devel ostree-libs ostree-grub2\nmetadata_expire=6h,' /etc/yum.repos.d/fedora-updates.repo
 # See also tests/vmcheck/overlay.sh
 
 install_builddeps rpm-ostree

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -328,6 +328,9 @@ EOF
     cd ${test_tmpdir}
     # sysroot dir already made by setup-session.sh
     ostree admin --sysroot=sysroot init-fs sysroot
+    if test -n "${OSTREE_NO_XATTRS:-}"; then
+        echo -e 'disable-xattrs=true\n' >> sysroot/ostree/repo/config
+    fi
     ostree admin --sysroot=sysroot os-init testos
 
     case $bootmode in


### PR DESCRIPTION
Right now due to rdgo using `git describe` we have `v2017.4.65`, which
is lower than `v2017.5`.
