### PR TITLE
core: allow no enabled repos

### DIFF
--- a/tests/vmcheck/test-layering-local.sh
+++ b/tests/vmcheck/test-layering-local.sh
@@ -28,6 +28,7 @@ vm_send_test_repo
 
 vm_assert_layered_pkg foo absent
 
+vm_cmd ostree refs $(vm_get_deployment_info 0 checksum) --create vmcheck_tmp/without_foo
 vm_rpmostree install /tmp/vmcheck/repo/packages/x86_64/foo-1.0-1.x86_64.rpm
 echo "ok install foo locally"
 
@@ -65,3 +66,10 @@ if vm_rpmostree install /tmp/vmcheck/repo/packages/x86_64/foo-1.0-1.x86_64.rpm; 
   assert_not_reached "didn't error out when trying to install same pkg"
 fi
 echo "ok error on layering same pkg in base"
+
+# check that installing local RPMs without any repos available works
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/without_foo
+vm_rpmostree upgrade
+vm_cmd rm -rf /etc/yum.repos.d/
+vm_rpmostree install /tmp/vmcheck/repo/packages/x86_64/foo-1.0-1.x86_64.rpm
+echo "ok layer local foo without repos"

--- a/tests/vmcheck/test.sh
+++ b/tests/vmcheck/test.sh
@@ -55,7 +55,7 @@ if ! vm_cmd test -f /etc/yum.repos.d/.vmcheck; then
     vm_cmd rm /etc/yum.repos.d.tmp -rf
     vm_cmd mkdir /etc/yum.repos.d.tmp
     vm_cmd touch /etc/yum.repos.d.tmp/.vmcheck
-    vm_cmd mv /etc/yum.repos.d{.tmp,}
+    vm_cmd cp -r /etc/yum.repos.d{.tmp,}
 else
     echo "Keeping existing vmcheck /etc/yum.repos.d"
 fi
@@ -152,6 +152,10 @@ for tf in $(find . -name 'test-*.sh' | sort); do
 
     # make sure to clean up any pending & rollback deployments
     vm_rpmostree cleanup -b -p -r || :
+
+    # and put back our tmp repo
+    vm_cmd rm /etc/yum.repos.d -rf
+    vm_cmd cp -r /etc/yum.repos.d{.tmp,}
 done
 
 


### PR DESCRIPTION
This is a valid case when layering local RPMs. Other paths (container &
treecompose) are forced to define repos since that's the only way for
them to get content.

Closes: #780