### PR TITLE
daemon/core: Fix leaks in metadata cleanup

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -581,7 +581,7 @@ find_missing_pkgs_in_rpmdb (int            rootfs_dfd,
     {
       glnx_unref_object OstreeRepo *pkgcache_repo = NULL;
 
-      if (!rpmostree_mkdtemp ("/tmp/rpmostree-metadata-XXXXXX",
+      if (!rpmostree_mkdtemp ("/tmp/rpmostree-localpkgmeta-XXXXXX",
                               &metadata_tmp_path, NULL, error))
         goto out;
 
@@ -631,12 +631,10 @@ find_missing_pkgs_in_rpmdb (int            rootfs_dfd,
     }
 
   *out_missing_pkgs = g_steal_pointer (&missing_pkgs);
-  return TRUE;
-
   ret = TRUE;
 out:
   if (metadata_tmp_path)
-    glnx_shutil_rm_rf_at (AT_FDCWD, metadata_tmp_path, cancellable, error);
+    (void) glnx_shutil_rm_rf_at (AT_FDCWD, metadata_tmp_path, NULL, NULL);
   return ret;
 }
 

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -303,8 +303,6 @@ rpmostree_context_finalize (GObject *object)
 
   g_clear_pointer (&rctx->passwd_dir, g_free);
 
-  g_clear_pointer (&rctx->metadata_dir_path, g_free);
-
   if (rctx->metadata_dir_path)
     {
       (void) glnx_shutil_rm_rf_at (AT_FDCWD, rctx->metadata_dir_path, NULL, NULL);


### PR DESCRIPTION
I noticed I had `/tmp/rpmostree-metadata*` directories, and there
were two cases where we created those dirs.  Astonishingly,
*both* had bugs that prevented cleaning up.

Rename one of them so in the future it'll be clearer which is buggy (or both).
