### PR TITLE
daemon: Install dbus introspection files

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -108,7 +108,11 @@ servicedir       = $(dbusservicedir)
 polkit_policy_DATA = $(srcdir)/src/daemon/org.projectatomic.rpmostree1.policy
 polkit_policydir = $(datadir)/polkit-1/actions
 
+dbus_introspection_DATA = src/daemon/org.projectatomic.rpmostree1.xml
+dbus_introspectiondir = $(datadir)/dbus-1/interfaces
+
 EXTRA_DIST += \
+	$(dbus_introspection_DATA) \
 	$(dbusservice_DATA) \
 	$(polkit_policy_DATA) \
 	$(service_in_files) \


### PR DESCRIPTION
This makes it possible to use the dbus introspection files in other apps
without having to bundle them.