### PR TITLE
compose: use test env fedora.repo file instead

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -70,7 +70,7 @@ host:
 # copy yum.repos.d to get any injected repos from the host, which
 # will point to a closer mirror
 tests:
-  - docker run --privileged --rm --name composer
+  - docker run --privileged -d --name composer
     -e RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO=1 -v $(pwd):/srv/code
     registry.fedoraproject.org/fedora:25 sleep infinity
   - docker cp /etc/yum.repos.d/. composer:/etc/yum.repos.d

--- a/.papr.yml
+++ b/.papr.yml
@@ -67,16 +67,15 @@ timeout: 30m
 host:
   distro: fedora/25/atomic
 
-# mount yum.repos.d to get any injected repos from the host, which
+# copy yum.repos.d to get any injected repos from the host, which
 # will point to a closer mirror
 tests:
-  - >
-      docker run --privileged --rm
-      -e RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO=1
-      -v /etc/yum.repos.d:/etc/yum.repos.d:ro
-      -v $(pwd):/srv/code
-      registry.fedoraproject.org/fedora:25 /bin/sh -c
-      "cd /srv/code && ./ci/build.sh && make install && ./tests/compose"
+  - docker run --privileged --rm -d --name composer
+    -e RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO=1 -v $(pwd):/srv/code
+    registry.fedoraproject.org/fedora:25 sleep infinity
+  - docker cp /etc/yum.repos.d/. composer:/etc/yum.repos.d
+  - docker exec composer /bin/sh -c
+    "cd /srv/code && ./ci/build.sh && make install && ./tests/compose"
 
 artifacts:
   - compose.log

--- a/.papr.yml
+++ b/.papr.yml
@@ -64,10 +64,18 @@ timeout: 30m
 host:
   distro: fedora/25/atomic
 
+env:
+  RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO: 1
+
+# mount yum.repos.d to get any injected repos from the host, which
+# will point to a closer mirror
 tests:
   - >
-      docker run --privileged -v $(pwd):/srv/code --rm
-      registry.fedoraproject.org/fedora:25 /bin/sh -c "cd /srv/code && ./ci/build.sh && make install && ./tests/compose"
+      docker run --privileged --rm
+      -v /etc/yum.repos.d:/etc/yum.repos.d
+      -v $(pwd):/srv/code
+      registry.fedoraproject.org/fedora:25 /bin/sh -c
+      "cd /srv/code && ./ci/build.sh && make install && ./tests/compose"
 
 artifacts:
   - compose.log

--- a/.papr.yml
+++ b/.papr.yml
@@ -65,7 +65,7 @@ host:
   distro: fedora/25/atomic
 
 env:
-  RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO: 1
+  RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO: yes
 
 # mount yum.repos.d to get any injected repos from the host, which
 # will point to a closer mirror

--- a/.papr.yml
+++ b/.papr.yml
@@ -54,6 +54,9 @@ timeout: 80m
 
 ---
 
+# NB: when bumping 25 here, also bump fedora.repo, compose script, and
+# fedora-base.json
+
 context: compose
 build: false
 timeout: 30m
@@ -64,15 +67,13 @@ timeout: 30m
 host:
   distro: fedora/25/atomic
 
-env:
-  RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO: "1"
-
 # mount yum.repos.d to get any injected repos from the host, which
 # will point to a closer mirror
 tests:
   - >
       docker run --privileged --rm
-      -v /etc/yum.repos.d:/etc/yum.repos.d
+      -e RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO=1
+      -v /etc/yum.repos.d:/etc/yum.repos.d:ro
       -v $(pwd):/srv/code
       registry.fedoraproject.org/fedora:25 /bin/sh -c
       "cd /srv/code && ./ci/build.sh && make install && ./tests/compose"

--- a/.papr.yml
+++ b/.papr.yml
@@ -70,12 +70,13 @@ host:
 # copy yum.repos.d to get any injected repos from the host, which
 # will point to a closer mirror
 tests:
-  - docker run --privileged --rm -d --name composer
+  - docker run --privileged --rm --name composer
     -e RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO=1 -v $(pwd):/srv/code
     registry.fedoraproject.org/fedora:25 sleep infinity
   - docker cp /etc/yum.repos.d/. composer:/etc/yum.repos.d
   - docker exec composer /bin/sh -c
     "cd /srv/code && ./ci/build.sh && make install && ./tests/compose"
+  - docker rm --force composer
 
 artifacts:
   - compose.log

--- a/.papr.yml
+++ b/.papr.yml
@@ -65,7 +65,7 @@ host:
   distro: fedora/25/atomic
 
 env:
-  RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO: yes
+  RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO: "1"
 
 # mount yum.repos.d to get any injected repos from the host, which
 # will point to a closer mirror

--- a/.papr.yml
+++ b/.papr.yml
@@ -70,13 +70,13 @@ host:
 # copy yum.repos.d to get any injected repos from the host, which
 # will point to a closer mirror
 tests:
-  - docker run --privileged -d --name composer
-    -e RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO=1 -v $(pwd):/srv/code
-    registry.fedoraproject.org/fedora:25 sleep infinity
-  - docker cp /etc/yum.repos.d/. composer:/etc/yum.repos.d
-  - docker exec composer /bin/sh -c
-    "cd /srv/code && ./ci/build.sh && make install && ./tests/compose"
-  - docker rm --force composer
+  - docker run --privileged --rm
+    -e RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO=1
+    -v /etc/yum.repos.d:/etc/yum.repos.d.host:ro
+    -v $(pwd):/srv/code -w /srv/code
+    registry.fedoraproject.org/fedora:25 /bin/sh -c
+    "cp -fv /etc/yum.repos.d{.host/*.repo,} &&
+     ./ci/build.sh && make install && ./tests/compose"
 
 artifacts:
   - compose.log

--- a/tests/compose
+++ b/tests/compose
@@ -49,8 +49,10 @@ mkdir -p ${test_compose_datadir}/cache
 
 echo "Preparing compose tests..." | tee -a ${LOG}
 
+# take the host repo if it matches our target tree
 if [ -n "${RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO:-}" ]; then
-  # take the host repo if it matches our target tree
+  # NB: when bumping 25 here, also bump fedora.repo, .papr.yml, and
+  # fedora-base.json
   (source /etc/os-release;
    if [ "$ID" == "fedora" ] && [ "$VERSION_ID" == "25" ]; then
      echo "Taking stable Fedora repo file from test env."

--- a/tests/compose
+++ b/tests/compose
@@ -49,6 +49,15 @@ mkdir -p ${test_compose_datadir}/cache
 
 echo "Preparing compose tests..." | tee -a ${LOG}
 
+if [ -n "${RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO:-}" ]; then
+  # take the host repo if it matches our target tree
+  (source /etc/os-release;
+   if [ "$ID" == "fedora" ] && [ "$VERSION_ID" == "25" ]; then
+     echo "Taking stable Fedora repo file from test env."
+     cp -fv /etc/yum.repos.d/fedora.repo ${dn}/composedata
+   fi) &>> ${LOG}
+fi
+
 # Delete the default ref, since we want to use subrefs of it
 (rm ${repobuild}/refs/heads/* -rf
  rpm-ostree compose --repo=${repobuild} tree --dry-run --cachedir=${test_compose_datadir}/cache ${dn}/composedata/fedora-base.json

--- a/tests/composedata/fedora-base.json
+++ b/tests/composedata/fedora-base.json
@@ -1,7 +1,7 @@
 {
     "ref": "fedora/25/${basearch}",
 
-    "repos": ["fedora-25"],
+    "repos": ["fedora"],
 
     "packages": ["kernel", "nss-altfiles", "systemd", "ostree", "selinux-policy-targeted"],
 

--- a/tests/composedata/fedora-base.json
+++ b/tests/composedata/fedora-base.json
@@ -1,4 +1,6 @@
 {
+    "COMMENT": "when bumping 25 here, also bump fedora.repo, compose script, and .papr.yml",
+
     "ref": "fedora/25/${basearch}",
 
     "repos": ["fedora"],

--- a/tests/composedata/fedora.repo
+++ b/tests/composedata/fedora.repo
@@ -1,4 +1,5 @@
 [fedora]
+#when bumping 25 here, also bump fedora-base.json, compose script, and .papr.yml
 name=Fedora 25 (devel) - $basearch
 failovermethod=priority
 baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/25/Everything/$basearch/os/

--- a/tests/composedata/fedora.repo
+++ b/tests/composedata/fedora.repo
@@ -1,4 +1,4 @@
-[fedora-25]
+[fedora]
 name=Fedora 25 (devel) - $basearch
 failovermethod=priority
 baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/25/Everything/$basearch/os/


### PR DESCRIPTION
During provisioning, PAPR injects a `fedora.repo` pointing at a much
better & faster mirror than `dl.fp.o`. Let's use that to make the compose
test less flaky. Hoping to make these sorts of optimizations more
discoverable in upstream PAPR.