### PR TITLE
 compose: Make `/tmp` a directory by default, add `old-style-tmp`

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -183,3 +183,10 @@ It supports the following parameters:
    source file must be in the same directory as the treefile.
 
    Example: `"add-files": [["bar", "/bar"], ["foo", "/foo"]]`
+
+ * `tmp-is-dir`: boolean, optional: Defaults to `false`.  By default,
+   rpm-ostree creates symlink `/tmp` → `/sysroot/tmp`.
+   It's more flexible to leave it as a directory (systemd will mount it),
+   and further, we don't want to encourage `/sysroot` to be writable.
+   For host system composes, we recommend turning this on; it's left off
+   by default to ease the transition.

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -38,3 +38,9 @@ echo "ok boot files"
 ostree --repo=${repobuild} ls -R ${treeref} /usr/share/man > manpages.txt
 assert_file_has_content manpages.txt man5/ostree.repo.5
 echo "ok manpages"
+
+# https://github.com/projectatomic/rpm-ostree/issues/669
+ostree --repo=${repobuild} ls  ${treeref} /tmp > ls.txt
+assert_file_has_content ls.txt 'd01777 0 0      0 /tmp'
+echo "ok /tmp"
+

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -41,6 +41,6 @@ echo "ok manpages"
 
 # https://github.com/projectatomic/rpm-ostree/issues/669
 ostree --repo=${repobuild} ls  ${treeref} /tmp > ls.txt
-assert_file_has_content ls.txt 'd01777 0 0      0 /tmp'
+assert_file_has_content ls.txt 'l00777 0 0      0 /tmp -> sysroot/tmp'
 echo "ok /tmp"
 

--- a/tests/compose-tests/test-misc-tweaks.sh
+++ b/tests/compose-tests/test-misc-tweaks.sh
@@ -18,6 +18,8 @@ pysetjsonmember "remove-files" '["etc/hosts"]'
 pysetjsonmember "remove-from-packages" '[["setup", "/etc/hosts\..*"]]'
 rnd=$RANDOM
 echo $rnd > composedata/foo.txt
+# Test tmp-is-dir
+pysetjsonmember "tmp-is-dir" 'True'
 
 # Do the compose
 runcompose
@@ -52,3 +54,8 @@ ostree --repo=${repobuild} ls ${treeref} /usr/etc > out.txt
 assert_not_file_has_content out.txt '/usr/etc/hosts\.allow$'
 assert_not_file_has_content out.txt '/usr/etc/hosts\.deny$'
 echo "ok remove-from-packages"
+
+# https://github.com/projectatomic/rpm-ostree/issues/669
+ostree --repo=${repobuild} ls  ${treeref} /tmp > ls.txt
+assert_file_has_content ls.txt 'd01777 0 0      0 /tmp'
+echo "ok /tmp"


### PR DESCRIPTION

There are a few reasons to do this.  First, systemd changed to refuse
mounts on symlinks, and hence if one *wants* "/tmp-on-tmpfs", it's
annoying.

Second, the original rationale for having this symlink was that if you had
multiple ostree stateroots ("osnames"), it's nicer if they had the same `/tmp`
to avoid duplication. But in practice today that's already an issue due to
`/var/tmp`, and further the multiple-stateroot case is pretty unusual. And that
case is *further* broken by SELinux (if one wanted to have e.g. an Ubuntu and
Fedora) stateroots.  So let's fully decouple this and make `/tmp` a plain
old directory by default, so systemd's `tmp.mount` can become useful.

Now, things get interesting for the case where someone wants a physical `/tmp`
that *does* persist across reboots. Right now, if one just did a `systemctl mask
tmp.mount` as we do in Fedora Atomic Host's cloud images, you'd get a semantic
where `/tmp` stays per-deployment, which is weird.  Our recommendation for
that should likely be to set up a bind mount for `/tmp` → `/var/tmp`.

Closes: #669