### PR TITLE
libglnx: bump for GLNX_HASH_TABLE_FOREACH macros

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1054,16 +1054,8 @@ rpmostree_compose_builtin_tree (int             argc,
 
   /* Convert metadata hash to GVariant */
   { g_autoptr(GVariantBuilder) metadata_builder = g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
-    gpointer key, value;
-    GHashTableIter viter;
-
-    g_hash_table_iter_init (&viter, metadata_hash);
-    while (g_hash_table_iter_next (&viter, &key, &value))
-      {
-        const char *strkey = key;
-        GVariant *v = value;
-        g_variant_builder_add (metadata_builder, "{sv}", strkey, v);
-      }
+    GLNX_HASH_TABLE_FOREACH_KV (metadata_hash, const char*, strkey, GVariant*, v)
+      g_variant_builder_add (metadata_builder, "{sv}", strkey, v);
 
     metadata = g_variant_ref_sink (g_variant_builder_end (metadata_builder));
     /* Canonicalize to big endian, like OSTree does. Without this, any numbers

--- a/src/daemon/rpmostree-sysroot-core.c
+++ b/src/daemon/rpmostree-sysroot-core.c
@@ -71,17 +71,8 @@ generate_baselayer_refs (OstreeSysroot            *sysroot,
     goto out;
 
   /* delete all the refs */
-  {
-    GHashTableIter it;
-    gpointer key;
-
-    g_hash_table_iter_init (&it, refs);
-    while (g_hash_table_iter_next (&it, &key, NULL))
-      {
-        const char *ref = key;
-        ostree_repo_transaction_set_refspec (repo, ref, NULL);
-      }
-  }
+  GLNX_HASH_TABLE_FOREACH (refs, const char*, ref)
+    ostree_repo_transaction_set_refspec (repo, ref, NULL);
 
   /* collect the csums */
   {
@@ -107,13 +98,8 @@ generate_baselayer_refs (OstreeSysroot            *sysroot,
   /* create the new refs */
   {
     guint i = 0;
-    GHashTableIter it;
-    gpointer key;
-
-    g_hash_table_iter_init (&it, bases);
-    while (g_hash_table_iter_next (&it, &key, NULL))
+    GLNX_HASH_TABLE_FOREACH (bases, const char*, base)
       {
-        const char *base = key;
         g_autofree char *ref = g_strdup_printf ("rpmostree/base/%u", i++);
         ostree_repo_transaction_set_refspec (repo, ref, base);
       }
@@ -176,8 +162,6 @@ clean_pkgcache_orphans (OstreeSysroot            *sysroot,
   g_autoptr(GHashTable) current_refs = NULL;
   g_autoptr(GHashTable) referenced_pkgs = /* cache refs of packages we want to keep */
     g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
-  GHashTableIter hiter;
-  gpointer hkey, hvalue;
   gint n_objects_total;
   gint n_objects_pruned;
   guint64 freed_space;
@@ -222,10 +206,8 @@ clean_pkgcache_orphans (OstreeSysroot            *sysroot,
                                   cancellable, error))
     return FALSE;
 
-  g_hash_table_iter_init (&hiter, current_refs);
-  while (g_hash_table_iter_next (&hiter, &hkey, &hvalue))
+  GLNX_HASH_TABLE_FOREACH (current_refs, const char*, ref)
     {
-      const char *ref = hkey;
       if (g_hash_table_contains (referenced_pkgs, ref))
         continue;
 

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -449,9 +449,6 @@ sysroot_populate_deployments_unlocked (RpmostreedSysroot *self,
   g_autofree gchar *booted_id = NULL;
   g_autoptr(GPtrArray) deployments = NULL;
   g_autoptr(GHashTable) seen_osnames = NULL;
-  GHashTableIter iter;
-  gpointer hashkey;
-  gpointer value;
   GVariantBuilder builder;
   guint i;
   gboolean sysroot_changed;
@@ -538,15 +535,14 @@ sysroot_populate_deployments_unlocked (RpmostreedSysroot *self,
     }
 
   /* Remove dead os paths */
-  g_hash_table_iter_init (&iter, self->os_interfaces);
-  while (g_hash_table_iter_next (&iter, &hashkey, &value))
+  GLNX_HASH_TABLE_FOREACH_IT (self->os_interfaces, it, const char*, k, GObject*, v)
     {
-      if (!g_hash_table_contains (seen_osnames, hashkey))
+      if (!g_hash_table_contains (seen_osnames, k))
         {
-          g_object_run_dispose (G_OBJECT (value));
-          g_hash_table_iter_remove (&iter);
+          g_object_run_dispose (G_OBJECT (v));
+          g_hash_table_iter_remove (&it);
 
-          g_hash_table_remove (self->osexperimental_interfaces, hashkey);
+          g_hash_table_remove (self->osexperimental_interfaces, k);
         }
     }
 
@@ -646,10 +642,7 @@ sysroot_dispose (GObject *object)
     }
 
   /* Tracked os paths are responsible to unpublish themselves */
-  GHashTableIter iter;
-  g_hash_table_iter_init (&iter, self->os_interfaces);
-  gpointer key, value;
-  while (g_hash_table_iter_next (&iter, &key, &value))
+  GLNX_HASH_TABLE_FOREACH_KV (self->os_interfaces, const char*, k, GObject*, value)
     g_object_run_dispose (value);
   g_hash_table_remove_all (self->os_interfaces);
   g_hash_table_remove_all (self->osexperimental_interfaces);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -802,8 +802,6 @@ rpmostree_pkgcache_find_pkg_header (OstreeRepo    *pkgcache,
 {
   g_autoptr(GVariant) header = NULL;
   g_autoptr(GHashTable) refs = NULL;
-  GHashTableIter it;
-  gpointer k;
 
   /* there's no safe way to convert a nevra string to its
    * cache branch, so let's just do a dumb lookup */
@@ -813,12 +811,9 @@ rpmostree_pkgcache_find_pkg_header (OstreeRepo    *pkgcache,
                                   error))
     return FALSE;
 
-  g_hash_table_iter_init (&it, refs);
-  while (g_hash_table_iter_next (&it, &k, NULL))
+  GLNX_HASH_TABLE_FOREACH (refs, const char*, ref)
     {
-      const char *ref = k;
       g_autofree char *cache_nevra = rpmostree_cache_branch_to_nevra (ref);
-
       if (!g_str_equal (nevra, cache_nevra))
         continue;
 
@@ -1537,16 +1532,10 @@ rpmostree_context_download (RpmOstreeContext *self,
     return TRUE;
 
   { guint progress_sigid;
-    GHashTableIter hiter;
-    gpointer key, value;
     g_autoptr(GHashTable) source_to_packages = gather_source_to_packages (self);
-
-    g_hash_table_iter_init (&hiter, source_to_packages);
-    while (g_hash_table_iter_next (&hiter, &key, &value))
+    GLNX_HASH_TABLE_FOREACH_KV (source_to_packages, DnfRepo*, src, GPtrArray*, src_packages)
       {
         g_autofree char *target_dir = NULL;
-        DnfRepo *src = key;
-        GPtrArray *src_packages = value;
         glnx_unref_object DnfState *hifstate = dnf_state_new ();
 
         g_autofree char *prefix

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -376,16 +376,10 @@ update_keyfile_pkgs_from_cache (RpmOstreeOrigin *origin,
 
   if (has_csum)
     {
-      GHashTableIter it;
-      gpointer k, v;
-
       g_autoptr(GPtrArray) pkg_csum =
         g_ptr_array_new_with_free_func (g_free);
-
-      g_hash_table_iter_init (&it, pkgs);
-      while (g_hash_table_iter_next (&it, &k, &v))
+      GLNX_HASH_TABLE_FOREACH_KV (pkgs, const char*, k, const char*, v)
         g_ptr_array_add (pkg_csum, g_strconcat (v, ":", k, NULL));
-
       g_key_file_set_string_list (origin->kf, group, key,
                                   (const char *const*)pkg_csum->pdata,
                                   pkg_csum->len);


### PR DESCRIPTION
Example of what the new macros look like when applied on a whole
codebase. It definitely feels much nicer to work with!

Update submodule: libglnx

Requires: https://github.com/GNOME/libglnx/pull/55