### PR TITLE
tests: Support older versions of rsync

### DIFF
--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -31,11 +31,12 @@ if test -z "${INSIDE_VM:-}"; then
        for pkg in ostree{,-libs,-grub2}; do
           rpm -q $pkg
           # We do not have perms to read /etc/grub2 as non-root
-          rpm -ql $pkg |grep -v '^/etc/'>  list.txt
+          rpm -ql $pkg | grep -v '^/etc/' | sed "s/^/+ /" >  list.txt
+          echo "- *" >> list.txt
           # In the prebuilt container case, manpages are missing.  Ignore that.
           # Also chown everything to writable, due to https://bugzilla.redhat.com/show_bug.cgi?id=517575
           chmod -R u+w ${DESTDIR}/
-          rsync -l --ignore-missing-args --files-from=list.txt / ${DESTDIR}/
+          rsync -l --include-from=list.txt / ${DESTDIR}/
           rm -f list.txt
        done
        make install DESTDIR=${DESTDIR}

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -36,6 +36,9 @@ if test -z "${INSIDE_VM:-}"; then
           # In the prebuilt container case, manpages are missing.  Ignore that.
           # Also chown everything to writable, due to https://bugzilla.redhat.com/show_bug.cgi?id=517575
           chmod -R u+w ${DESTDIR}/
+          # The --ignore-missing-args option was added in rsync 3.1.0,
+          # but CentOS7 only has rsync 3.0.9.  Can simulate the behavior
+          # with --include-from and the way we constructed list.txt.
           rsync -l --include-from=list.txt / ${DESTDIR}/
           rm -f list.txt
        done

--- a/tests/vmcheck/sync.sh
+++ b/tests/vmcheck/sync.sh
@@ -23,11 +23,12 @@ if test -z "${INSIDE_VM:-}"; then
     for pkg in ostree{,-libs,-grub2}; do
        rpm -q $pkg
        # We do not have perms to read /etc/grub2 as non-root
-       rpm -ql $pkg |grep -v '^/etc/'>  list.txt
+       rpm -ql $pkg | grep -v '^/etc/' | sed "s/^/+ /" >  list.txt
+       echo "- *" >> list.txt
        # In the prebuilt container case, manpages are missing.  Ignore that.
        # Also chown everything to writable, due to https://bugzilla.redhat.com/show_bug.cgi?id=517575
        chmod -R u+w ${VMCHECK_INSTTREE}/
-       rsync -l --ignore-missing-args --files-from=list.txt / ${VMCHECK_INSTTREE}/
+       rsync -l --include-from=list.txt / ${VMCHECK_INSTTREE}/
        rm -f list.txt
     done
 

--- a/tests/vmcheck/sync.sh
+++ b/tests/vmcheck/sync.sh
@@ -28,6 +28,9 @@ if test -z "${INSIDE_VM:-}"; then
        # In the prebuilt container case, manpages are missing.  Ignore that.
        # Also chown everything to writable, due to https://bugzilla.redhat.com/show_bug.cgi?id=517575
        chmod -R u+w ${VMCHECK_INSTTREE}/
+       # The --ignore-missing-args option was added in rsync 3.1.0,
+       # but CentOS7 only has rsync 3.0.9.  Can simulate the behavior
+       # with --include-from and the way we constructed list.txt.
        rsync -l --include-from=list.txt / ${VMCHECK_INSTTREE}/
        rm -f list.txt
     done


### PR DESCRIPTION
Older versions of rsync (< 3.1) lack an `--ignore-missing-args` option.
Use [this workaround](https://stackoverflow.com/questions/43391493/rsync-simulate-ignore-missing-args-on-old-server-version) to allow `make vmsync` to work on CentOS 7.

@jlebon I'm still trying to get my container+vagrant environment set up, so can you double check the tests pass with this?