### PR TITLE
 lib/scripts: Handle script interpreters

### DIFF
--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -235,43 +235,37 @@ run_known_rpm_script (const KnownRpmScriptKind *rpmscript,
                       GCancellable  *cancellable,
                       GError       **error)
 {
-  const char *desc = rpmscript->desc;
   rpmTagVal tagval = rpmscript->tag;
   rpmTagVal progtagval = rpmscript->progtag;
-  const char *script;
-  g_autofree char **args = NULL;
-  RpmOstreeScriptAction action;
-  struct rpmtd_s td;
 
   if (!(headerIsEntry (hdr, tagval) || headerIsEntry (hdr, progtagval)))
     return TRUE;
 
-  script = headerGetString (hdr, tagval);
+  const char *script = headerGetString (hdr, tagval);
   if (!script)
     return TRUE;
 
+  struct rpmtd_s td;
+  g_autofree char **args = NULL;
   if (headerGet (hdr, progtagval, &td, (HEADERGET_ALLOC|HEADERGET_ARGV)))
     args = td.data;
 
-  action = lookup_script_action (pkg, ignore_scripts, desc);
+  const char *desc = rpmscript->desc;
+  RpmOstreeScriptAction action = lookup_script_action (pkg, ignore_scripts, desc);
   switch (action)
     {
     case RPMOSTREE_SCRIPT_ACTION_DEFAULT:
       {
-        static const char lua[] = "<lua>";
-        if (args && args[0] && strcmp (args[0], lua) == 0)
-          {
-            g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                         "Package '%s' has (currently) unsupported %s script in '%s'",
-                         dnf_package_get_name (pkg), lua, desc);
-            return FALSE;
-          }
+        const char *argv0 = args && args[0] ? args[0] : "/bin/sh";
+
+        static const char lua_builtin[] = "<lua>";
+        if (g_strcmp0 (argv0, lua_builtin) == 0)
+          return glnx_throw (error, "Package '%s' has (currently) unsupported %s script in '%s'",
+                             dnf_package_get_name (pkg), lua_builtin, desc);
+
         if (!run_script_in_bwrap_container (rootfs_fd, dnf_package_get_name (pkg), desc, script,
                                             cancellable, error))
-          {
-            g_prefix_error (error, "Running %s for %s: ", desc, dnf_package_get_name (pkg));
-            return FALSE;
-          }
+          return glnx_prefix_error (error, "Running %s for %s", desc, dnf_package_get_name (pkg));
         break;
       }
     case RPMOSTREE_SCRIPT_ACTION_IGNORE:

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -377,7 +377,7 @@ Summary: %{name}
 License: GPLv2+
 EOF
 
-    local build= install= files= pretrans= pre= post= posttrans=
+    local build= install= files= pretrans= pre= post= posttrans= post_interp=
     while [ $# -ne 0 ]; do
         local section=$1; shift
         local arg=$1; shift
@@ -388,6 +388,8 @@ EOF
             echo "Provides: $arg" >> $spec;;
         conflicts)
             echo "Conflicts: $arg" >> $spec;;
+        post_interp)
+            post_interp="$arg"; post="$1"; shift;;
         version|release|arch|build|install|files|pretrans|pre|post|posttrans)
             declare $section="$arg";;
         *)
@@ -415,7 +417,7 @@ $pretrans
 ${pre:+%pre}
 $pre
 
-${post:+%post}
+${post:+%post} ${post_interp:+-p ${post_interp}}
 $post
 
 ${posttrans:+%posttrans}

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -32,6 +32,7 @@ vm_build_rpm scriptpkg1 \
   pre "groupadd -r scriptpkg1" \
   pretrans "# http://lists.rpm.org/pipermail/rpm-ecosystem/2016-August/000391.html
             echo i should've been ignored && exit 1" \
+  post_interp /usr/bin/python 'open("/usr/lib/rpmostreetestinterp", "w")' \
   posttrans "# Firewalld; https://github.com/projectatomic/rpm-ostree/issues/638
              . /etc/os-release || :
              # See https://github.com/projectatomic/rpm-ostree/pull/647
@@ -58,6 +59,9 @@ echo "ok no embarrassing crud leftover"
 # let's check that the group was successfully added
 vm_cmd getent group scriptpkg1
 echo "ok group scriptpkg1 active"
+
+vm_has_files "/usr/lib/rpmostreetestinterp"
+echo "ok interp"
 
 # And now, things that should fail
 vm_build_rpm rofiles-violation \


### PR DESCRIPTION

Seen in the wild with `vagrant`'s use of `%post -p /usr/bin/ruby`. This was a
very easy fix, and actually makes the code a little bit nicer, as we no longer
need to explicitly make the script executable, since we now pass it as
`argv[1]`, the same way librpm does. That in turn would make it possible to fix
the TODO and use `bwrap --file`, but that can come later.

Closes: projectatomic#856