### PR TITLE
ci: start testing on F26

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -52,7 +52,7 @@ timeout: 15m
 
 inherit: true
 
-context: vmcheck
+context: f25-vmcheck
 
 required: true
 
@@ -80,12 +80,21 @@ timeout: 80m
 
 ---
 
+branches:
+  - master
+  - auto
+  - try
+
 # NB: when bumping 25 here, also bump fedora.repo, compose script, and
 # fedora-base.json
 
-context: compose
+context: f25-compose
+
 build: false
+
 timeout: 30m
+
+required: true
 
 # This test case wants an "unprivileged container with bubblewrap",
 # which we don't have right now; so just provision a VM and do a

--- a/.papr.yml
+++ b/.papr.yml
@@ -87,6 +87,9 @@ cluster:
 env:
   HOSTS: vmcheck1 vmcheck2 vmcheck3
 
+packages:
+  - rsync
+
 tests:
   - ./ci/build.sh
   - make vmcheck

--- a/.papr.yml
+++ b/.papr.yml
@@ -116,6 +116,13 @@ cluster:
 env:
   HOSTS: vmcheck
 
+tests:
+  # updates-source mirrors are being flaky
+  - sed -i '/metalink=.*updates-released-source.*/ d' /etc/yum.repos.d/fedora-updates.repo
+  - sed -i '/SRPMS/ s/^#baseurl/baseurl/' /etc/yum.repos.d/fedora-updates.repo
+  - ./ci/build.sh
+  - make vmcheck
+
 ---
 
 branches:

--- a/.papr.yml
+++ b/.papr.yml
@@ -27,6 +27,17 @@ artifacts:
 
 inherit: true
 
+context: f26-build-check
+
+required: false
+
+container:
+    image: registry.fedoraproject.org/fedora:26
+
+---
+
+inherit: true
+
 context: c7-build
 
 required: true
@@ -67,9 +78,12 @@ cluster:
   container:
     image: registry.fedoraproject.org/fedora:25
 
+env:
+  HOSTS: vmcheck1 vmcheck2 vmcheck3
+
 tests:
   - ./ci/build.sh
-  - make vmcheck HOSTS="vmcheck1 vmcheck2 vmcheck3"
+  - make vmcheck
 
 artifacts:
   - vmcheck
@@ -77,6 +91,23 @@ artifacts:
 # We really need to work on getting this down:
 # https://github.com/projectatomic/rpm-ostree/issues/662
 timeout: 80m
+
+---
+
+inherit: true
+
+context: f26-vmcheck
+
+required: false
+
+cluster:
+  hosts:
+    - name: vmcheck
+      distro: fedora/26/atomic
+  container:
+    image: registry.fedoraproject.org/fedora:26
+
+env:
 
 ---
 

--- a/.papr.yml
+++ b/.papr.yml
@@ -108,6 +108,7 @@ cluster:
     image: registry.fedoraproject.org/fedora:26
 
 env:
+  HOSTS: vmcheck
 
 ---
 

--- a/.papr.yml
+++ b/.papr.yml
@@ -34,6 +34,12 @@ required: false
 container:
     image: registry.fedoraproject.org/fedora:26
 
+tests:
+  # updates-source mirrors are being flaky
+  - sed -i '/metalink=.*updates-released-source.*/ d' /etc/yum.repos.d/fedora-updates.repo
+  - sed -i '/SRPMS/ s/^#baseurl/baseurl/' /etc/yum.repos.d/fedora-updates.repo
+  - ci/build-check.sh
+
 ---
 
 inherit: true

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -67,7 +67,7 @@ check-local:
 vmsync:
 	@env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/sync.sh
 
-HOSTS := "vmcheck"
+HOSTS ?= "vmcheck"
 
 vmoverlay:
 	@if [ -z "$(SKIP_VMOVERLAY)" ]; then \


### PR DESCRIPTION
Now that PAPR has support for pre-release images of Fedora Atomic Host
26, let's start testing there. We mark it as not required for the time
being.