### PR TITLE
Add human-readable Title to transaction, render in status

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -152,6 +152,7 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
   const char *red_prefix = is_tty ? "\x1b[31m" : "";
   const char *red_suffix = is_tty ? "\x1b[22m" : "";
   GVariant* txn = get_active_txn (sysroot_proxy);
+  const char *txn_path = rpmostree_sysroot_get_active_transaction_path (sysroot_proxy);
 
   /* First, gather global state */
   gboolean have_any_live_overlay = FALSE;
@@ -176,11 +177,27 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
       have_any_live_overlay = have_any_live_overlay || have_live_changes;
     }
 
-  if (txn)
+  if (txn && txn_path)
     {
       const char *method, *sender, *path;
       g_variant_get (txn, "(&s&s&s)", &method, &sender, &path);
-      g_print ("State: transaction: %s %s %s\n", method, sender, path);
+
+      /* Things currently could race here if the transaction completes after we get the
+       * path.  For now, just ignore errors.  TODO: A more correct fix would involve a loop
+       * on watching the path property, trying a connection, and re-reading the value
+       * and only erroring out if the property hasn't changed.
+       */
+      g_autoptr(RPMOSTreeTransactionProxy) txn_proxy = (RPMOSTreeTransactionProxy*)rpmostree_transaction_connect (txn_path, NULL, NULL);
+      if (txn_proxy)
+        {
+          const char *title = rpmostree_transaction_get_title ((RPMOSTreeTransaction*)txn_proxy);
+          g_print ("State: transaction: %s\n", title);
+        }
+      /* Print the address if verbose, *or* if we somehow failed to get
+       * the txn, so we aren't masking errors.
+       */
+      if (opt_verbose || (path && !txn_proxy))
+        g_print ("TransactionAddress: %s %s %s\n", method, sender, path);
     }
   else
     g_print ("State: idle\n");

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -57,7 +57,10 @@ rpmostree_load_os_proxies                    (RPMOSTreeSysroot *sysroot_proxy,
                                               RPMOSTreeOS **out_os_proxy,
                                               RPMOSTreeOSExperimental **out_osexperimental_proxy,
                                               GError **error);
-
+RPMOSTreeTransaction *
+rpmostree_transaction_connect                (const char *transaction_address,
+                                              GCancellable *cancellable,
+                                              GError      **error);
 
 gboolean
 rpmostree_transaction_get_response_sync      (RPMOSTreeSysroot *sysroot_proxy,

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -23,8 +23,10 @@
     <!-- The system root path -->
     <property name="Path" type="s" access="read"/>
 
-    <!-- The values are (method-name, sender-name) -->
+    <!-- The values are (method-name, sender-name, object path) -->
     <property name="ActiveTransaction" type="(sss)" access="read"/>
+    <!-- A DBus address - connect to it to access its methods -->
+    <property name="ActiveTransactionPath" type="s" access="read"/>
 
     <!-- (Currently) optional method to denote the client plans
          to either invoke methods on the daemon, or monitor status.
@@ -272,6 +274,9 @@
   </interface>
 
   <interface name="org.projectatomic.rpmostree1.Transaction">
+
+    <!-- A single-line human-readable string -->
+    <property name="Title" type="s" access="read"/>
 
     <!-- Yes, we can. -->
     <method name="Cancel"/>

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -426,6 +426,20 @@ sysroot_transform_transaction_to_attrs (GBinding *binding,
 }
 
 static gboolean
+sysroot_transform_transaction_to_address (GBinding *binding,
+                                          const GValue *src_value,
+                                          GValue *dst_value,
+                                          gpointer user_data)
+{
+  RpmostreedTransaction *transaction = g_value_get_object (src_value);
+  const char *address = "";
+  if (transaction != NULL)
+    address = rpmostreed_transaction_get_client_address (transaction);
+  g_value_set_string (dst_value, address);
+  return TRUE;
+}
+
+static gboolean
 sysroot_populate_deployments_unlocked (RpmostreedSysroot *self,
 				       gboolean *out_changed,
 				       GError **error)
@@ -703,6 +717,17 @@ sysroot_constructed (GObject *object)
                                NULL,
                                NULL,
                                NULL);
+  g_object_bind_property_full (self->transaction_monitor,
+                               "active-transaction",
+                               self,
+                               "active-transaction-path",
+                               G_BINDING_DEFAULT |
+                               G_BINDING_SYNC_CREATE,
+                               sysroot_transform_transaction_to_address,
+                               NULL,
+                               NULL,
+                               NULL);
+
 
   /* Failure is not fatal, but the client may miss some messages. */
   if (!sysroot_setup_stdout_redirect (self, &local_error))

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -563,6 +563,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
   g_autoptr(GString) txn_title = g_string_new ("");
   if (is_install)
     g_string_append (txn_title, "install");
+  else if (self->refspec)
+    g_string_append (txn_title, "rebase");
   else if (self->revision)
     g_string_append (txn_title, "deploy");
   else

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -555,6 +555,18 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
     {
       rpmostree_origin_set_override_commit (origin, NULL, NULL);
     }
+  /* In practice today */
+  const gboolean is_install = self->flags & RPMOSTREE_TRANSACTION_DEPLOY_FLAG_NO_PULL_BASE
+    && !self->revision;
+
+  /* https://github.com/projectatomic/rpm-ostree/issues/454 */
+  g_autoptr(GString) txn_title = g_string_new ("");
+  if (is_install)
+    g_string_append (txn_title, "install");
+  else if (self->revision)
+    g_string_append (txn_title, "deploy");
+  else
+    g_string_append (txn_title, "upgrade");
 
   gboolean changed = FALSE;
   if (self->packages_removed)
@@ -608,6 +620,15 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
 
       changed = TRUE;
     }
+
+
+  if (self->packages_removed || self->packages_added || self->local_packages_added)
+    g_string_append_printf (txn_title, "; remove: %u install: %u; localinstall: %u",
+                            g_strv_length (self->packages_removed),
+                            g_strv_length (self->packages_added),
+                            g_unix_fd_list_get_length (self->local_packages_added));
+
+  rpmostree_transaction_set_title ((RPMOSTreeTransaction*)self, txn_title->str);
 
   rpmostree_sysroot_upgrader_set_origin (upgrader, origin);
 


### PR DESCRIPTION
There's a lot that could be done to improve this; we're not setting a title for
`rollback` etc. But I think in practice right now the "deploy" path (which
includes upgrade/install) etc. is most important.

Re-synthesizing a human readable string here is definitely a bit fragile and
going to be a maintenance pain. One thing I debated is having the client send
its commandline as a string. But that would only work for `/usr/bin/rpm-ostree`,
not e.g. Cockpit.

Anyways for now, this is useful and we can always improve it later.

Closes: https://github.com/projectatomic/rpm-ostree/issues/454
