### PR TITLE
core: only update repos enabled for packages

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -925,7 +925,7 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
 {
   g_assert (!self->empty);
 
-  g_autoptr(GPtrArray) rpmmd_repos = get_enabled_rpmmd_repos (self->hifctx, DNF_REPO_ENABLED_METADATA);
+  g_autoptr(GPtrArray) rpmmd_repos = get_enabled_rpmmd_repos (self->hifctx, DNF_REPO_ENABLED_PACKAGES);
 
   g_print ("Enabled rpm-md repositories:");
   for (guint i = 0; i < rpmmd_repos->len; i++)


### PR DESCRIPTION
We don't care about repos enabled only for `METADATA`. This works around
an interesting libdnf behaviour in which all repos in `redhat.repo` are
enabled for metadata, even if disabled.

Downstream RHBZ: #1468302