### PR TITLE
 upgrader: Add user-inaccessible private dir for rootfs checkouts

### DIFF
--- a/src/daemon/rpmostree-sysroot-core.h
+++ b/src/daemon/rpmostree-sysroot-core.h
@@ -24,8 +24,12 @@
 
 /* Used by the upgrader to hold a strong ref temporarily to a base commit */
 #define RPMOSTREE_TMP_BASE_REF "rpmostree/base/tmp"
+/* Diretory that is defined to have 0700 mode always, used for checkouts */
+#define RPMOSTREE_TMP_PRIVATE_DIR "extensions/rpmostree/private"
 /* Where we check out a new rootfs */
-#define RPMOSTREE_TMP_ROOTFS_DIR "extensions/rpmostree/commit"
+#define RPMOSTREE_TMP_ROOTFS_DIR RPMOSTREE_TMP_PRIVATE_DIR "/commit"
+/* The legacy dir, which we will just delete if we find it */
+#define RPMOSTREE_OLD_TMP_ROOTFS_DIR "extensions/rpmostree/commit"
 
 gboolean
 rpmostree_syscore_cleanup (OstreeSysroot            *sysroot,

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -35,9 +35,6 @@
 
 #include "ostree-repo.h"
 
-#define RPMOSTREE_TMP_BASE_REF "rpmostree/base/tmp"
-#define RPMOSTREE_TMP_ROOTFS_DIR "extensions/rpmostree/commit"
-
 /**
  * SECTION:rpmostree-sysroot-upgrader
  * @title: Simple upgrade class


### PR DESCRIPTION
This is part of the saga of permissions and checkouts that
came about thinking about flatpak, but suid and world-writable dirs
are also an issue for us.

There's no reason to make suid binaries accessible temporarily
to users while we're computing a new root.  Similarly, we don't
want anyone to actually *write* to our temporary `/tmp`.  The
simple fix is to make an intermediate dir that's `0700`.

See: ostreedev/ostree#909