### PR TITLE
livefs: Fix etc merge with subdirectories

### DIFF
--- a/src/daemon/rpmostreed-transaction-livefs.c
+++ b/src/daemon/rpmostreed-transaction-livefs.c
@@ -193,6 +193,9 @@ copy_new_config_files (OstreeRepo          *repo,
   if (!glnx_opendirat (new_deployment_dfd, "etc", TRUE, &deployment_etc_dfd, error))
     return FALSE;
 
+  /* FIXME: This algorithm currently unncessarily recurses into added
+   * subdirectories, and checks out each file/subdir again.
+   */
   guint n_added = 0;
   for (guint i = 0; i < diff->added->len; i++)
     {

--- a/tests/common/compose/yum/test-livefs-with-etc.spec
+++ b/tests/common/compose/yum/test-livefs-with-etc.spec
@@ -27,7 +27,16 @@ mkdir -p %{buildroot}/usr/bin
 install %{name} %{buildroot}/usr/bin
 mkdir -p %{buildroot}/etc
 install %{name}.conf %{buildroot}/etc
+mkdir -p %{buildroot}/etc/%{name}/
+echo subconfig-one > %{buildroot}/etc/%{name}/subconfig-one.conf
+echo subconfig-two > %{buildroot}/etc/%{name}/subconfig-two.conf
+mkdir -p %{buildroot}/etc/%{name}/subdir
+echo subconfig-three > %{buildroot}/etc/%{name}/subdir/subconfig-three.conf
+mkdir -p %{buildroot}/etc/opt
+echo file-in-opt-subdir > %{buildroot}/etc/opt/%{name}-opt.conf
 
 %files
 /usr/bin/%{name}
 /etc/%{name}.conf
+/etc/%{name}/*
+/etc/opt/%{name}*

--- a/tests/vmcheck/test-livefs.sh
+++ b/tests/vmcheck/test-livefs.sh
@@ -58,6 +58,10 @@ vm_cmd rpm -q foo test-livefs-with-etc > rpmq.txt
 assert_file_has_content rpmq.txt foo-1.0-1 test-livefs-with-etc-1.0-1
 vm_cmd cat /etc/test-livefs-with-etc.conf > test-livefs-with-etc.conf
 assert_file_has_content test-livefs-with-etc.conf "A config file for test-livefs-with-etc"
+for v in subconfig-one subconfig-two subdir/subconfig-three; do
+    vm_cmd cat /etc/test-livefs-with-etc/${v}.conf > test-livefs-with-etc.conf
+    assert_file_has_content_literal test-livefs-with-etc.conf $(basename $v)
+done
 
 echo "ok livefs stage2"
 

--- a/tests/vmcheck/test-livefs.sh
+++ b/tests/vmcheck/test-livefs.sh
@@ -62,6 +62,8 @@ for v in subconfig-one subconfig-two subdir/subconfig-three; do
     vm_cmd cat /etc/test-livefs-with-etc/${v}.conf > test-livefs-with-etc.conf
     assert_file_has_content_literal test-livefs-with-etc.conf $(basename $v)
 done
+vm_cmd cat /etc/opt/test-livefs-with-etc-opt.conf > test-livefs-with-etc.conf
+assert_file_has_content test-livefs-with-etc.conf "file-in-opt-subdir"
 
 echo "ok livefs stage2"
 


### PR DESCRIPTION
This was a kind of last-minute bug introduced when I tweaked the
checkout to use `.` to avoid a `mkdir()` for files.  But there were
multiple bugs with that; for files that are in subdirectories of `/etc`
we obviously need to get the right subdir and not use `/etc`.

Second, we need to handle the case where we're adding new subdirectories.

This change fixes `rpm-ostree install firewalld + rpm-ostree ex livefs`.
