### PR TITLE
core: don't use rpmfiles if missing

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -26,6 +26,30 @@ artifacts:
 
 inherit: true
 
+context: c7-build
+
+required: true
+
+container:
+  image: registry.centos.org/centos/centos:7
+
+extra-repos:
+  - name: atomic-centos-continuous
+    baseurl: https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/build
+    gpgcheck: 0
+
+# XXX: integrate better with ci/ scripts
+tests:
+  - yum-builddep -y rpm-ostree
+  - yum install -y make
+  - source ci/libbuild.sh && build
+
+timeout: 15m
+
+---
+
+inherit: true
+
 context: vmcheck
 
 required: true

--- a/configure.ac
+++ b/configure.ac
@@ -77,6 +77,12 @@ AC_SEARCH_LIBS([rpmsqSetInterruptSafety], [rpmio],
   AC_DEFINE([BUILDOPT_HAVE_RPMSQ_SET_INTERRUPT_SAFETY], 0, [Set to 1 if we have interrupt safety API])
 )
 
+# rpmfiles was made public in rpm >= 4.12, el7 is still on 4.11
+AC_SEARCH_LIBS([rpmfilesNew], [rpm],
+  AC_DEFINE([BUILDOPT_HAVE_RPMFILES], 1, [Set to 1 if we have rpmfiles API]),
+  AC_DEFINE([BUILDOPT_HAVE_RPMFILES], 0, [Set to 1 if we have rpmfiles API])
+)
+
 # Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 >= 2.40.0 json-glib-1.0

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -187,7 +187,9 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
        * on watching the path property, trying a connection, and re-reading the value
        * and only erroring out if the property hasn't changed.
        */
-      g_autoptr(RPMOSTreeTransactionProxy) txn_proxy = (RPMOSTreeTransactionProxy*)rpmostree_transaction_connect (txn_path, NULL, NULL);
+      /* gdbus-codegen started generating autocleanups from 2.50 */
+      glnx_unref_object RPMOSTreeTransactionProxy *txn_proxy =
+        (RPMOSTreeTransactionProxy*)rpmostree_transaction_connect (txn_path, NULL, NULL);
       if (txn_proxy)
         {
           const char *title = rpmostree_transaction_get_title ((RPMOSTreeTransaction*)txn_proxy);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1770,8 +1770,12 @@ delete_package_from_root (RpmOstreeContext *self,
                           GCancellable *cancellable,
                           GError      **error)
 {
+#if BUILDOPT_HAVE_RPMFILES /* use rpmfiles API if possible, rpmteFI is deprecated */
   g_auto(rpmfiles) files = rpmteFiles (pkg);
   g_auto(rpmfi) fi = rpmfilesIter (files, RPMFI_ITER_FWD);
+#else
+  rpmfi fi = rpmteFI (pkg); /* rpmfi owned by rpmte */
+#endif
 
   g_autoptr(GPtrArray) deleted_dirs = g_ptr_array_new_with_free_func (g_free);
 

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1531,7 +1531,7 @@ rpmostree_context_download (RpmOstreeContext *self,
       guint64 size =
         dnf_package_array_get_download_size (self->pkgs_to_download);
       g_autofree char *sizestr = g_format_size (size);
-      g_print ("Will download: %u package%s (%s)\n", n, n > 1 ? "s" : "", sizestr);
+      g_print ("Will download: %u package%s (%s)\n", n, _NS(n), sizestr);
     }
   else
     return TRUE;
@@ -1674,7 +1674,7 @@ rpmostree_context_import (RpmOstreeContext *self,
 
   sd_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR,
                    SD_ID128_FORMAT_VAL(RPMOSTREE_MESSAGE_PKG_IMPORT),
-                   "MESSAGE=Imported %u pkg%s", n, n > 1 ? "s" : "",
+                   "MESSAGE=Imported %u pkg%s", n, _NS(n),
                    "IMPORTED_N_PKGS=%u", n, NULL);
 
   return TRUE;
@@ -2174,8 +2174,7 @@ rpmostree_context_relabel (RpmOstreeContext *self,
   g_return_val_if_fail (ostreerepo != NULL, FALSE);
 
   glnx_unref_object DnfState *hifstate = dnf_state_new ();
-  g_autofree char *prefix = g_strdup_printf ("Relabeling %d package%s:",
-                                             n, n>1 ? "s" : "");
+  g_autofree char *prefix = g_strdup_printf ("Relabeling %d package%s:", n, _NS(n));
 
   dnf_state_set_number_steps (hifstate, self->pkgs_to_relabel->len);
   progress_sigid = g_signal_connect (hifstate, "percentage-changed",
@@ -2627,12 +2626,15 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
   }
 
   if (overrides_remove->len > 0 && overlays->len > 0)
-    rpmostree_output_task_begin ("Applying %u overrides and %u overlays",
-                                 overrides_remove->len, overlays->len);
+    rpmostree_output_task_begin ("Applying %u override%s and %u overlay%s",
+                                 overrides_remove->len, _NS(overrides_remove->len),
+                                 overlays->len, _NS(overlays->len));
   else if (overrides_remove->len > 0)
-    rpmostree_output_task_begin ("Applying %u overrides", overrides_remove->len);
+    rpmostree_output_task_begin ("Applying %u override%s", overrides_remove->len,
+                                 _NS(overrides_remove->len));
   else if (overlays->len > 0)
-    rpmostree_output_task_begin ("Applying %u overlays", overlays->len);
+    rpmostree_output_task_begin ("Applying %u overlay%s", overlays->len,
+                                 _NS(overlays->len));
   else
     g_assert_not_reached ();
 

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -68,9 +68,11 @@ rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff);
  * itself. TODO: Move them to libdnf */
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(Header, headerFree, NULL)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmfi, rpmfiFree, NULL)
-G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmfiles, rpmfilesFree, NULL)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmts, rpmtsFree, NULL)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmdbMatchIterator, rpmdbFreeIterator, NULL)
+#if BUILDOPT_HAVE_RPMFILES
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(rpmfiles, rpmfilesFree, NULL)
+#endif
 
 void
 rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff);

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -25,6 +25,9 @@
 #include <sys/wait.h>
 #include <ostree.h>
 
+#define _N(single, plural, n) ( (n) == 1 ? (single) : (plural) )
+#define _NS(n) _N("", "s", n)
+
 int
 rpmostree_ptrarray_sort_compare_strings (gconstpointer ap,
                                          gconstpointer bp);


### PR DESCRIPTION
Starting from v4.12, rpmteFI has been deprecated in favour of
rpmteFiles. Make use of it if we can, otherwise fall back to the older
API.