### PR TITLE
Do rpm-md repo caching + Move rpm-md repo status display into core

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -367,30 +367,6 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
   if (!rpmostree_context_download_metadata (ctx, cancellable, error))
     goto out;
 
-  { GPtrArray *repos = dnf_context_get_repos (rpmostree_context_get_hif (ctx));
-    g_autoptr(GString) disabled = g_string_new ("");
-
-    g_print ("rpm-md repository versions:\n");
-    for (guint i = 0; i < repos->len; i++)
-      {
-        DnfRepo *repo = repos->pdata[i];
-        if (dnf_repo_get_enabled (repo) & DNF_REPO_ENABLED_PACKAGES)
-          {
-            g_autoptr(GDateTime) ts = g_date_time_new_from_unix_utc (dnf_repo_get_timestamp_generated (repo));
-            g_autofree char *formatted = g_date_time_format (ts, "%Y-%m-%d %T");
-            g_print ("  %s: packages=%u generated=%s\n",
-                     dnf_repo_get_id (repo),
-                     dnf_repo_get_n_solvables (repo),
-                     formatted);
-          }
-        else
-          {
-            g_string_append (disabled, dnf_repo_get_id (repo));
-            g_string_append_c (disabled, ' ');
-          }
-      }
-    g_print ("Disabled repositories: %s\n", disabled->str);
-  }
   if (!rpmostree_context_prepare_install (ctx, &hifinstall, cancellable, error))
     goto out;
 

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -312,9 +312,14 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
   /* By default, retain packages in addition to metadata with --cachedir */
   if (opt_cachedir)
     dnf_context_set_keep_cache (hifctx, TRUE);
-  if (opt_cache_only)
+  /* For compose, always try to refresh metadata; we're used in build servers
+   * where fetching should be cheap. Otherwise, if --cache-only is set, it's
+   * likely an offline developer laptop case, so never refresh.
+   */
+  if (!opt_cache_only)
+    dnf_context_set_cache_age (hifctx, 0);
+  else
     dnf_context_set_cache_age (hifctx, G_MAXUINT);
-
   g_key_file_set_string (treespec, "tree", "ref", self->ref);
   g_key_file_set_string_list (treespec, "tree", "packages", (const char *const*)packages, g_strv_length (packages));
 

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -915,8 +915,6 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
 {
   g_assert (!self->empty);
 
-  g_auto(RpmSighandlerResetCleanup) rpmsigreset = { 0, };
-
   g_autoptr(GPtrArray) rpmmd_repos = get_enabled_rpmmd_repos (self->hifctx, DNF_REPO_ENABLED_METADATA);
 
   g_print ("Enabled rpm-md repositories:");

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -365,10 +365,10 @@ rpmostree_context_new_system (GCancellable *cancellable,
   dnf_context_set_http_proxy (self->hifctx, g_getenv ("http_proxy"));
 
   dnf_context_set_repo_dir (self->hifctx, "/etc/yum.repos.d");
-  /* Operating on stale metadata is too annoying -- but provide a way to
-   * override this for testing. */
-  if (g_getenv("RPMOSTREE_USE_CACHED_METADATA") == NULL)
-      dnf_context_set_cache_age (self->hifctx, 0);
+  /* TODO: re cache_age https://github.com/rpm-software-management/libdnf/issues/291
+   * We override the one-week default since it's too slow for Fedora.
+   */
+  dnf_context_set_cache_age (self->hifctx, 60 * 60 * 24);
   dnf_context_set_cache_dir (self->hifctx, RPMOSTREE_CORE_CACHEDIR RPMOSTREE_DIR_CACHE_REPOMD);
   dnf_context_set_solv_dir (self->hifctx, RPMOSTREE_CORE_CACHEDIR RPMOSTREE_DIR_CACHE_SOLV);
   dnf_context_set_lock_dir (self->hifctx, "/run/rpm-ostree/" RPMOSTREE_DIR_LOCK);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -141,7 +141,7 @@ get_enabled_rpmmd_repos (DnfContext *dnfctx, DnfRepoEnabled enablement)
   for (guint i = 0; i < repos->len; i++)
     {
       DnfRepo *repo = repos->pdata[i];
-      if (dnf_repo_get_enabled (repo) >= enablement)
+      if (dnf_repo_get_enabled (repo) & enablement)
         g_ptr_array_add (ret, repo);
     }
   return g_steal_pointer (&ret);


### PR DESCRIPTION

Part of: #774

Basically, for `rpm-ostree status` to accurately help people
understand whether or not their system is up to date, we need
to be showing repository timestamps.

Ideally, we'd change the libdnf API to support what we're doing
here better.  But, this works for now.