### PR TITLE
core: turn off -Wunused-variable for sighandler

### DIFF
--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -11,7 +11,7 @@ build() {
 }
 
 build_default() {
-    export CFLAGS='-fsanitize=undefined'
+    export CFLAGS="${CFLAGS:-} -fsanitize=undefined"
     build
 }
 

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -354,7 +354,10 @@ rpmostree_context_new_system (GCancellable *cancellable,
 #endif
 
   self->hifctx = dnf_context_new ();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
   g_auto(RpmSighandlerResetCleanup) rpmsigreset = { 0, };
+#pragma GCC diagnostic pop
   dnf_context_set_http_proxy (self->hifctx, g_getenv ("http_proxy"));
 
   dnf_context_set_repo_dir (self->hifctx, "/etc/yum.repos.d");
@@ -897,7 +900,10 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
                                            G_CALLBACK (on_hifstate_percentage_changed),
                                            "Downloading metadata:");
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
   g_auto(RpmSighandlerResetCleanup) rpmsigreset = { 0, };
+#pragma GCC diagnostic pop
   if (!dnf_context_setup_sack (self->hifctx, hifstate, error))
     return FALSE;
 
@@ -2478,7 +2484,10 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
       }
   }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
   { g_auto(RpmSighandlerResetCleanup) rpmsigreset = { 0, };
+#pragma GCC diagnostic pop
     rpmtsOrder (ordering_ts);
   }
 


### PR DESCRIPTION
This is an unfortunate consequence of clang being too smart for its own
good. Though to be fair, we are playing a funny game here.