### PR TITLE
 lib/util: Add a DECLARE_RPMSIGHANDLER_RESET to pacify clang

### DIFF
--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -11,7 +11,7 @@ build() {
 }
 
 build_default() {
-    export CFLAGS='-fsanitize=undefined'
+    export CFLAGS="${CFLAGS:-} -fsanitize=undefined"
     build
 }
 

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -897,10 +897,7 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
                                            G_CALLBACK (on_hifstate_percentage_changed),
                                            "Downloading metadata:");
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-  g_auto(RpmSighandlerResetCleanup) rpmsigreset = { 0, };
-#pragma GCC diagnostic pop
+  DECLARE_RPMSIGHANDLER_RESET;
   if (!dnf_context_setup_sack (self->hifctx, hifstate, error))
     return FALSE;
 

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -354,7 +354,7 @@ rpmostree_context_new_system (GCancellable *cancellable,
 #endif
 
   self->hifctx = dnf_context_new ();
-  g_auto(RpmSighandlerResetCleanup) rpmsigreset = { 0, };
+  DECLARE_RPMSIGHANDLER_RESET;
   dnf_context_set_http_proxy (self->hifctx, g_getenv ("http_proxy"));
 
   dnf_context_set_repo_dir (self->hifctx, "/etc/yum.repos.d");
@@ -897,7 +897,10 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
                                            G_CALLBACK (on_hifstate_percentage_changed),
                                            "Downloading metadata:");
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
   g_auto(RpmSighandlerResetCleanup) rpmsigreset = { 0, };
+#pragma GCC diagnostic pop
   if (!dnf_context_setup_sack (self->hifctx, hifstate, error))
     return FALSE;
 
@@ -2478,7 +2481,7 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
       }
   }
 
-  { g_auto(RpmSighandlerResetCleanup) rpmsigreset = { 0, };
+  { DECLARE_RPMSIGHANDLER_RESET;
     rpmtsOrder (ordering_ts);
   }
 

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -980,7 +980,7 @@ rpmostree_print_transaction (DnfContext   *hifctx)
 }
 
 void
-_rpmostree_reset_rpm_sighandlers (void)
+rpmostree_sighandler_reset_cleanup (RpmSighandlerResetCleanup *cleanup)
 {
   /* Forcibly override rpm/librepo SIGINT handlers.  We always operate
    * in a fully idempotent/atomic mode, and can be killed at any time.

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -126,18 +126,16 @@ void
 rpmostree_print_transaction (DnfContext   *context);
 
 
-void _rpmostree_reset_rpm_sighandlers (void);
-
-/* This cleanup struct wraps _rpmostree_reset_rpm_sighandlers() */
+/* This cleanup struct wraps _rpmostree_reset_rpm_sighandlers(). We have a dummy
+ * variable to pacify clang's unused variable detection.
+ */
 typedef struct {
-  gpointer unused;
+  gboolean v;
 } RpmSighandlerResetCleanup;
-static inline void
-cleanup_rpmsighandler_reset(RpmSighandlerResetCleanup *cleanup)
-{
-  _rpmostree_reset_rpm_sighandlers ();
-}
-G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(RpmSighandlerResetCleanup, cleanup_rpmsighandler_reset);
+void rpmostree_sighandler_reset_cleanup (RpmSighandlerResetCleanup *cleanup);
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(RpmSighandlerResetCleanup, rpmostree_sighandler_reset_cleanup);
+
+#define DECLARE_RPMSIGHANDLER_RESET __attribute__((unused)) g_auto(RpmSighandlerResetCleanup) sigcleanup = { 0, };
 
 GVariant *
 rpmostree_fcap_to_xattr_variant (const char *fcap);

--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -188,8 +188,8 @@ rpmostree_unpacker_read_metainfo (int fd,
   gsize ret_cpio_offset;
   g_autofree char *abspath = g_strdup_printf ("/proc/self/fd/%d", fd);
 
+  DECLARE_RPMSIGHANDLER_RESET;
   ts = rpmtsCreate ();
-  _rpmostree_reset_rpm_sighandlers ();
   rpmtsSetVSFlags (ts, _RPMVSF_NOSIGNATURES);
 
   /* librpm needs Fopenfd */


### PR DESCRIPTION

We need to add an `__attribute((used))` to the autocleanup variable in order to
pacify its set-but-unused, so make a macro to simplify callers. This is a bit
like systemd's `PRESERVE_ERRNO` cleanup.