### PR TITLE
postprocess: stronger handling for sepolicy in /var

### DIFF
--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -592,7 +592,8 @@ postprocess_selinux_policy_store_location (int rootfs_dfd,
     return TRUE;
 
   var_policy_location = glnx_strjoina ("var/lib/selinux/", name);
-  if (fstatat (rootfs_dfd, var_policy_location, &stbuf, 0) != 0)
+  const char *modules_location = glnx_strjoina (var_policy_location, "/active/modules");
+  if (fstatat (rootfs_dfd, modules_location, &stbuf, 0) != 0)
     {
       if (errno != ENOENT)
         return glnx_throw_errno_prefix (error, "fstat(%s)", modules_location);

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -595,10 +595,7 @@ postprocess_selinux_policy_store_location (int rootfs_dfd,
   if (fstatat (rootfs_dfd, var_policy_location, &stbuf, 0) != 0)
     {
       if (errno != ENOENT)
-        {
-          glnx_set_error_from_errno (error);
-          return FALSE;
-        }
+        return glnx_throw_errno_prefix (error, "fstat(%s)", modules_location);
 
       /* Okay, this is probably CentOS 7, or maybe we have a build of
        * selinux-policy with the path moved back into /etc (or maybe it's
@@ -615,28 +612,19 @@ postprocess_selinux_policy_store_location (int rootfs_dfd,
     orig_contents = glnx_file_get_contents_utf8_at (rootfs_dfd, semanage_path, NULL,
                                                     cancellable, error);
     if (orig_contents == NULL)
-      {
-        g_prefix_error (error, "Opening %s: ", semanage_path);
-        return FALSE;
-      }
+      return glnx_prefix_error (error, "Opening %s:", semanage_path);
 
     contents = g_strconcat (orig_contents, "\nstore-root=/etc/selinux\n", NULL);
 
     if (!glnx_file_replace_contents_at (rootfs_dfd, semanage_path,
                                         (guint8*)contents, -1, 0,
                                         cancellable, error))
-      {
-        g_prefix_error (error, "Replacing %s: ", semanage_path);
-        return FALSE;
-      }
+      return glnx_prefix_error (error, "Replacing %s:", semanage_path);
   }
 
   etc_policy_location = glnx_strjoina ("etc/selinux/", name);
   if (!glnx_opendirat (rootfs_dfd, etc_policy_location, TRUE, &etc_selinux_dfd, error))
-    {
-      g_prefix_error (error, "Opening %s: ", etc_policy_location);
-      return FALSE;
-    }
+    return glnx_prefix_error (error, "Opening %s:", etc_policy_location);
 
   if (!glnx_dirfd_iterator_init_at (rootfs_dfd, var_policy_location, TRUE, &dfd_iter, error))
     return FALSE;


### PR DESCRIPTION
We shouldn't just check that the "targeted" dir exists, but rather that
the actual directory where the modules are stored exists. This fixes a
regression on RHEL in which the new selinux-policy-targeted lists some
%ghost files under /var/lib/selinux and as a result think that the
policy is in /var.