### PR TITLE
Add polkit 🔒 support

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -41,6 +41,7 @@ extra-repos:
 # XXX: integrate better with ci/ scripts
 tests:
   - yum-builddep -y rpm-ostree
+  - yum install -y polkit-devel
   - yum install -y make
   - source ci/libbuild.sh && build
 

--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -105,8 +105,12 @@ servicedir       = $(dbusservicedir)
 %.service: %.service.in Makefile
 	$(SED_SUBST) $@.in > $@.tmp && mv $@.tmp $@
 
+polkit_policy_DATA = $(srcdir)/src/daemon/org.projectatomic.rpmostree1.policy
+polkit_policydir = $(datadir)/polkit-1/actions
+
 EXTRA_DIST += \
 	$(dbusservice_DATA) \
+	$(polkit_policy_DATA) \
 	$(service_in_files) \
 	$(systemdunit_in_files) \
 	$(NULL)

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -23,6 +23,7 @@ install_builddeps() {
 
     # builddeps+runtime deps
     dnf builddep -y $pkg
+    dnf install -y polkit-devel
     dnf install -y $pkg
     rpm -e $pkg
 }

--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,7 @@ PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 >= 2.40.0 json-glib-1.0
 				     ostree-1 >= 2017.4
 				     libsystemd
+				     polkit-gobject-1
 				     rpm librepo
 				     libarchive])
 dnl bundled libdnf

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -21,6 +21,7 @@ BuildRequires: pkgconfig(json-glib-1.0)
 BuildRequires: pkgconfig(rpm)
 BuildRequires: pkgconfig(libarchive)
 BuildRequires: pkgconfig(libsystemd)
+BuildRequires: pkgconfig(polkit-gobject-1)
 BuildRequires: libcap-devel
 BuildRequires: libattr-devel
 
@@ -115,7 +116,8 @@ python autofiles.py > files \
   '%{_sysconfdir}/dbus-1/system.d/*' \
   '%{_prefix}/lib/systemd/system/*' \
   '%{_libexecdir}/rpm-ostree*' \
-  '%{_datadir}/dbus-1/system-services'
+  '%{_datadir}/dbus-1/system-services' \
+  '%{_datadir}/polkit-1/actions/org.projectatomic.rpmostree1.policy'
 python autofiles.py > files.devel \
   '%{_libdir}/lib*.so' \
   '%{_includedir}/*' \

--- a/src/daemon/org.projectatomic.rpmostree1.conf
+++ b/src/daemon/org.projectatomic.rpmostree1.conf
@@ -10,11 +10,15 @@
     <allow send_destination="org.projectatomic.rpmostree1"/>
   </policy>
 
+  <!-- Allow anyone to call into the service - we'll reject callers using PolicyKit -->
   <policy context="default">
     <deny send_destination="org.projectatomic.rpmostree1"/>
 
     <allow send_destination="org.projectatomic.rpmostree1"
            send_interface="org.freedesktop.DBus.Introspectable"/>
+
+    <allow send_destination="org.projectatomic.rpmostree1"
+           send_interface="org.freedesktop.DBus.ObjectManager"/>
 
     <allow send_destination="org.projectatomic.rpmostree1"
            send_interface="org.freedesktop.DBus.Peer"/>
@@ -26,6 +30,9 @@
     <allow send_destination="org.projectatomic.rpmostree1"
            send_interface="org.freedesktop.DBus.Properties"
            send_member="GetAll"/>
+
+    <allow send_destination="org.projectatomic.rpmostree1"
+           send_interface="org.projectatomic.rpmostree1.OS"/>
 
     <allow send_destination="org.projectatomic.rpmostree1"
            send_interface="org.projectatomic.rpmostree1.Sysroot"

--- a/src/daemon/org.projectatomic.rpmostree1.policy
+++ b/src/daemon/org.projectatomic.rpmostree1.policy
@@ -8,9 +8,20 @@
   <vendor_url>https://www.projectatomic.io/</vendor_url>
   <icon_name>package-x-generic</icon_name>
 
-  <action id="org.projectatomic.rpmostree1.package-install-uninstall">
+  <action id="org.projectatomic.rpmostree1.install-uninstall-packages">
     <description>Install and remove packages</description>
     <message>Authentication is required to install and remove software</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.projectatomic.rpmostree1.install-local-packages">
+    <description>Install local packages</description>
+    <message>Authentication is required to install software</message>
     <icon_name>package-x-generic</icon_name>
     <defaults>
       <allow_any>auth_admin</allow_any>
@@ -37,7 +48,7 @@
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
-      <allow_active>yes</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
 
@@ -48,7 +59,7 @@
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
-      <allow_active>yes</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
 
@@ -59,7 +70,7 @@
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
-      <allow_active>yes</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
 
@@ -70,7 +81,7 @@
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
-      <allow_active>yes</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
 
@@ -81,7 +92,7 @@
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>
-      <allow_active>yes</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
 </policyconfig>

--- a/src/daemon/org.projectatomic.rpmostree1.policy
+++ b/src/daemon/org.projectatomic.rpmostree1.policy
@@ -30,9 +30,9 @@
     </defaults>
   </action>
 
-  <action id="org.projectatomic.rpmostree1.rebase">
-    <description>Switch to a different base OS</description>
-    <message>Authentication is required to switch to a different base OS</message>
+  <action id="org.projectatomic.rpmostree1.deploy">
+    <description>Update base OS</description>
+    <message>Authentication is required to update software</message>
     <icon_name>package-x-generic</icon_name>
     <defaults>
       <allow_any>auth_admin</allow_any>
@@ -44,6 +44,17 @@
   <action id="org.projectatomic.rpmostree1.upgrade">
     <description>Update base OS</description>
     <message>Authentication is required to update software</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.projectatomic.rpmostree1.rebase">
+    <description>Switch to a different base OS</description>
+    <message>Authentication is required to switch to a different base OS</message>
     <icon_name>package-x-generic</icon_name>
     <defaults>
       <allow_any>auth_admin</allow_any>

--- a/src/daemon/org.projectatomic.rpmostree1.policy
+++ b/src/daemon/org.projectatomic.rpmostree1.policy
@@ -85,9 +85,9 @@
     </defaults>
   </action>
 
-  <action id="org.projectatomic.rpmostree1.set-initramfs-state">
-    <description>Set initramfs state</description>
-    <message>Authentication is required to enable or disable local initramfs generation</message>
+  <action id="org.projectatomic.rpmostree1.bootconfig">
+    <description>Change boot configuration</description>
+    <message>Authentication is required to change boot configuration</message>
     <icon_name>package-x-generic</icon_name>
     <defaults>
       <allow_any>auth_admin</allow_any>

--- a/src/daemon/org.projectatomic.rpmostree1.policy
+++ b/src/daemon/org.projectatomic.rpmostree1.policy
@@ -30,6 +30,17 @@
     </defaults>
   </action>
 
+  <action id="org.projectatomic.rpmostree1.override">
+    <description>Override packages</description>
+    <message>Authentication is required to override base OS software</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
   <action id="org.projectatomic.rpmostree1.deploy">
     <description>Update base OS</description>
     <message>Authentication is required to update software</message>

--- a/src/daemon/org.projectatomic.rpmostree1.policy
+++ b/src/daemon/org.projectatomic.rpmostree1.policy
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+
+  <vendor>Project Atomic</vendor>
+  <vendor_url>https://www.projectatomic.io/</vendor_url>
+  <icon_name>package-x-generic</icon_name>
+
+  <action id="org.projectatomic.rpmostree1.package-install-uninstall">
+    <description>Install and remove packages</description>
+    <message>Authentication is required to install and remove software</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.projectatomic.rpmostree1.rebase">
+    <description>Switch to a different base OS</description>
+    <message>Authentication is required to switch to a different base OS</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.projectatomic.rpmostree1.upgrade">
+    <description>Update base OS</description>
+    <message>Authentication is required to update software</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.projectatomic.rpmostree1.rollback">
+    <description>Rollback OS updates</description>
+    <message>Authentication is required to roll back software updates</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.projectatomic.rpmostree1.set-initramfs-state">
+    <description>Set initramfs state</description>
+    <message>Authentication is required to enable or disable local initramfs generation</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.projectatomic.rpmostree1.cleanup">
+    <description>Clear cache</description>
+    <message>Authentication is required to clear cache / pending data</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.projectatomic.rpmostree1.repo-refresh">
+    <description>Refresh repository metadata</description>
+    <message>Authentication is required to check available updates</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+</policyconfig>

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -170,6 +170,8 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
                                      G_VARIANT_TYPE("ah"));
       gboolean no_pull_base =
         vardict_lookup_bool (&options_dict, "no-pull-base", FALSE);
+      gboolean no_overrides =
+        vardict_lookup_bool (&options_dict, "no-overrides", FALSE);
 
       if (refspec != NULL)
         g_ptr_array_add (actions, "org.projectatomic.rpmostree1.rebase");
@@ -185,7 +187,8 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
         g_ptr_array_add (actions, "org.projectatomic.rpmostree1.install-local-packages");
 
       if (override_replace_pkgs != NULL || override_remove_pkgs != NULL || override_reset_pkgs != NULL ||
-          (override_replace_local_pkgs != NULL && g_variant_n_children (override_replace_local_pkgs) > 0))
+          (override_replace_local_pkgs != NULL && g_variant_n_children (override_replace_local_pkgs) > 0) ||
+          no_overrides)
         g_ptr_array_add (actions, "org.projectatomic.rpmostree1.override");
     }
 

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -44,6 +44,7 @@ struct _RpmostreedOS
   RPMOSTreeOSSkeleton parent_instance;
   PolkitAuthority *authority;
   RpmostreedTransactionMonitor *transaction_monitor;
+  gboolean on_session_bus;
   guint signal_id;
 };
 
@@ -95,13 +96,22 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
   g_autoptr(GPtrArray) actions = g_ptr_array_new ();
   gboolean authorized = FALSE;
 
-  if (g_strcmp0 (method_name, "GetDeploymentsRpmDiff") == 0 ||
-      g_strcmp0 (method_name, "GetCachedDeployRpmDiff") == 0 ||
-      g_strcmp0 (method_name, "DownloadDeployRpmDiff") == 0 ||
-      g_strcmp0 (method_name, "GetCachedUpdateRpmDiff") == 0 ||
-      g_strcmp0 (method_name, "DownloadUpdateRpmDiff") == 0 ||
-      g_strcmp0 (method_name, "GetCachedRebaseRpmDiff") == 0 ||
-      g_strcmp0 (method_name, "DownloadRebaseRpmDiff") == 0)
+  if (self->on_session_bus)
+    {
+      /* This is test code, make sure it never runs with privileges */
+      g_assert (geteuid () != 0);
+      g_assert (getuid () != 0);
+      g_assert (getegid () != 0);
+      g_assert (getgid () != 0);
+      authorized = TRUE;
+    }
+  else if (g_strcmp0 (method_name, "GetDeploymentsRpmDiff") == 0 ||
+           g_strcmp0 (method_name, "GetCachedDeployRpmDiff") == 0 ||
+           g_strcmp0 (method_name, "DownloadDeployRpmDiff") == 0 ||
+           g_strcmp0 (method_name, "GetCachedUpdateRpmDiff") == 0 ||
+           g_strcmp0 (method_name, "DownloadUpdateRpmDiff") == 0 ||
+           g_strcmp0 (method_name, "GetCachedRebaseRpmDiff") == 0 ||
+           g_strcmp0 (method_name, "DownloadRebaseRpmDiff") == 0)
     {
       g_ptr_array_add (actions, "org.projectatomic.rpmostree1.repo-refresh");
     }
@@ -232,13 +242,7 @@ static void
 os_constructed (GObject *object)
 {
   RpmostreedOS *self = RPMOSTREED_OS (object);
-  g_autoptr(GError) error = NULL;
 
-  self->authority = polkit_authority_get_sync (NULL, &error);
-  if (self->authority == NULL)
-    {
-      errx (1, "Can't get polkit authority: %s", error->message);
-    }
   self->signal_id = g_signal_connect (rpmostreed_sysroot_get (),
                                       "updated",
                                       G_CALLBACK (sysroot_changed), self);
@@ -1495,6 +1499,20 @@ rpmostreed_os_new (OstreeSysroot *sysroot,
 
   /* FIXME Make this a construct-only property? */
   obj->transaction_monitor = g_object_ref (monitor);
+
+  if (g_getenv ("RPMOSTREE_USE_SESSION_BUS") != NULL)
+    obj->on_session_bus = TRUE;
+
+  /* Only use polkit when running as root on system bus; self-tests don't need it */
+  if (!obj->on_session_bus)
+    {
+      g_autoptr(GError) local_error = NULL;
+      obj->authority = polkit_authority_get_sync (NULL, &local_error);
+      if (obj->authority == NULL)
+        {
+          errx (1, "Can't get polkit authority: %s", local_error->message);
+        }
+    }
 
   /* FIXME - use GInitable */
   { g_autoptr(GError) local_error = NULL;

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -156,8 +156,17 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
         vardict_lookup_ptr (&modifiers_dict, "install-packages", "^a&s");
       g_autofree char **uninstall_pkgs =
         vardict_lookup_ptr (&modifiers_dict, "uninstall-packages", "^a&s");
+      g_autofree const char *const *override_replace_pkgs =
+        vardict_lookup_ptr (&modifiers_dict, "override-replace-packages", "^a&s");
+      g_autofree const char *const *override_remove_pkgs =
+        vardict_lookup_ptr (&modifiers_dict, "override-remove-packages", "^a&s");
+      g_autofree const char *const *override_reset_pkgs =
+        vardict_lookup_ptr (&modifiers_dict, "override-reset-packages", "^a&s");
       g_autoptr(GVariant) install_local_pkgs =
         g_variant_dict_lookup_value (&modifiers_dict, "install-local-packages",
+                                     G_VARIANT_TYPE("ah"));
+      g_autoptr(GVariant) override_replace_local_pkgs =
+        g_variant_dict_lookup_value (&modifiers_dict, "override-replace-local-packages",
                                      G_VARIANT_TYPE("ah"));
       gboolean no_pull_base =
         vardict_lookup_bool (&options_dict, "no-pull-base", FALSE);
@@ -174,6 +183,10 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
 
       if (install_local_pkgs != NULL && g_variant_n_children (install_local_pkgs) > 0)
         g_ptr_array_add (actions, "org.projectatomic.rpmostree1.install-local-packages");
+
+      if (override_replace_pkgs != NULL || override_remove_pkgs != NULL || override_reset_pkgs != NULL ||
+          (override_replace_local_pkgs != NULL && g_variant_n_children (override_replace_local_pkgs) > 0))
+        g_ptr_array_add (actions, "org.projectatomic.rpmostree1.override");
     }
 
   for (guint i = 0; i < actions->len; i++)

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -98,11 +98,7 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
 
   if (self->on_session_bus)
     {
-      /* This is test code, make sure it never runs with privileges */
-      g_assert (geteuid () != 0);
-      g_assert (getuid () != 0);
-      g_assert (getegid () != 0);
-      g_assert (getgid () != 0);
+      /* The daemon is on the session bus, running self tests */
       authorized = TRUE;
     }
   else if (g_strcmp0 (method_name, "GetDeploymentsRpmDiff") == 0 ||

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -125,7 +125,7 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
     }
   else if (g_strcmp0 (method_name, "SetInitramfsState") == 0)
     {
-      g_ptr_array_add (actions, "org.projectatomic.rpmostree1.set-initramfs-state");
+      g_ptr_array_add (actions, "org.projectatomic.rpmostree1.bootconfig");
     }
   else if (g_strcmp0 (method_name, "Cleanup") == 0)
     {
@@ -190,6 +190,10 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
           (override_replace_local_pkgs != NULL && g_variant_n_children (override_replace_local_pkgs) > 0) ||
           no_overrides)
         g_ptr_array_add (actions, "org.projectatomic.rpmostree1.override");
+    }
+  else
+    {
+      authorized = FALSE;
     }
 
   for (guint i = 0; i < actions->len; i++)


### PR DESCRIPTION
Here's my very first try on contributing to rpm-ostree; please let me know if I should do anything differently.

This pull request adds polkit support to org.projectatomic.rpmostree1.OS interface which so far has been completely locked down to root-only. We need this for landing the gnome-software rpm-ostree backend where gnome-software runs as a regular user.

Not sure how granular the individual polkit actions should be. I tried to keep them roughly matching in granularity with what PackageKit and flatpak are already doing, except for one exception: package install and uninstall.

I lumped install and uninstall together under one action here because the rpm-ostree DBus API allows doing them in one transaction. The main reason why they were separate for PackageKit and flatpak was to allow wheel group users to install apps without popping up a polkit dialog, but at the same time we wanted to require auth for uninstall. I think since we're going for an app / base OS split in rpm-ostree based Fedora Workstation, it should be fine to support auth-less app install only with flatpak and require auth for the rpm-ostree layer app install, but if needed we should be able to easily change this in the future.

Comments welcome!