### PR TITLE
base override pkg removals

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -31,6 +31,7 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-builtin-cleanup.c \
 	src/app/rpmostree-builtin-initramfs.c \
 	src/app/rpmostree-builtin-livefs.c \
+	src/app/rpmostree-builtin-override.c \
 	src/app/rpmostree-pkg-builtins.c \
 	src/app/rpmostree-builtin-status.c \
 	src/app/rpmostree-builtin-ex.c \
@@ -44,6 +45,8 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-dbus-helpers.h \
 	src/app/rpmostree-container-builtins.h \
 	src/app/rpmostree-container-builtins.c \
+	src/app/rpmostree-override-builtins.h \
+	src/app/rpmostree-override-builtins.c \
 	src/app/rpmostree-ex-builtin-unpack.c \
 	src/app/rpmostree-libbuiltin.c \
 	src/app/rpmostree-libbuiltin.h \

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -25,6 +25,7 @@ CLEANFILES += \
 testpackages = \
 	tests/common/compose/yum/repo/packages/x86_64/empty-1.0-1.x86_64.rpm \
 	tests/common/compose/yum/repo/packages/x86_64/foo-1.0-1.x86_64.rpm \
+	tests/common/compose/yum/repo/packages/x86_64/foo-ext-1.0-1.x86_64.rpm \
 	tests/common/compose/yum/repo/packages/x86_64/bar-1.0-1.x86_64.rpm \
 	tests/common/compose/yum/repo/packages/x86_64/scriptpkg1-1.0-1.x86_64.rpm \
 	tests/common/compose/yum/repo/packages/x86_64/nonrootcap-1.0-1.x86_64.rpm \

--- a/src/app/rpmostree-builtin-deploy.c
+++ b/src/app/rpmostree-builtin-deploy.c
@@ -118,7 +118,8 @@ rpmostree_builtin_deploy (int            argc,
                                        TRUE,   /* allow-downgrade */
                                        FALSE,  /* skip-purge */
                                        FALSE,  /* no-pull-base */
-                                       FALSE); /* dry-run */
+                                       FALSE,  /* dry-run */
+                                       FALSE); /* no-overrides */
 
       /* This will set the GVariant if the default deployment changes. */
       g_signal_connect (os_proxy, "notify::default-deployment",
@@ -133,6 +134,9 @@ rpmostree_builtin_deploy (int            argc,
                                             revision,
                                             install_pkgs,
                                             uninstall_pkgs,
+                                            NULL, /* override replace */
+                                            NULL, /* override remove */
+                                            NULL, /* override reset */
                                             options,
                                             &transaction_address,
                                             cancellable,

--- a/src/app/rpmostree-builtin-override.c
+++ b/src/app/rpmostree-builtin-override.c
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
  *
- * Copyright (C) 2015 Colin Walters <walters@verbum.org>
+ * Copyright (C) 2017 Red Hat Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -21,31 +21,28 @@
 #include "config.h"
 
 #include "rpmostree-ex-builtins.h"
+#include "rpmostree-override-builtins.h"
 
-static RpmOstreeCommand ex_subcommands[] = {
-  { "livefs", RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
-    rpmostree_ex_builtin_livefs },
-  { "override", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    rpmostree_ex_builtin_override },
-  { "unpack", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    rpmostree_ex_builtin_unpack },
-  { "container", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    rpmostree_builtin_container },
+static RpmOstreeCommand override_subcommands[] = {
+  { "replace", RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT |
+               RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS |
+               RPM_OSTREE_BUILTIN_FLAG_HIDDEN, /* XXX UNDER CONSTRUCTION XXX */
+    rpmostree_override_builtin_replace },
+  { "remove", RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT |
+              RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+    rpmostree_override_builtin_remove },
+  { "reset", RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT |
+             RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+    rpmostree_override_builtin_reset },
   { NULL, 0, NULL }
 };
 
-/*
-static GOptionEntry global_entries[] = {
-  { NULL }
-};
-*/
-
 int
-rpmostree_builtin_ex (int argc, char **argv,
-                      RpmOstreeCommandInvocation *invocation,
-                      GCancellable *cancellable, GError **error)
+rpmostree_ex_builtin_override (int argc, char **argv,
+                               RpmOstreeCommandInvocation *invocation,
+                               GCancellable *cancellable, GError **error)
 {
-  return rpmostree_handle_subcommand (argc, argv, ex_subcommands,
+  return rpmostree_handle_subcommand (argc, argv, override_subcommands,
                                       invocation, cancellable, error);
 }
 

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -94,7 +94,8 @@ rpmostree_builtin_rebase (int             argc,
                                    TRUE,   /* allow-downgrade */
                                    opt_skip_purge,
                                    FALSE,  /* no-pull-base */
-                                   FALSE); /* dry-run */
+                                   FALSE,  /* dry-run */
+                                   FALSE); /* no-overrides */
 
   /* Use newer D-Bus API only if we have to. */
   if (install_pkgs || uninstall_pkgs)
@@ -104,6 +105,9 @@ rpmostree_builtin_rebase (int             argc,
                                         revision,
                                         install_pkgs,
                                         uninstall_pkgs,
+                                        NULL, /* override replace */
+                                        NULL, /* override remove */
+                                        NULL, /* override reset */
                                         options,
                                         &transaction_address,
                                         cancellable,

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -213,6 +213,7 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
       g_autofree const gchar **origin_packages = NULL;
       g_autofree const gchar **origin_requested_packages = NULL;
       g_autofree const gchar **origin_requested_local_packages = NULL;
+      g_autofree const gchar **origin_removed_base_packages = NULL;
       const gchar *origin_refspec;
       const gchar *id;
       const gchar *os_name;
@@ -228,7 +229,8 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
       gboolean is_booted;
       const gboolean was_first = first;
       /* Add the long keys here */
-      const guint max_key_len = MAX (strlen ("PendingBaseVersion"), strlen ("InterruptedLiveCommit"));
+      const guint max_key_len = MAX (strlen ("RemovedBasePackages"),
+                                     strlen ("InterruptedLiveCommit"));
       g_autoptr(GVariant) signatures = NULL;
       g_autofree char *timestamp_string = NULL;
 
@@ -251,6 +253,8 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
             lookup_array_and_canonicalize (dict, "requested-packages");
           origin_requested_local_packages =
             lookup_array_and_canonicalize (dict, "requested-local-packages");
+          origin_removed_base_packages =
+            lookup_array_and_canonicalize (dict, "removed-base-packages");
         }
       else
         origin_refspec = NULL;
@@ -410,6 +414,11 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
               print_kv ("GPGSignature", max_key_len, "(unsigned)");
             }
         }
+
+      /* print base overrides before overlays */
+      if (origin_removed_base_packages)
+        print_packages ("RemovedBasePackages", max_key_len,
+                        origin_removed_base_packages, NULL);
 
       /* let's be nice and only print requested - layered, rather than repeating
        * the ones in layered twice */

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -125,7 +125,8 @@ rpmostree_builtin_upgrade (int             argc,
                                        opt_allow_downgrade,
                                        FALSE,  /* skip-purge */
                                        FALSE,  /* no-pull-base */
-                                       FALSE); /* dry-run */
+                                       FALSE,  /* dry-run */
+                                       FALSE); /* no-overrides */
 
       /* Use newer D-Bus API only if we have to. */
       if (install_pkgs || uninstall_pkgs)
@@ -135,6 +136,9 @@ rpmostree_builtin_upgrade (int             argc,
                                             NULL, /* revision */
                                             install_pkgs,
                                             uninstall_pkgs,
+                                            NULL, /* override replace */
+                                            NULL, /* override remove */
+                                            NULL, /* override reset */
                                             options,
                                             &transaction_address,
                                             cancellable,

--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -846,11 +846,11 @@ get_modifiers_variant (const char   *set_refspec,
   if (set_revision)
     g_variant_dict_insert (&dict, "set-revision", "s", set_revision);
 
+  vardict_insert_strv (&dict, "uninstall-packages", uninstall_pkgs);
+
   /* NB: when we implement this, we'll have to pass it through sort_pkgs_strv to
    * split out local pkgs */
   vardict_insert_strv (&dict, "override-replace-packages", override_replace_pkgs);
-
-  vardict_insert_strv (&dict, "uninstall-packages", uninstall_pkgs);
   vardict_insert_strv (&dict, "override-remove-packages", override_remove_pkgs);
   vardict_insert_strv (&dict, "override-reset-packages", override_reset_pkgs);
 

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -87,7 +87,8 @@ rpmostree_get_options_variant (gboolean reboot,
                                gboolean allow_downgrade,
                                gboolean skip_purge,
                                gboolean no_pull_base,
-                               gboolean dry_run);
+                               gboolean dry_run,
+                               gboolean no_overrides);
 
 gboolean
 rpmostree_update_deployment (RPMOSTreeOS  *os_proxy,
@@ -95,6 +96,9 @@ rpmostree_update_deployment (RPMOSTreeOS  *os_proxy,
                              const char   *set_revision,
                              const char *const* install_pkgs,
                              const char *const* uninstall_pkgs,
+                             const char *const* override_replace_pkgs,
+                             const char *const* override_remove_pkgs,
+                             const char *const* override_reset_pkgs,
                              GVariant     *options,
                              char        **out_transaction_address,
                              GCancellable *cancellable,

--- a/src/app/rpmostree-override-builtins.c
+++ b/src/app/rpmostree-override-builtins.c
@@ -1,0 +1,239 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include "rpmostree-override-builtins.h"
+#include "rpmostree-libbuiltin.h"
+
+#include <libglnx.h>
+
+static char *opt_osname;
+static gboolean opt_reboot;
+static gboolean opt_dry_run;
+static gboolean opt_reset_all;
+static const char *const *install_pkgs;
+static const char *const *uninstall_pkgs;
+
+static GOptionEntry option_entries[] = {
+  { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
+  { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after upgrade is prepared", NULL },
+  { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction", NULL },
+  { NULL }
+};
+
+static GOptionEntry reset_option_entries[] = {
+  { "all", 'a', 0, G_OPTION_ARG_NONE, &opt_reset_all, "Reset all active overrides", NULL },
+  { NULL }
+};
+
+static gboolean
+handle_override (RPMOSTreeSysroot  *sysroot_proxy,
+                 const char *const *override_remove,
+                 const char *const *override_replace,
+                 const char *const *override_reset,
+                 GCancellable      *cancellable,
+                 GError           **error)
+{
+  glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
+  if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
+                                cancellable, &os_proxy, error))
+    return EXIT_FAILURE;
+
+  g_autoptr(GVariant) options =
+    rpmostree_get_options_variant (opt_reboot,
+                                   FALSE,   /* allow-downgrade */
+                                   FALSE,   /* skip-purge */
+                                   TRUE,    /* no-pull-base */
+                                   opt_dry_run,
+                                   opt_reset_all);
+
+  g_autofree char *transaction_address = NULL;
+  if (!rpmostree_update_deployment (os_proxy,
+                                    NULL, /* set-refspec */
+                                    NULL, /* set-revision */
+                                    install_pkgs,
+                                    uninstall_pkgs,
+                                    override_replace,
+                                    override_remove,
+                                    override_reset,
+                                    options,
+                                    &transaction_address,
+                                    cancellable,
+                                    error))
+    return EXIT_FAILURE;
+
+  if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
+                                                transaction_address,
+                                                cancellable,
+                                                error))
+    return EXIT_FAILURE;
+
+  if (opt_dry_run)
+    {
+      g_print ("Exiting because of '--dry-run' option\n");
+    }
+  else if (!opt_reboot)
+    {
+      const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
+      if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
+                                                           cancellable,
+                                                           error))
+        return EXIT_FAILURE;
+
+      g_print ("Run \"systemctl reboot\" to start a reboot\n");
+    }
+
+  return EXIT_SUCCESS;
+}
+
+gboolean
+rpmostree_override_builtin_replace (int argc, char **argv,
+                                    RpmOstreeCommandInvocation *invocation,
+                                    GCancellable *cancellable,
+                                    GError **error)
+{
+  GOptionContext *context;
+  glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
+  _cleanup_peer_ GPid peer_pid = 0;
+
+  context = g_option_context_new ("PACKAGE [PACKAGE...] - "
+                                  "Remove packages from the base layer");
+
+  if (!rpmostree_option_context_parse (context,
+                                       option_entries,
+                                       &argc, &argv,
+                                       invocation,
+                                       cancellable,
+                                       &install_pkgs,
+                                       &uninstall_pkgs,
+                                       &sysroot_proxy,
+                                       &peer_pid,
+                                       error))
+    return EXIT_FAILURE;
+
+  if (argc < 2)
+    {
+      rpmostree_usage_error (context, "At least one PACKAGE must be specified",
+                             error);
+      return EXIT_FAILURE;
+    }
+
+  /* shift to first pkgspec and ensure it's a proper strv (previous parsing
+   * might have moved args around) */
+  argv++; argc--;
+  argv[argc] = NULL;
+
+  return handle_override (sysroot_proxy,
+                          NULL, (const char *const*)argv, NULL,
+                          cancellable, error);
+}
+
+gboolean
+rpmostree_override_builtin_remove (int argc, char **argv,
+                                   RpmOstreeCommandInvocation *invocation,
+                                   GCancellable *cancellable,
+                                   GError **error)
+{
+  GOptionContext *context;
+  glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
+  _cleanup_peer_ GPid peer_pid = 0;
+
+  context = g_option_context_new ("PACKAGE [PACKAGE...] - "
+                                  "Remove packages from the base layer");
+
+  if (!rpmostree_option_context_parse (context,
+                                       option_entries,
+                                       &argc, &argv,
+                                       invocation,
+                                       cancellable,
+                                       &install_pkgs,
+                                       &uninstall_pkgs,
+                                       &sysroot_proxy,
+                                       &peer_pid,
+                                       error))
+    return EXIT_FAILURE;
+
+  if (argc < 2)
+    {
+      rpmostree_usage_error (context, "At least one PACKAGE must be specified",
+                             error);
+      return EXIT_FAILURE;
+    }
+
+  /* shift to first pkgspec and ensure it's a proper strv (previous parsing
+   * might have moved args around) */
+  argv++; argc--;
+  argv[argc] = NULL;
+
+  return handle_override (sysroot_proxy,
+                          (const char *const*)argv, NULL, NULL,
+                          cancellable, error);
+}
+
+gboolean
+rpmostree_override_builtin_reset (int argc, char **argv,
+                                  RpmOstreeCommandInvocation *invocation,
+                                  GCancellable *cancellable,
+                                  GError **error)
+{
+  GOptionContext *context;
+  glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
+  _cleanup_peer_ GPid peer_pid = 0;
+
+  context = g_option_context_new ("PACKAGE [PACKAGE...] - "
+                                  "Reset currently active package overrides");
+
+  g_option_context_add_main_entries (context, reset_option_entries, NULL);
+
+  if (!rpmostree_option_context_parse (context,
+                                       option_entries,
+                                       &argc, &argv,
+                                       invocation,
+                                       cancellable,
+                                       &install_pkgs,
+                                       &uninstall_pkgs,
+                                       &sysroot_proxy,
+                                       &peer_pid,
+                                       error))
+    return EXIT_FAILURE;
+
+  if (argc < 2 && !opt_reset_all)
+    {
+      rpmostree_usage_error (context, "At least one PACKAGE must be specified",
+                             error);
+      return EXIT_FAILURE;
+    }
+  else if (opt_reset_all && argc >= 2)
+    {
+      rpmostree_usage_error (context, "Cannot specify PACKAGEs with --all",
+                             error);
+      return EXIT_FAILURE;
+    }
+
+  /* shift to first pkgspec and ensure it's a proper strv (previous parsing
+   * might have moved args around) */
+  argv++; argc--;
+  argv[argc] = NULL;
+
+  return handle_override (sysroot_proxy,
+                          NULL, NULL, (const char *const*)argv,
+                          cancellable, error);
+}

--- a/src/app/rpmostree-override-builtins.h
+++ b/src/app/rpmostree-override-builtins.h
@@ -1,6 +1,6 @@
 /* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
  *
- * Copyright (C) 2015 Colin Walters <walters@verbum.org>
+ * Copyright (C) 2017 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -26,15 +26,21 @@
 
 G_BEGIN_DECLS
 
-#define BUILTINPROTO(name) gboolean rpmostree_ex_builtin_ ## name (int argc, char **argv, \
-                                                                   RpmOstreeCommandInvocation *invocation, \
-                                                                   GCancellable *cancellable, GError **error)
-
-BUILTINPROTO(unpack);
-BUILTINPROTO(livefs);
-BUILTINPROTO(override);
-
-#undef BUILTINPROTO
+gboolean
+rpmostree_override_builtin_replace (int argc, char **argv,
+                                    RpmOstreeCommandInvocation *invocation,
+                                    GCancellable *cancellable,
+                                    GError **error);
+gboolean
+rpmostree_override_builtin_remove (int argc, char **argv,
+                                   RpmOstreeCommandInvocation *invocation,
+                                   GCancellable *cancellable,
+                                   GError **error);
+gboolean
+rpmostree_override_builtin_reset (int argc, char **argv,
+                                  RpmOstreeCommandInvocation *invocation,
+                                  GCancellable *cancellable,
+                                  GError **error);
 
 G_END_DECLS
 

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -76,7 +76,8 @@ pkg_change (RPMOSTreeSysroot *sysroot_proxy,
                                    FALSE,   /* allow-downgrade */
                                    FALSE,   /* skip-purge */
                                    TRUE,    /* no-pull-base */
-                                   opt_dry_run);
+                                   opt_dry_run,
+                                   FALSE);  /* no-overrides */
 
   gboolean met_local_pkg = FALSE;
   for (const char *const* it = packages_to_add; it && *it; it++)
@@ -91,6 +92,9 @@ pkg_change (RPMOSTreeSysroot *sysroot_proxy,
                                         NULL, /* revision */
                                         packages_to_add,
                                         packages_to_remove,
+                                        NULL, /* override replace */
+                                        NULL, /* override remove */
+                                        NULL, /* override reset */
                                         options,
                                         &transaction_address,
                                         cancellable,

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -231,6 +231,10 @@
          "install-packages" (type 'as')
          "uninstall-packages" (type 'as')
          "install-local-packages" (type 'ah')
+         "override-remove-packages" (type 'as')
+         "override-reset-packages" (type 'as')
+         "override-replace-packages" (type 'as')
+         "override-replace-local-packages" (type 'ah')
 
          Available options:
          "reboot" (type 'b')
@@ -248,6 +252,9 @@
          "dry-run" (type 'b')
             Stop short of deploying the new tree. If
             layering packages, the pkg diff is printed.
+         "no-overrides" (type 'b')
+            Remove all active overrides. Not valid if any override
+            modifiers are specified.
     -->
     <method name="UpdateDeployment">
       <arg type="a{sv}" name="modifiers" direction="in"/>

--- a/src/daemon/rpmostree-sysroot-core.c
+++ b/src/daemon/rpmostree-sysroot-core.c
@@ -96,7 +96,7 @@ generate_baselayer_refs (OstreeSysroot            *sysroot,
         g_autofree char *base_rev = NULL;
 
         if (!rpmostree_deployment_get_layered_info (repo, deployment, NULL,
-                                                    &base_rev, NULL, error))
+                                                    &base_rev, NULL, NULL, error))
           goto out;
 
         if (base_rev)
@@ -192,7 +192,7 @@ clean_pkgcache_orphans (OstreeSysroot            *sysroot,
       gboolean is_layered;
 
       if (!rpmostree_deployment_get_layered_info (repo, deployment, &is_layered,
-                                                  NULL, NULL, error))
+                                                  NULL, NULL, NULL, error))
         return FALSE;
 
       if (is_layered)

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -653,7 +653,8 @@ finalize_packages_to_overlay (RpmOstreeSysrootUpgrader *self,
   while (g_hash_table_iter_next (&it, &itkey, NULL))
     {
       const char *pattern = itkey;
-      GPtrArray *matches = rpmostree_get_matching_packages (self->rsack->sack, pattern);
+      g_autoptr(GPtrArray) matches =
+        rpmostree_get_matching_packages (self->rsack->sack, pattern);
 
       if (matches->len == 0)
         {

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -67,6 +67,7 @@ struct RpmOstreeSysrootUpgrader {
   /* Used during tree construction */
   OstreeRepoDevInoCache *devino_cache;
   int tmprootfs_dfd;
+  RpmOstreeRefSack *rsack;
 
   GPtrArray *overlay_packages; /* Finalized list of pkgs to overlay */
 
@@ -164,7 +165,7 @@ rpmostree_sysroot_upgrader_initable_init (GInitable        *initable,
   if (!rpmostree_deployment_get_layered_info (self->repo,
                                               self->origin_merge_deployment,
                                               &is_layered, &self->base_revision,
-                                              NULL, error))
+                                              NULL, NULL, error))
     return FALSE;
 
   if (is_layered)
@@ -187,6 +188,8 @@ static void
 rpmostree_sysroot_upgrader_finalize (GObject *object)
 {
   RpmOstreeSysrootUpgrader *self = RPMOSTREE_SYSROOT_UPGRADER (object);
+
+  g_clear_pointer (&self->rsack, rpmostree_refsack_unref);
 
   if (self->tmprootfs_dfd != -1)
     (void)close (self->tmprootfs_dfd);
@@ -337,6 +340,12 @@ rpmostree_sysroot_upgrader_set_origin (RpmOstreeSysrootUpgrader *self,
   self->origin = rpmostree_origin_dup (new_origin);
 }
 
+const char *
+rpmostree_sysroot_upgrader_get_base (RpmOstreeSysrootUpgrader *self)
+{
+  return self->base_revision;
+}
+
 OstreeDeployment*
 rpmostree_sysroot_upgrader_get_merge_deployment (RpmOstreeSysrootUpgrader *self)
 {
@@ -461,6 +470,12 @@ checkout_base_tree (RpmOstreeSysrootUpgrader *self,
                        &self->tmprootfs_dfd, error))
     return FALSE;
 
+  /* build a centralized rsack for it, since we need it in a few places */
+  self->rsack = rpmostree_get_refsack_for_root (self->tmprootfs_dfd, ".",
+                                                cancellable, error);
+  if (self->rsack == NULL)
+    return FALSE;
+
   rpmostree_output_task_end ("done");
 
   return TRUE;
@@ -501,7 +516,62 @@ generate_treespec (RpmOstreeSysrootUpgrader *self)
                                   sha256_nevra->len);
     }
 
+  GHashTable *overrides_remove =
+    rpmostree_origin_get_overrides_remove (self->origin);
+  if (g_hash_table_size (overrides_remove) > 0)
+    {
+      g_autofree char **pkgv =
+        (char**) g_hash_table_get_keys_as_array (overrides_remove, NULL);
+      g_key_file_set_string_list (treespec, "tree",
+                                  "removed-base-packages",
+                                  (const char* const*)pkgv,
+                                  g_strv_length (pkgv));
+    }
+
   return rpmostree_treespec_new_from_keyfile (treespec, NULL);
+}
+
+static gboolean
+finalize_overrides (RpmOstreeSysrootUpgrader *self,
+                    GCancellable             *cancellable,
+                    GError                  **error)
+{
+  /* Removal overrides have the magical property that they drop out if the base layer no
+   * longer has them. This keeps the origin consistent. New removal overrides are checked in
+   * deploy_transaction_execute() to ensure they're valid; i.e. the pkgs exist. */
+
+  GHashTable *removals = rpmostree_origin_get_overrides_remove (self->origin);
+
+  if (g_hash_table_size (removals) == 0)
+    return TRUE;
+
+  /* NB: strings are owned by hash table */
+  g_autoptr(GPtrArray) removals_to_remove = g_ptr_array_new ();
+
+  GHashTableIter it;
+  gpointer itkey;
+  g_hash_table_iter_init (&it, removals);
+  while (g_hash_table_iter_next (&it, &itkey, NULL))
+    {
+      /* only match pkgname */
+      const char *pkgname = itkey;
+      hy_autoquery HyQuery query = hy_query_create (self->rsack->sack);
+      hy_query_filter (query, HY_PKG_NAME, HY_EQ, pkgname);
+      g_autoptr(GPtrArray) pkgs = hy_query_run (query);
+
+      if (pkgs->len == 0)
+        g_ptr_array_add (removals_to_remove, (gpointer)pkgname);
+    }
+
+  if (removals_to_remove->len > 0)
+    {
+      g_ptr_array_add (removals_to_remove, NULL);
+      if (!rpmostree_origin_remove_overrides (self->origin,
+                                              (char**)removals_to_remove->pdata, error))
+        return FALSE;
+    }
+
+  return TRUE;
 }
 
 /* Go through rpmdb and jot down the missing pkgs from the given set. Really, we
@@ -525,12 +595,6 @@ finalize_packages_to_overlay (RpmOstreeSysrootUpgrader *self,
 
   GHashTableIter it;
   gpointer itkey, itval;
-
-  g_autoptr(RpmOstreeRefSack) rsack =
-    rpmostree_get_refsack_for_root (self->tmprootfs_dfd, ".",
-                                    cancellable, error);
-  if (rsack == NULL)
-    goto out;
 
   /* Add the local pkgs as if they were installed: since they're unconditionally
    * layered, we treat them as part of the base wrt regular requested pkgs. E.g.
@@ -571,23 +635,52 @@ finalize_packages_to_overlay (RpmOstreeSysrootUpgrader *self,
           /* Also check if that exact NEVRA is already in the root (if the pkg
            * exists, but is a different EVR, depsolve will catch that). In the
            * future, we'll allow packages to replace base pkgs. */
-          if (rpmostree_sack_has_subject (rsack->sack, nevra))
+          if (rpmostree_sack_has_subject (self->rsack->sack, nevra))
             {
               g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                            "Package '%s' is already in the base", nevra);
               goto out;
             }
 
-          dnf_sack_add_cmdline_package (rsack->sack, path);
+          dnf_sack_add_cmdline_package (self->rsack->sack, path);
         }
     }
+
+  GHashTable *removals = rpmostree_origin_get_overrides_remove (self->origin);
 
   /* check for each package if we have a provides or a path match */
   g_hash_table_iter_init (&it, rpmostree_origin_get_packages (self->origin));
   while (g_hash_table_iter_next (&it, &itkey, NULL))
     {
-      if (!rpmostree_sack_has_subject (rsack->sack, itkey))
-        g_ptr_array_add (ret_missing_pkgs, g_strdup (itkey));
+      const char *pattern = itkey;
+      GPtrArray *matches = rpmostree_get_matching_packages (self->rsack->sack, pattern);
+
+      if (matches->len == 0)
+        {
+          /* no matches, so we'll need to layer it */
+          g_ptr_array_add (ret_missing_pkgs, g_strdup (itkey));
+          continue;
+        }
+
+      /* Error out if it matches a base package that was also requested to be removed.
+       * Conceptually, we want users to use override replacements, not remove+overlay. */
+      for (guint i = 0; i < matches->len; i++)
+        {
+          DnfPackage *pkg = matches->pdata[i];
+          const char *name = dnf_package_get_name (pkg);
+          const char *repo = dnf_package_get_reponame (pkg);
+
+          if (g_strcmp0 (repo, HY_CMDLINE_REPO_NAME) == 0)
+            continue; /* local RPM added up above */
+
+          if (g_hash_table_contains (removals, name))
+            {
+              glnx_throw (error, "Cannot request '%s' provided by removed package '%s'",
+                          pattern, dnf_package_get_nevra (pkg));
+            }
+        }
+
+      /* otherwise, it's a dormant package */
     }
 
   self->overlay_packages = g_steal_pointer (&ret_missing_pkgs);
@@ -665,15 +758,18 @@ do_local_assembly (RpmOstreeSysrootUpgrader *self,
                                 treespec, cancellable, error))
     return FALSE;
 
-  glnx_unref_object OstreeRepo *pkgcache_repo = NULL;
+  g_autoptr(OstreeRepo) pkgcache_repo = NULL;
   if (!rpmostree_get_pkgcache_repo (self->repo, &pkgcache_repo,
                                     cancellable, error))
     return FALSE;
 
   rpmostree_context_set_repos (ctx, self->repo, pkgcache_repo);
 
+  GHashTable *overrides_remove =
+    rpmostree_origin_get_overrides_remove (self->origin);
   const gboolean have_packages = (self->overlay_packages->len > 0 ||
-                                  g_hash_table_size (local_pkgs) > 0);
+                                  g_hash_table_size (local_pkgs) > 0 ||
+                                  g_hash_table_size (overrides_remove) > 0);
 
   if (have_packages)
     {
@@ -699,10 +795,11 @@ do_local_assembly (RpmOstreeSysrootUpgrader *self,
       if (!rpmostree_context_relabel (ctx, cancellable, error))
         return FALSE;
 
-      /* --- Overlay and commit --- */
       g_clear_pointer (&self->final_revision, g_free);
       gboolean noscripts =
         (self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_NOSCRIPTS) > 0;
+
+      /* --- override/overlay and commit --- */
       if (!rpmostree_context_assemble_tmprootfs (ctx, self->tmprootfs_dfd,
                                                  self->devino_cache, noscripts,
                                                  cancellable, error))
@@ -761,6 +858,8 @@ static gboolean
 requires_local_assembly (RpmOstreeSysrootUpgrader *self)
 {
   GHashTable *local_pkgs = rpmostree_origin_get_local_packages (self->origin);
+  GHashTable *overrides_remove =
+    rpmostree_origin_get_overrides_remove (self->origin);
 
   /* Now, it's possible all requested packages are in the new tree, so we have
    * another optimization here for that case. This is a bit tricky: assuming we
@@ -772,6 +871,7 @@ requires_local_assembly (RpmOstreeSysrootUpgrader *self)
    */
 
   return g_hash_table_size (local_pkgs) > 0 ||
+         g_hash_table_size (overrides_remove) > 0 ||
          self->overlay_packages->len > 0 ||
          rpmostree_origin_get_regenerate_initramfs (self->origin);
 }
@@ -783,6 +883,9 @@ maybe_do_local_assembly (RpmOstreeSysrootUpgrader *self,
                          GError                  **error)
 {
   if (!checkout_base_tree (self, cancellable, error))
+    return FALSE;
+
+  if (!finalize_overrides (self, cancellable, error))
     return FALSE;
 
   if (!finalize_packages_to_overlay (self, cancellable, error))

--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -72,6 +72,9 @@ void
 rpmostree_sysroot_upgrader_set_origin (RpmOstreeSysrootUpgrader *self,
                                        RpmOstreeOrigin *origin);
 
+const char *
+rpmostree_sysroot_upgrader_get_base (RpmOstreeSysrootUpgrader *self);
+
 gboolean
 rpmostree_sysroot_upgrader_pull (RpmOstreeSysrootUpgrader  *self,
                                  const char             *dir_to_pull,

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -588,7 +588,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
   g_autoptr(GString) txn_title = g_string_new ("");
   if (is_install)
     g_string_append (txn_title, "install");
-  if (is_override)
+  else if (is_override)
     g_string_append (txn_title, "override");
   else if (self->refspec)
     g_string_append (txn_title, "rebase");

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -53,22 +53,25 @@ typedef enum {
   RPMOSTREE_TRANSACTION_DEPLOY_FLAG_ALLOW_DOWNGRADE = (1 << 2),
   RPMOSTREE_TRANSACTION_DEPLOY_FLAG_NO_PULL_BASE = (1 << 4),
   RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DRY_RUN = (1 << 5),
-  RPMOSTREE_TRANSACTION_DEPLOY_FLAG_NOSCRIPTS = (1 << 6)
+  RPMOSTREE_TRANSACTION_DEPLOY_FLAG_NOSCRIPTS = (1 << 6),
+  RPMOSTREE_TRANSACTION_DEPLOY_FLAG_NO_OVERRIDES = (1 << 7)
 } RpmOstreeTransactionDeployFlags;
 
 
 RpmostreedTransaction *
-               rpmostreed_transaction_new_deploy           (GDBusMethodInvocation *invocation,
-                                                            OstreeSysroot *sysroot,
-                                                            RpmOstreeTransactionDeployFlags flags,
-                                                            const char *osname,
-                                                            const char *refspec,
-                                                            const char *revision,
-                                                            const char *const *packages_added,
-                                                            const char *const *packages_removed,
-                                                            GUnixFDList *local_packages_added,
-                                                            GCancellable *cancellable,
-                                                            GError **error);
+rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
+                                   OstreeSysroot *sysroot,
+                                   RpmOstreeTransactionDeployFlags flags,
+                                   const char *osname,
+                                   const char *refspec,
+                                   const char *revision,
+                                   const char *const *packages_added,
+                                   const char *const *packages_removed,
+                                   GUnixFDList *local_packages_added,
+                                   const char *const *override_remove_packages,
+                                   const char *const *override_reset_packages,
+                                   GCancellable *cancellable,
+                                   GError **error);
 
 RpmostreedTransaction *
 rpmostreed_transaction_new_initramfs_state       (GDBusMethodInvocation *invocation,

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1755,12 +1755,12 @@ get_rpmdb_pkg_header (rpmts rpmdb_ts,
   g_auto(rpmdbMatchIterator) it =
     rpmtsInitIterator (rpmdb_ts, RPMDBI_PACKAGES, &dbid, sizeof(dbid));
 
-  g_auto(Header) hdr = it ? rpmdbNextIterator (it) : NULL;
+  Header hdr = it ? rpmdbNextIterator (it) : NULL;
   if (hdr == NULL)
     return glnx_null_throw (error, "Failed to find package '%s' in rpmdb",
                             dnf_package_get_nevra (pkg));
 
-  return headerLink (g_steal_pointer (&hdr));
+  return headerLink (hdr);
 }
 
 static gboolean
@@ -2622,7 +2622,15 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
     rpmtsOrder (ordering_ts);
   }
 
-  rpmostree_output_task_begin ("Applying overrides and overlays");
+  if (overrides_remove->len > 0 && overlays->len > 0)
+    rpmostree_output_task_begin ("Applying %u overrides and %u overlays",
+                                 overrides_remove->len, overlays->len);
+  else if (overrides_remove->len > 0)
+    rpmostree_output_task_begin ("Applying %u overrides", overrides_remove->len);
+  else if (overlays->len > 0)
+    rpmostree_output_task_begin ("Applying %u overlays", overlays->len);
+  else
+    g_assert_not_reached ();
 
   guint n_rpmts_elements = (guint)rpmtsNElements (ordering_ts);
   g_assert (n_rpmts_elements > 0);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -126,10 +126,11 @@ add_canonicalized_string_array (GVariantBuilder *builder,
     }
 
   sorted = (char**)g_hash_table_get_keys_as_array (set, &count);
-  g_qsort_with_data (sorted, count, sizeof (void*), qsort_cmpstr, NULL);
+  if (count > 1)
+    g_qsort_with_data (sorted, count, sizeof (void*), qsort_cmpstr, NULL);
 
   g_variant_builder_add (builder, "{sv}", key,
-                         g_variant_new_strv ((const char*const*)sorted, g_strv_length (sorted)));
+                         g_variant_new_strv ((const char*const*)sorted, count));
 }
 
 static GPtrArray *
@@ -165,6 +166,8 @@ rpmostree_treespec_new_from_keyfile (GKeyFile   *keyfile,
 
   add_canonicalized_string_array (&builder, "packages", NULL, keyfile);
   add_canonicalized_string_array (&builder, "cached-packages", NULL, keyfile);
+  add_canonicalized_string_array (&builder, "removed-base-packages",
+                                  NULL, keyfile);
 
   /* We allow the "repo" key to be missing. This means that we rely on hif's
    * normal behaviour (i.e. look at repos in repodir with enabled=1). */
@@ -1246,26 +1249,38 @@ join_package_list (const char *prefix, char **pkgs, int len)
 
 static gboolean
 check_goal_solution (HyGoal    goal,
+                     const char *const *allowed_base_removals,
                      GError  **error)
 {
   g_autoptr(GPtrArray) packages = NULL;
 
-  /* Now we need to make sure that none of the pkgs in the base are marked for
-   * removal. The issue is that marking a package for DNF_INSTALL could
-   * uninstall a base pkg if it's an update or obsoletes it. There doesn't seem
-   * to be a way to tell libsolv to never touch pkgs in the base layer, so we
-   * just inspect its solution in retrospect. libdnf has the concept of
+  /* Now we need to make sure that only the pkgs in the base allowed to be
+   * removed are removed. The issue is that marking a package for DNF_INSTALL
+   * could uninstall a base pkg if it's an update or obsoletes it. There doesn't
+   * seem to be a way to tell libsolv to not touch some pkgs in the base layer,
+   * so we just inspect its solution in retrospect. libdnf has the concept of
    * protected packages, but it still allows updating protected packages. */
 
   packages = dnf_goal_get_packages (goal,
                                     DNF_PACKAGE_INFO_REMOVE,
                                     DNF_PACKAGE_INFO_OBSOLETE,
                                     -1);
-  if (packages->len > 0)
+
+  g_autoptr(GPtrArray) filtered_packages = g_ptr_array_new ();
+  for (guint i = 0; i < packages->len; i++)
+    {
+      DnfPackage *pkg = packages->pdata[i];
+      if (g_strv_contains (allowed_base_removals, dnf_package_get_name (pkg)))
+        continue;
+
+      g_ptr_array_add (filtered_packages, pkg);
+    }
+
+  if (filtered_packages->len > 0)
     {
       g_autofree char *msg = join_package_list (
           "The following base packages would be removed: ",
-          (char**)packages->pdata, packages->len);
+          (char**)filtered_packages->pdata, filtered_packages->len);
       g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, msg);
       return FALSE;
     }
@@ -1310,7 +1325,6 @@ rpmostree_context_prepare (RpmOstreeContext *self,
   g_assert (!self->empty);
 
   DnfContext *hifctx = self->hifctx;
-
   g_autofree char **pkgnames = NULL;
   g_assert (g_variant_dict_lookup (self->spec->dict, "packages",
                                    "^a&s", &pkgnames));
@@ -1318,6 +1332,10 @@ rpmostree_context_prepare (RpmOstreeContext *self,
   g_autofree char **cached_pkgnames = NULL;
   g_assert (g_variant_dict_lookup (self->spec->dict, "cached-packages",
                                    "^a&s", &cached_pkgnames));
+
+  g_autofree char **removed_base_pkgnames = NULL;
+  g_assert (g_variant_dict_lookup (self->spec->dict, "removed-base-packages",
+                                   "^a&s", &removed_base_pkgnames));
 
   /* setup sack if not yet set up */
   if (dnf_context_get_sack (hifctx) == NULL)
@@ -1391,28 +1409,34 @@ rpmostree_context_prepare (RpmOstreeContext *self,
                      NULL);
   }
 
-  { const char *const*strviter = (const char *const*)pkgnames;
-    for (; strviter && *strviter; strviter++)
-      {
-        const char *pkgname = *strviter;
-        if (!dnf_context_install (hifctx, pkgname, error))
-          return FALSE;
-      }
-  }
+  for (char **it = pkgnames; it && *it; it++)
+    {
+      const char *pkgname = *it;
+      if (!dnf_context_install (hifctx, pkgname, error))
+        return FALSE;
+    }
+
+  for (char **it = removed_base_pkgnames; it && *it; it++)
+    {
+      const char *pkgname = *it;
+      if (!dnf_context_remove (hifctx, pkgname, error))
+        return FALSE;
+    }
 
   rpmostree_output_task_begin ("Resolving dependencies");
 
-  if (!dnf_goal_depsolve (goal, DNF_INSTALL, error) ||
-      !check_goal_solution (goal, error))
+  /* XXX: consider a --allow-uninstall switch? */
+  if (!dnf_goal_depsolve (goal, DNF_INSTALL | DNF_ALLOW_UNINSTALL, error) ||
+      !check_goal_solution (goal, (const char *const*)removed_base_pkgnames, error))
     {
       g_print ("failed\n");
       return FALSE;
     }
 
-  rpmostree_output_task_end ("done");
-
   if (!sort_packages (self, error))
     return FALSE;
+
+  rpmostree_output_task_end ("done");
 
   return TRUE;
 }
@@ -1711,6 +1735,88 @@ checkout_package_into_root (RpmOstreeContext *self,
                          devino_cache, pkg_commit,
                          cancellable, error))
     return FALSE;
+
+  return TRUE;
+}
+
+static Header
+get_rpmdb_pkg_header (rpmts rpmdb_ts,
+                      DnfPackage *pkg,
+                      GCancellable *cancellable,
+                      GError **error)
+{
+  g_auto(rpmts) rpmdb_ts_owned = NULL;
+  if (!rpmdb_ts) /* allow callers to pass NULL */
+    rpmdb_ts = rpmdb_ts_owned = rpmtsCreate ();
+
+  unsigned int dbid = dnf_package_get_rpmdbid (pkg);
+  g_assert (dbid > 0);
+
+  g_auto(rpmdbMatchIterator) it =
+    rpmtsInitIterator (rpmdb_ts, RPMDBI_PACKAGES, &dbid, sizeof(dbid));
+
+  g_auto(Header) hdr = it ? rpmdbNextIterator (it) : NULL;
+  if (hdr == NULL)
+    return glnx_null_throw (error, "Failed to find package '%s' in rpmdb",
+                            dnf_package_get_nevra (pkg));
+
+  return headerLink (g_steal_pointer (&hdr));
+}
+
+static gboolean
+delete_package_from_root (RpmOstreeContext *self,
+                          rpmte         pkg,
+                          int           rootfs_dfd,
+                          GCancellable *cancellable,
+                          GError      **error)
+{
+  g_auto(rpmfiles) files = rpmteFiles (pkg);
+  g_auto(rpmfi) fi = rpmfilesIter (files, RPMFI_ITER_FWD);
+
+  g_autoptr(GPtrArray) deleted_dirs = g_ptr_array_new_with_free_func (g_free);
+
+  int i;
+  while ((i = rpmfiNext (fi)) >= 0)
+    {
+      /* see also apply_rpmfi_overrides() for a commented version of the loop */
+      const char *fn = rpmfiFN (fi);
+      rpm_mode_t mode = rpmfiFMode (fi);
+
+      if (!(S_ISREG (mode) ||
+            S_ISLNK (mode) ||
+            S_ISDIR (mode)))
+        continue;
+
+      g_assert (fn != NULL);
+      fn += strspn (fn, "/");
+      g_assert (fn[0]);
+
+      g_autofree char *fn_owned = NULL;
+      if (g_str_has_prefix (fn, "etc/"))
+        fn = fn_owned = g_strconcat ("usr/", fn, NULL);
+
+      /* for now, we only remove files from /usr */
+      if (!g_str_has_prefix (fn, "usr/"))
+        continue;
+
+      /* avoiding the stat syscall is worth a bit of userspace computation */
+      if (rpmostree_str_has_prefix_in_ptrarray (fn, deleted_dirs))
+        continue;
+
+      struct stat stbuf;
+      if (fstatat (rootfs_dfd, fn, &stbuf, AT_SYMLINK_NOFOLLOW) != 0)
+        {
+          if (errno == ENOENT)
+            continue; /* a job well done */
+          return glnx_throw_errno_prefix (error, "fstatat(%s)", fn);
+        }
+
+      if (!glnx_shutil_rm_rf_at (rootfs_dfd, fn, cancellable, error))
+        return FALSE;
+
+      if (S_ISDIR (mode))
+        g_ptr_array_add (deleted_dirs, g_strconcat (fn, "/", NULL));
+    }
 
   return TRUE;
 }
@@ -2159,17 +2265,16 @@ get_package_metainfo (RpmOstreeContext *self,
 }
 
 static gboolean
-add_to_transaction (RpmOstreeContext *self,
-                    rpmts  ts,
-                    DnfPackage *pkg,
-                    gboolean noscripts,
-                    GHashTable *ignore_scripts,
-                    GCancellable *cancellable,
-                    GError **error)
+rpmts_add_install (RpmOstreeContext *self,
+                   rpmts  ts,
+                   DnfPackage *pkg,
+                   gboolean noscripts,
+                   GHashTable *ignore_scripts,
+                   GCancellable *cancellable,
+                   GError **error)
 {
   g_auto(Header) hdr = NULL;
   g_autofree char *path = get_package_relpath (pkg);
-  int r;
 
   if (!get_package_metainfo (self, path, &hdr, NULL, error))
     return FALSE;
@@ -2180,16 +2285,28 @@ add_to_transaction (RpmOstreeContext *self,
         return FALSE;
     }
 
-  r = rpmtsAddInstallElement (ts, hdr, pkg, TRUE, NULL);
-  if (r != 0)
-    {
-      g_set_error (error,
-                   G_IO_ERROR,
-                   G_IO_ERROR_FAILED,
-                   "Failed to add install element for %s",
-                   dnf_package_get_filename (pkg));
-      return FALSE;
-    }
+  if (rpmtsAddInstallElement (ts, hdr, pkg, TRUE, NULL) != 0)
+    return glnx_throw (error, "Failed to add install element for %s",
+                       dnf_package_get_filename (pkg));
+
+  return TRUE;
+}
+
+static gboolean
+rpmts_add_erase (RpmOstreeContext *self,
+                 rpmts ts,
+                 DnfPackage *pkg,
+                 GCancellable *cancellable,
+                 GError **error)
+{
+  /* NB: we're not running any %*un scriptlets right now */
+  g_auto(Header) hdr = get_rpmdb_pkg_header (ts, pkg, cancellable, error);
+  if (hdr == NULL)
+    return FALSE;
+
+  if (rpmtsAddEraseElement (ts, hdr, -1))
+    return glnx_throw (error, "Failed to add erase element for package '%s'",
+                       dnf_package_get_nevra (pkg));
 
   return TRUE;
 }
@@ -2427,6 +2544,7 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
 
   g_auto(rpmts) ordering_ts = rpmtsCreate ();
   rpmtsSetRootDir (ordering_ts, dnf_context_get_install_root (hifctx));
+
   /* First for the ordering TS, set the dbpath to relative, which will also gain
    * the root dir.
    */
@@ -2438,63 +2556,76 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
    */
   rpmtsSetVSFlags (ordering_ts, _RPMVSF_NOSIGNATURES | _RPMVSF_NODIGESTS | RPMTRANS_FLAG_TEST);
 
+  g_autoptr(GPtrArray) overlays =
+    dnf_goal_get_packages (dnf_context_get_goal (hifctx),
+                           DNF_PACKAGE_INFO_INSTALL,
+                           -1);
+
+  g_autoptr(GPtrArray) overrides_remove =
+    dnf_goal_get_packages (dnf_context_get_goal (hifctx),
+                           DNF_PACKAGE_INFO_REMOVE,
+                           DNF_PACKAGE_INFO_OBSOLETE,
+                           -1);
+
+  if (overlays->len == 0 && overrides_remove->len == 0)
+    return glnx_throw (error, "No packages in transaction");
+
   /* Tell librpm about each one so it can tsort them.  What we really
    * want is to do this from the rpm-md metadata so that we can fully
    * parallelize download + unpack.
    */
-  { g_autoptr(GPtrArray) package_list = NULL;
 
-    package_list = dnf_goal_get_packages (dnf_context_get_goal (hifctx),
-                                          DNF_PACKAGE_INFO_INSTALL,
-                                          -1);
+  for (guint i = 0; i < overrides_remove->len; i++)
+    {
+      DnfPackage *pkg = overrides_remove->pdata[i];
+      if (!rpmts_add_erase (self, ordering_ts, pkg, cancellable, error))
+        return FALSE;
+    }
 
-    if (package_list->len == 0)
-      return glnx_throw (error, "No packages in installation set");
+  for (guint i = 0; i < overlays->len; i++)
+    {
+      DnfPackage *pkg = overlays->pdata[i];
+      g_autofree char *cachebranch = rpmostree_get_cache_branch_pkg (pkg);
+      g_autofree char *cached_rev = NULL;
+      gboolean sepolicy_matches;
 
-    for (guint i = 0; i < package_list->len; i++)
-      {
-        DnfPackage *pkg = package_list->pdata[i];
-        g_autofree char *cachebranch = rpmostree_get_cache_branch_pkg (pkg);
-        g_autofree char *cached_rev = NULL;
-        gboolean sepolicy_matches;
+      if (!ostree_repo_resolve_rev (pkgcache_repo, cachebranch, FALSE,
+                                    &cached_rev, error))
+        return FALSE;
 
-        if (!ostree_repo_resolve_rev (pkgcache_repo, cachebranch, FALSE,
-                                      &cached_rev, error))
-          return FALSE;
+      if (self->sepolicy)
+        {
+          if (!commit_has_matching_sepolicy (pkgcache_repo, cached_rev,
+                                             self->sepolicy, &sepolicy_matches,
+                                             error))
+            return FALSE;
 
-        if (self->sepolicy)
-          {
-            if (!commit_has_matching_sepolicy (pkgcache_repo, cached_rev,
-                                               self->sepolicy, &sepolicy_matches,
-                                               error))
-              return FALSE;
+          /* We already did any relabeling/reimporting above */
+          g_assert (sepolicy_matches);
+        }
 
-            /* We already did any relabeling/reimporting above */
-            g_assert (sepolicy_matches);
-          }
+      if (!checkout_pkg_metadata_by_dnfpkg (self, pkg, cancellable, error))
+        return FALSE;
 
-        if (!checkout_pkg_metadata_by_dnfpkg (self, pkg, cancellable, error))
-          return FALSE;
+      if (!rpmts_add_install (self, ordering_ts, pkg,
+                              noscripts, self->ignore_scripts,
+                              cancellable, error))
+        return FALSE;
 
-        if (!add_to_transaction (self, ordering_ts, pkg,
-                                 noscripts, self->ignore_scripts,
-                                 cancellable, error))
-          return FALSE;
+      g_hash_table_insert (pkg_to_ostree_commit, g_object_ref (pkg), g_steal_pointer (&cached_rev));
 
-        g_hash_table_insert (pkg_to_ostree_commit, g_object_ref (pkg), g_steal_pointer (&cached_rev));
-
-        if (strcmp (dnf_package_get_name (pkg), "filesystem") == 0)
-          filesystem_package = g_object_ref (pkg);
-      }
-  }
+      if (strcmp (dnf_package_get_name (pkg), "filesystem") == 0)
+        filesystem_package = g_object_ref (pkg);
+    }
 
   { DECLARE_RPMSIGHANDLER_RESET;
     rpmtsOrder (ordering_ts);
   }
 
-  rpmostree_output_task_begin ("Overlaying");
+  rpmostree_output_task_begin ("Applying overrides and overlays");
 
   guint n_rpmts_elements = (guint)rpmtsNElements (ordering_ts);
+  g_assert (n_rpmts_elements > 0);
 
   /* Okay so what's going on in Fedora with incestuous relationship
    * between the `filesystem`, `setup`, `libgcc` RPMs is actively
@@ -2515,42 +2646,29 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
                                        cancellable, error))
         return FALSE;
     }
-  else
-    {
-      /* Otherwise, we unpack the first package to get the initial
-       * rootfs dir.
-       */
-      rpmte te = rpmtsElement (ordering_ts, 0);
-      DnfPackage *pkg = (void*)rpmteKey (te);
-
-      g_assert (pkg);
-
-      if (!checkout_package_into_root (self, pkg,
-                                       tmprootfs_dfd, ".", devino_cache,
-                                       g_hash_table_lookup (pkg_to_ostree_commit,
-                                                            pkg),
-                                       cancellable, error))
-        return FALSE;
-
-      filesystem_package = g_object_ref (pkg);
-    }
 
   for (guint i = 0; i < n_rpmts_elements; i++)
     {
       rpmte te = rpmtsElement (ordering_ts, i);
-      DnfPackage *pkg = (void*)rpmteKey (te);
+      rpmElementType type = rpmteType (te);
 
-      g_assert (pkg);
+      if (type == TR_ADDED)
+        {
+          DnfPackage *pkg = (void*)rpmteKey (te);
+          if (pkg == filesystem_package)
+            continue;
 
-      if (pkg == filesystem_package)
-        continue;
-
-      if (!checkout_package_into_root (self, pkg,
-                                       tmprootfs_dfd, ".", devino_cache,
-                                       g_hash_table_lookup (pkg_to_ostree_commit,
-                                                            pkg),
-                                       cancellable, error))
-        return FALSE;
+          if (!checkout_package_into_root (self, pkg, tmprootfs_dfd, ".", devino_cache,
+                                           g_hash_table_lookup (pkg_to_ostree_commit, pkg),
+                                           cancellable, error))
+            return FALSE;
+        }
+      else
+        {
+          g_assert (type == TR_REMOVED);
+          if (!delete_package_from_root (self, te, tmprootfs_dfd, cancellable, error))
+            return FALSE;
+        }
     }
 
   rpmostree_output_task_end ("done");
@@ -2558,7 +2676,9 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
   if (!rpmostree_rootfs_prepare_links (tmprootfs_dfd, cancellable, error))
     return FALSE;
 
-  if (!noscripts)
+  /* NB: we're not running scripts right now for removals, so this is only for
+   * overlays */
+  if (!noscripts && overlays->len > 0)
     {
       gboolean have_passwd;
       gboolean have_systemctl;
@@ -2607,12 +2727,13 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
       for (guint i = 0; i < n_rpmts_elements; i++)
         {
           rpmte te = rpmtsElement (ordering_ts, i);
-          DnfPackage *pkg = (void*)rpmteKey (te);
+          if (rpmteType (te) != TR_ADDED)
+            continue;
 
+          DnfPackage *pkg = (void*)rpmteKey (te);
           g_assert (pkg);
 
-          if (!run_pre_sync (self, tmprootfs_dfd, pkg,
-                             cancellable, error))
+          if (!run_pre_sync (self, tmprootfs_dfd, pkg, cancellable, error))
             return FALSE;
         }
 
@@ -2653,18 +2774,19 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
       for (guint i = 0; i < n_rpmts_elements; i++)
         {
           rpmte te = rpmtsElement (ordering_ts, i);
+          if (rpmteType (te) != TR_ADDED)
+            continue;
+
           DnfPackage *pkg = (void*)rpmteKey (te);
 
           g_assert (pkg);
 
-          if (!apply_rpmfi_overrides (self, tmprootfs_dfd,
-                                      pkg, passwdents, groupents,
+          if (!apply_rpmfi_overrides (self, tmprootfs_dfd, pkg, passwdents, groupents,
                                       cancellable, error))
             return glnx_prefix_error (error, "While applying overrides for pkg %s: ",
                                       dnf_package_get_name (pkg));
 
-          if (!run_posttrans_sync (self, tmprootfs_dfd, pkg,
-                                   cancellable, error))
+          if (!run_posttrans_sync (self, tmprootfs_dfd, pkg, cancellable, error))
             return FALSE;
         }
 
@@ -2716,20 +2838,23 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
   tdata.ctx = self;
   rpmtsSetNotifyCallback (rpmdb_ts, ts_callback, &tdata);
 
-  { gpointer k;
-    GHashTableIter hiter;
+  for (guint i = 0; i < overlays->len; i++)
+    {
+      DnfPackage *pkg = overlays->pdata[i];
 
-    g_hash_table_iter_init (&hiter, pkg_to_ostree_commit);
-    while (g_hash_table_iter_next (&hiter, &k, NULL))
-      {
-        DnfPackage *pkg = k;
+      /* Set noscripts since we already validated them above */
+      if (!rpmts_add_install (self, rpmdb_ts, pkg, TRUE, NULL,
+                              cancellable, error))
+        return FALSE;
+    }
 
-        /* Set noscripts since we already validated them above */
-        if (!add_to_transaction (self, rpmdb_ts, pkg, TRUE, NULL,
-                                 cancellable, error))
-          return FALSE;
-      }
-  }
+  /* and mark removed packages as such so they drop out of rpmdb */
+  for (guint i = 0; i < overrides_remove->len; i++)
+    {
+      DnfPackage *pkg = overrides_remove->pdata[i];
+      if (!rpmts_add_erase (self, rpmdb_ts, pkg, cancellable, error))
+        return FALSE;
+    }
 
   rpmtsOrder (rpmdb_ts);
 
@@ -2800,27 +2925,50 @@ rpmostree_context_commit_tmprootfs (RpmOstreeContext      *self,
         g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.clientlayer",
                                g_variant_new_boolean (TRUE));
 
-        if (!self->empty)
-          {
-            g_autoptr(GVariant) pkgs =
-              g_variant_dict_lookup_value (self->spec->dict, "packages",
-                                           G_VARIANT_TYPE ("as"));
-            g_assert (pkgs);
-            g_variant_builder_add (&metadata_builder, "{sv}",
-                                   "rpmostree.packages", pkgs);
-          }
-        else
-          {
-            const char *const p[] = { NULL };
-            g_variant_builder_add (&metadata_builder, "{sv}",
-                                   "rpmostree.packages",
-                                   g_variant_new_strv (p, -1));
-          }
+        /* embed packages (really, "patterns") layered */
+        g_autoptr(GVariant) pkgs =
+          g_variant_dict_lookup_value (self->spec->dict, "packages", G_VARIANT_TYPE ("as"));
+        g_assert (pkgs);
+        g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.packages", pkgs);
+
+        /* embed the full NEVRA names of the base pkgs removed to make it easier to display
+         * to users (this does not include reverse deps that were also removed -- users can
+         * do `db diff` for the full list, much like regular pkglayering) */
+        {
+          g_autofree char **removed_base_pkgnames = NULL;
+          g_assert (g_variant_dict_lookup (self->spec->dict, "removed-base-packages",
+                                           "^a&s", &removed_base_pkgnames));
+          /* NB: strings owned by solv pool */
+          g_autoptr(GPtrArray) removed_base_pkgnevras = g_ptr_array_new ();
+
+          if (!self->empty)
+            {
+              g_autoptr(GPtrArray) packages =
+                dnf_goal_get_packages (dnf_context_get_goal (self->hifctx),
+                                       DNF_PACKAGE_INFO_REMOVE,
+                                       DNF_PACKAGE_INFO_OBSOLETE, -1);
+
+              for (guint i = 0; i < packages->len; i++)
+                {
+                  DnfPackage *pkg = packages->pdata[i];
+                  const char *name = dnf_package_get_name (pkg);
+                  const char *nevra = dnf_package_get_nevra (pkg);
+                  if (g_strv_contains ((const char*const*)removed_base_pkgnames, name))
+                    g_ptr_array_add (removed_base_pkgnevras, (gpointer)nevra);
+                }
+            }
+
+          g_variant_builder_add (&metadata_builder, "{sv}",
+                                 "rpmostree.removed-base-packages",
+                                 g_variant_new_strv (
+                                   (const char *const*)removed_base_pkgnevras->pdata,
+                                   removed_base_pkgnevras->len));
+        }
 
         /* be nice to our future selves */
         g_variant_builder_add (&metadata_builder, "{sv}",
                                "rpmostree.clientlayer_version",
-                               g_variant_new_uint32 (1));
+                               g_variant_new_uint32 (2));
       }
     else if (assemble_type == RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE)
       {

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -478,20 +478,12 @@ rpmostree_origin_remove_packages (RpmOstreeOrigin  *origin,
 
   for (char **it = packages; it && *it; it++)
     {
-      if (g_hash_table_contains (origin->cached_local_packages, *it))
-        {
-          g_hash_table_remove (origin->cached_local_packages, *it);
-          local_changed = TRUE;
-        }
-      else if (g_hash_table_contains (origin->cached_packages, *it))
-        {
-          g_hash_table_remove (origin->cached_packages, *it);
-          changed = TRUE;
-        }
+      if (g_hash_table_remove (origin->cached_local_packages, *it))
+        local_changed = TRUE;
+      else if (g_hash_table_remove (origin->cached_packages, *it))
+        changed = TRUE;
       else
-        {
-          return glnx_throw (error, "Package/capability '%s' is not currently requested", *it);
-        }
+        return glnx_throw (error, "Package/capability '%s' is not currently requested", *it);
     }
 
   if (changed)
@@ -540,10 +532,8 @@ rpmostree_origin_remove_overrides (RpmOstreeOrigin  *origin,
   for (char **it = packages; it && *it; it++)
     {
       const char *pkg = *it;
-      if (!g_hash_table_contains (origin->cached_overrides_remove, pkg))
+      if (!g_hash_table_remove (origin->cached_overrides_remove, pkg))
         return glnx_throw (error, "No overrides for package '%s'", pkg);
-
-      g_hash_table_remove (origin->cached_overrides_remove, pkg);
       changed = TRUE;
     }
 

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -60,6 +60,9 @@ rpmostree_origin_get_packages (RpmOstreeOrigin *origin);
 GHashTable *
 rpmostree_origin_get_local_packages (RpmOstreeOrigin *origin);
 
+GHashTable *
+rpmostree_origin_get_overrides_remove (RpmOstreeOrigin *origin);
+
 const char *
 rpmostree_origin_get_override_commit (RpmOstreeOrigin *origin);
 
@@ -113,6 +116,22 @@ gboolean
 rpmostree_origin_remove_packages (RpmOstreeOrigin  *origin,
                                   char            **packages,
                                   GError          **error);
+
+gboolean
+rpmostree_origin_add_overrides (RpmOstreeOrigin  *origin,
+                                char            **packages,
+                                gboolean          is_remove_override,
+                                GError          **error);
+
+gboolean
+rpmostree_origin_remove_overrides (RpmOstreeOrigin  *origin,
+                                   char            **packages,
+                                   GError          **error);
+
+gboolean
+rpmostree_origin_remove_all_overrides (RpmOstreeOrigin  *origin,
+                                       gboolean         *out_changed,
+                                       GError          **error);
 
 void
 rpmostree_origin_set_live_state (RpmOstreeOrigin *origin,

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -24,6 +24,7 @@
 
 #include <rpm/rpmlib.h>
 #include <rpm/rpmlog.h>
+#include <rpm/rpmdb.h>
 #include "libglnx.h"
 #include "rpmostree-util.h"
 #include "rpmostree-refsack.h"
@@ -67,7 +68,9 @@ rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff);
  * itself. TODO: Move them to libdnf */
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(Header, headerFree, NULL)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmfi, rpmfiFree, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmfiles, rpmfilesFree, NULL)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmts, rpmtsFree, NULL)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmdbMatchIterator, rpmdbFreeIterator, NULL)
 
 void
 rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff);

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -101,6 +101,7 @@ rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
                                        gboolean          *out_is_layered,
                                        char             **out_base_layer,
                                        char            ***out_layered_pkgs,
+                                       char            ***out_removed_base_pkgs,
                                        GError           **error);
 
 gboolean

--- a/tests/common/compose/yum/foo-ext.spec
+++ b/tests/common/compose/yum/foo-ext.spec
@@ -1,0 +1,36 @@
+Summary: Awesome utility that requires foo
+Name: foo-ext
+Version: 1.0
+Release: 1
+License: GPL+
+Group: Development/Tools
+URL: http://foo.bar.com
+BuildArch: x86_64
+
+Requires: foo
+
+%description
+%{summary}
+
+%prep
+
+%build
+cat > foo-ext << EOF
+#!/bin/sh
+echo "Happy ext foobing!"
+EOF
+chmod a+x foo-ext
+
+%install
+mkdir -p %{buildroot}/usr/bin
+install foo-ext %{buildroot}/usr/bin
+
+%clean
+rm -rf %{buildroot}
+
+%files
+/usr/bin/foo-ext
+
+%changelog
+* Tue Jun 21 2016 Jonathan Lebon <jlebon@redhat.com> 1.0-1
+- First Build

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# make sure that package-related entries are always present,
+# even when they're empty
+vm_assert_status_jq \
+  '.deployments[0]["packages"]' \
+  '.deployments[0]["requested-packages"]' \
+  '.deployments[0]["requested-local-packages"]' \
+  '.deployments[0]["removed-base-packages"]'
+echo "ok empty pkg arrays in status json"
+
+# Be sure an unprivileged user exists
+vm_cmd getent passwd bin
+
+# Make sure we can't layer as non-root
+if vm_cmd "runuser -u bin rpm-ostree pkg-add foo-1.0"; then
+    assert_not_reached "Was able to install a package as non-root!"
+fi
+echo "ok layering requires root"
+
+# Assert that we can do status as non-root
+vm_cmd "runuser -u bin rpm-ostree status"
+echo "ok status doesn't require root"

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -37,22 +37,7 @@ vm_assert_status_jq \
   '.deployments[0]["base-checksum"]|not' \
   '.deployments[0]["pending-base-checksum"]|not'
 
-# make sure that package-related entries are always present,
-# even when they're empty
-vm_assert_status_jq \
-  '.deployments[0]["packages"]' \
-  '.deployments[0]["requested-packages"]'
-
-# Be sure an unprivileged user exists
-vm_cmd getent passwd bin
-if vm_cmd "runuser -u bin rpm-ostree pkg-add foo-1.0"; then
-    assert_not_reached "Was able to install a package as non-root!"
-fi
-
-# Assert that we can do status as non-root
-vm_cmd "runuser -u bin rpm-ostree status" >/dev/null
-
-# Be sure an unprivileged user exists
+# make sure installing in /opt fails
 if vm_rpmostree install test-opt-1.0 2>err.txt; then
     assert_not_reached "Was able to install a package in /opt"
 fi

--- a/tests/vmcheck/test-override-remove.sh
+++ b/tests/vmcheck/test-override-remove.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+vm_send_test_repo
+
+# create a new vmcheck commit which has foo and nonrootcap in it already so that
+# we can target them with our override
+
+# make sure the packages are not already layered
+vm_assert_layered_pkg foo absent
+vm_assert_layered_pkg nonrootcap absent
+vm_assert_status_jq \
+  '.deployments[0]["base-checksum"]|not' \
+  '.deployments[0]["pending-base-checksum"]|not'
+
+vm_cmd ostree refs $(vm_get_booted_csum) --create vmcheck_tmp/without_foo_and_nonrootcap
+
+# create a new branch with foo and nonrootcap already in it
+vm_rpmostree install foo nonrootcap
+vm_cmd ostree refs $(vm_get_deployment_info 0 checksum) \
+  --create vmcheck_tmp/with_foo_and_nonrootcap
+vm_rpmostree cleanup -p
+
+# upgrade to new commit with foo in the base layer
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo_and_nonrootcap
+vm_rpmostree upgrade
+vm_reboot
+if ! vm_has_packages foo nonrootcap; then
+    assert_not_reached "foo or nonrootcap not in base layer"
+fi
+echo "ok setup"
+
+vm_rpmostree ex override remove foo nonrootcap
+vm_assert_status_jq \
+  '.deployments[0]["removed-base-packages"]|length == 2' \
+  '.deployments[0]["removed-base-packages"]|index("foo-1.0-1.x86_64") >= 0' \
+  '.deployments[0]["removed-base-packages"]|index("nonrootcap-1.0-1.x86_64") >= 0'
+echo "ok override remove foo and nonrootcap"
+
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
+vm_rpmostree upgrade
+vm_assert_status_jq \
+  '.deployments[0]["removed-base-packages"]|length == 2' \
+  '.deployments[0]["removed-base-packages"]|index("foo-1.0-1.x86_64") >= 0' \
+  '.deployments[0]["removed-base-packages"]|index("nonrootcap-1.0-1.x86_64") >= 0'
+echo "ok override remove carried through upgrade"
+
+vm_rpmostree ex override reset foo
+vm_assert_status_jq \
+  '.deployments[0]["removed-base-packages"]|length == 1' \
+  '.deployments[0]["removed-base-packages"]|index("nonrootcap-1.0-1.x86_64") >= 0'
+echo "ok override reset foo"
+
+vm_rpmostree ex override reset --all
+vm_assert_status_jq \
+  '.deployments[0]["removed-base-packages"]|length == 0'
+echo "ok override reset --all"
+
+# check that upgrading to a base without foo drops the override
+vm_rpmostree ex override remove foo
+vm_assert_status_jq \
+  '.deployments[0]["removed-base-packages"]|length == 1' \
+  '.deployments[0]["removed-base-packages"]|index("foo-1.0-1.x86_64") >= 0'
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/without_foo_and_nonrootcap
+vm_rpmostree upgrade
+vm_assert_status_jq \
+  '.deployments[0]["removed-base-packages"]|length == 0'
+echo "ok override drops out"
+
+# a few error checks
+
+if vm_rpmostree ex override remove non-existent-package; then
+  assert_not_reached "override remove non-existent-package succeeded?"
+fi
+echo "ok override remove non-existent-package fails"
+
+vm_rpmostree install foo
+if vm_rpmostree ex override remove foo; then
+  assert_not_reached "override remove layered pkg foo succeeded?"
+fi
+vm_rpmostree cleanup -p
+echo "ok override remove layered pkg foo fails"
+
+# the next two error checks expect an upgraded layer with foo builtin
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo_and_nonrootcap
+
+vm_rpmostree upgrade
+vm_rpmostree ex override remove foo
+if vm_rpmostree install foo; then
+  assert_not_reached "tried to layer pkg removed by override"
+fi
+# the check blocking this isn't related to overrides, though for consistency
+# let's make sure this fails here too
+if vm_rpmostree install /tmp/vmcheck/repo/packages/x86_64/foo-1.0-1.x86_64.rpm; then
+  assert_not_reached "tried to layer local pkg removed by override"
+fi
+vm_rpmostree cleanup -p
+echo "ok can't layer pkg removed by override"
+
+vm_rpmostree upgrade --install foo-ext
+if vm_rpmostree ex override remove foo; then
+  assert_not_reached "override remove base pkg needed by layered pkg succeeded?"
+fi
+vm_rpmostree cleanup -p
+echo "ok override remove base dep to layered pkg fails"


### PR DESCRIPTION
Add basic support for base layer pkg removals. This is still in somewhat rough shape; some shortcuts were taken esp. in the core that I'd like to revisit. There's also a lot of fixes & refactors, with varying degrees of relatedness to base overrides. And of course, tests.

Will split this up into multiple PRs.

Removing base package:

```
[root@f25-ros-dev ~]# rpm-ostree status
State: idle
Deployments:
* vmcheck
              Timestamp: 2017-05-26 17:28:42
                 Commit: fe6ddc529c161964f5801f4879f8ad5c98a197e24cfd86714874ba1dd02df762
[root@f25-ros-dev ~]# rpm -q strace
strace-4.16-1.fc25.x86_64
[root@f25-ros-dev ~]# strace
strace: must have PROG [ARGS] or -p PID
Try 'strace -h' for more information.
[root@f25-ros-dev ~]# rpm-ostree ex override remove strace
Checking out tree fe6ddc5... done

Downloading metadata: [==========================================================================================] 100%
Resolving dependencies... done
Applying overlays and overrides... done
Writing rpmdb... done
Writing OSTree commit... done
Copying /etc changes: 26 modified, 0 removed, 102 added
Transaction complete; bootconfig swap: yes deployment count change: 1
Removed:
  strace-4.16-1.fc25.x86_64
Run "systemctl reboot" to start a reboot
[root@f25-ros-dev ~]# reboot
...
[root@f25-ros-dev ~]# rpm-ostree status
State: idle
Deployments:
* vmcheck
              Timestamp: 2017-05-26 17:28:42
             BaseCommit: fe6ddc529c161964f5801f4879f8ad5c98a197e24cfd86714874ba1dd02df762
    RemovedBasePackages: strace

  vmcheck
              Timestamp: 2017-05-26 17:28:42
                 Commit: fe6ddc529c161964f5801f4879f8ad5c98a197e24cfd86714874ba1dd02df762
[root@f25-ros-dev ~]# rpm -q strace
package strace is not installed
[root@f25-ros-dev ~]# strace
bash: strace: command not found
```

And of course, resetting the override takes us back to the same BaseCommit:

```
[root@f25-ros-dev ~]# rpm-ostree ex override reset strace
Copying /etc changes: 26 modified, 0 removed, 102 added
Transaction complete; bootconfig swap: no deployment count change: 0
Added:
  strace-4.16-1.fc25.x86_64
Run "systemctl reboot" to start a reboot
[root@f25-ros-dev ~]# rpm-ostree status -v
State: idle
Deployments:
  vmcheck
              Timestamp: 2017-05-26 17:28:42
                 Commit: fe6ddc529c161964f5801f4879f8ad5c98a197e24cfd86714874ba1dd02df762
              StateRoot: fedora-atomic

* vmcheck
              Timestamp: 2017-05-26 17:28:42
             BaseCommit: fe6ddc529c161964f5801f4879f8ad5c98a197e24cfd86714874ba1dd02df762
                 Commit: 5fb1929c7136b03e049557d3c84578517618a38ae2baef42a0435fcc5dad9ed5
              StateRoot: fedora-atomic
    RemovedBasePackages: strace
```
