### PR TITLE
core: Ignore overrides for nonexistent %ghost files in /etc

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2301,10 +2301,9 @@ apply_rpmfi_overrides (int            tmp_metadata_dfd,
           /* Not early loop skip; in the ghost case, we expect it to not
            * exist.
            */
-          if (is_ghost)
+          if (errno == ENOENT && is_ghost)
             continue;
-          glnx_set_prefix_error_from_errno (error, "fstatat: %s", fn);
-          return FALSE;
+          return glnx_throw_errno_prefix (error, "fstatat(%s)", fn);
         }
 
       if ((S_IFMT & stbuf.st_mode) != (S_IFMT & mode))

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2253,6 +2253,8 @@ apply_rpmfi_overrides (int            tmp_metadata_dfd,
       const char *group = rpmfiFGroup (fi) ?: "root";
       const char *fcaps = rpmfiFCaps (fi) ?: '\0';
       rpm_mode_t mode = rpmfiFMode (fi);
+      rpmfileAttrs fattrs = rpmfiFFlags (fi);
+      const gboolean is_ghost = fattrs & RPMFILE_GHOST;
       struct stat stbuf;
       uid_t uid = 0;
       gid_t gid = 0;
@@ -2296,6 +2298,11 @@ apply_rpmfi_overrides (int            tmp_metadata_dfd,
 
       if (fstatat (tmprootfs_dfd, fn, &stbuf, AT_SYMLINK_NOFOLLOW) != 0)
         {
+          /* Not early loop skip; in the ghost case, we expect it to not
+           * exist.
+           */
+          if (is_ghost)
+            continue;
           glnx_set_prefix_error_from_errno (error, "fstatat: %s", fn);
           return FALSE;
         }

--- a/tests/common/compose/yum/nonrootcap.spec
+++ b/tests/common/compose/yum/nonrootcap.spec
@@ -52,6 +52,7 @@ rm -rf %{buildroot}
 /usr/bin/nrc-none.sh
 %attr(-, nrcuser, -) /etc/nrc.conf
 %attr(-, nrcuser, -) /etc/nrc-link.conf
+%ghost %attr(-, nrcuser, -) /etc/nrc-ghost.conf
 %attr(-, nrcuser, -) /usr/bin/nrc-user.sh
 %attr(-, nrcuser, -) /usr/bin/nrc-user-link.sh
 %attr(-, -, nrcgroup) /usr/bin/nrc-group.sh


### PR DESCRIPTION
As seen in e.g. `ipa-client-common`.  We expect ghosts 👻 to not
exist.

Closes: https://github.com/projectatomic/rpm-ostree/issues/784
