### PR TITLE
livefs: fix nested continue bug in optimization

### DIFF
--- a/src/daemon/rpmostreed-transaction-livefs.c
+++ b/src/daemon/rpmostreed-transaction-livefs.c
@@ -216,12 +216,8 @@ copy_new_config_files (OstreeRepo          *repo,
        * changed subdirectories.  But at the scale we're dealing with here the
        * constants for this O(N²) algorithm are tiny.
        */
-      for (guint j = 0; j < added_subdirs->len; j++)
-        {
-          const char *already_added_subdir = added_subdirs->pdata[j];
-          if (g_str_has_prefix (sub_etc_relpath, already_added_subdir))
-            continue;
-        }
+      if (rpmostree_str_has_prefix_in_ptrarray (sub_etc_relpath, added_subdirs))
+        continue;
 
       g_autoptr(GFileInfo) finfo = g_file_query_info (added_f, "standard::type",
                                                       G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -422,6 +422,19 @@ rpmostree_file_get_path_cached (GFile *file)
 }
 
 gboolean
+rpmostree_str_has_prefix_in_ptrarray (const char *str,
+                                      GPtrArray  *prefixes)
+{
+  for (guint j = 0; j < prefixes->len; j++)
+    {
+      const char *prefix = prefixes->pdata[j];
+      if (g_str_has_prefix (str, prefix))
+        return TRUE;
+    }
+  return FALSE;
+}
+
+gboolean
 rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
                                        OstreeDeployment  *deployment,
                                        gboolean          *out_is_layered,

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -92,6 +92,10 @@ void rpmostree_diff_print (OstreeRepo *repo,
                            GPtrArray *modified_new);
 
 gboolean
+rpmostree_str_has_prefix_in_ptrarray (const char *str,
+                                      GPtrArray  *prefixes);
+
+gboolean
 rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
                                        OstreeDeployment  *deployment,
                                        gboolean          *out_is_layered,


### PR DESCRIPTION
There's a subtle but classic issue in this code: calling `continue`
really just continued the inner loop, whereas we meant continuing the
outer loop.

Fix this by making the prefix lookup check a proper predicate function.
Place that function somewhere public, because we'll make use of it in
base overrides as well.