### PR TITLE
daemon: Log caller uid

### DIFF
--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -31,7 +31,7 @@ GType              rpmostreed_daemon_get_type       (void) G_GNUC_CONST;
 RpmostreedDaemon * rpmostreed_daemon_get            (void);
 void               rpmostreed_daemon_add_client     (RpmostreedDaemon *self, const char *client);
 void               rpmostreed_daemon_remove_client  (RpmostreedDaemon *self, const char *client);
-gboolean           rpmostreed_daemon_has_client     (RpmostreedDaemon *self, const char *client);
+char *             rpmostreed_daemon_client_get_string  (RpmostreedDaemon *self, const char *client);
 void               rpmostreed_daemon_exit_now       (RpmostreedDaemon *self);
 void               rpmostreed_daemon_run_until_idle_exit (RpmostreedDaemon *self);
 void               rpmostreed_daemon_publish        (RpmostreedDaemon *self,


### PR DESCRIPTION
This is an extension to the previous change to distingush between
"caller" and "client".  Now for clients we log the uid (both
in the message and structured).

This is a natural followon from the polkit work, since now different
uids can invoke us.
