### PR TITLE
origin: drop GCancellable arg and rename function

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -573,8 +573,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
   gboolean changed = FALSE;
   if (self->packages_removed)
     {
-      if (!rpmostree_origin_delete_packages (origin, self->packages_removed,
-                                             cancellable, error))
+      if (!rpmostree_origin_remove_packages (origin, self->packages_removed, error))
         return FALSE;
 
       /* in reality, there may not be any new layer required (if e.g. we're
@@ -585,8 +584,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
 
   if (self->packages_added)
     {
-      if (!rpmostree_origin_add_packages (origin, self->packages_added,
-                                          FALSE, cancellable, error))
+      if (!rpmostree_origin_add_packages (origin, self->packages_added, FALSE, error))
         return FALSE;
 
       changed = TRUE;
@@ -615,8 +613,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
       if (pkgs->len > 0)
         {
           g_ptr_array_add (pkgs, NULL);
-          if (!rpmostree_origin_add_packages (origin, (char**)pkgs->pdata,
-                                              TRUE, cancellable, error))
+          if (!rpmostree_origin_add_packages (origin, (char**)pkgs->pdata, TRUE, error))
             return FALSE;
         }
 

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -388,7 +388,6 @@ gboolean
 rpmostree_origin_add_packages (RpmOstreeOrigin   *origin,
                                char             **packages,
                                gboolean           local,
-                               GCancellable      *cancellable,
                                GError           **error)
 {
   gboolean changed = FALSE;
@@ -443,9 +442,8 @@ rpmostree_origin_add_packages (RpmOstreeOrigin   *origin,
 }
 
 gboolean
-rpmostree_origin_delete_packages (RpmOstreeOrigin  *origin,
+rpmostree_origin_remove_packages (RpmOstreeOrigin  *origin,
                                   char            **packages,
-                                  GCancellable     *cancellable,
                                   GError          **error)
 {
   gboolean changed = FALSE;

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -107,13 +107,11 @@ gboolean
 rpmostree_origin_add_packages (RpmOstreeOrigin   *origin,
                                char             **packages,
                                gboolean           local,
-                               GCancellable      *cancellable,
                                GError           **error);
 
 gboolean
-rpmostree_origin_delete_packages (RpmOstreeOrigin  *origin,
+rpmostree_origin_remove_packages (RpmOstreeOrigin  *origin,
                                   char            **packages,
-                                  GCancellable     *cancellable,
                                   GError          **error);
 
 void


### PR DESCRIPTION
1. There's no point in passing a GCancellable in those cases. All the
   manipulations should be short-lived.
2. Rename delete_packages to remove_packages, since "remove" is the
   proper antonym of "add".

Split out of #797.