### PR TITLE
 scripts: Honor the -e flag for scripts

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -176,7 +176,6 @@ rpmostree_treespec_new_from_keyfile (GKeyFile   *keyfile,
       add_canonicalized_string_array (&builder, "repos", NULL, keyfile);
   }
   add_canonicalized_string_array (&builder, "instlangs", "instlangs-all", keyfile);
-  add_canonicalized_string_array (&builder, "ignore-scripts", NULL, keyfile);
 
   { gboolean documentation = TRUE;
     g_autofree char *value = g_key_file_get_value (keyfile, "tree", "documentation", NULL);
@@ -618,12 +617,8 @@ rpmostree_context_setup (RpmOstreeContext    *self,
   }
 
   /* We could likely delete this, but I'm keeping a log message just in case */
-  const char *const *ignore_scripts = NULL;
-  if (g_variant_dict_lookup (self->spec->dict, "ignore-scripts", "^a&s", &ignore_scripts))
-    {
-      if (ignore_scripts && *ignore_scripts)
-        sd_journal_print (LOG_INFO, "ignore-scripts is no longer supported");
-    }
+  if (g_variant_dict_contains (self->spec->dict, "ignore-scripts"))
+    sd_journal_print (LOG_INFO, "ignore-scripts is no longer supported");
 
   return TRUE;
 }

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -236,7 +236,6 @@ struct _RpmOstreeContext {
   RpmOstreeTreespec *spec;
   gboolean empty;
   DnfContext *hifctx;
-  GHashTable *ignore_scripts;
   OstreeRepo *ostreerepo;
   OstreeRepo *pkgcache_repo;
   gboolean unprivileged;
@@ -263,8 +262,6 @@ rpmostree_context_finalize (GObject *object)
 
   g_clear_object (&rctx->spec);
   g_clear_object (&rctx->hifctx);
-
-  g_clear_pointer (&rctx->ignore_scripts, g_hash_table_unref);
 
   g_clear_object (&rctx->pkgcache_repo);
   g_clear_object (&rctx->ostreerepo);
@@ -478,15 +475,6 @@ rpmostree_context_set_passwd_dir (RpmOstreeContext *self,
   self->passwd_dir = g_strdup (passwd_dir);
 }
 
-void
-rpmostree_context_set_ignore_scripts (RpmOstreeContext *self,
-                                      GHashTable   *ignore_scripts)
-{
-  g_clear_pointer (&self->ignore_scripts, g_hash_table_unref);
-  if (ignore_scripts)
-    self->ignore_scripts = g_hash_table_ref (ignore_scripts);
-}
-
 DnfContext *
 rpmostree_context_get_hif (RpmOstreeContext *self)
 {
@@ -629,16 +617,13 @@ rpmostree_context_setup (RpmOstreeContext    *self,
                                    DNF_TRANSACTION_FLAG_NODOCS);
   }
 
-  { const char *const *ignore_scripts = NULL;
-    if (g_variant_dict_lookup (self->spec->dict, "ignore-scripts", "^a&s", &ignore_scripts))
-      {
-        g_autoptr(GHashTable) ignore_hash = NULL;
-
-        if (!rpmostree_script_ignore_hash_from_strv (ignore_scripts, &ignore_hash, error))
-          return FALSE;
-        rpmostree_context_set_ignore_scripts (self, ignore_hash);
-      }
-  }
+  /* We could likely delete this, but I'm keeping a log message just in case */
+  const char *const *ignore_scripts = NULL;
+  if (g_variant_dict_lookup (self->spec->dict, "ignore-scripts", "^a&s", &ignore_scripts))
+    {
+      if (ignore_scripts && *ignore_scripts)
+        sd_journal_print (LOG_INFO, "ignore-scripts is no longer supported");
+    }
 
   return TRUE;
 }
@@ -2409,7 +2394,6 @@ rpmts_add_install (RpmOstreeContext *self,
                    DnfPackage *pkg,
                    gboolean is_upgrade,
                    gboolean noscripts,
-                   GHashTable *ignore_scripts,
                    GCancellable *cancellable,
                    GError **error)
 {
@@ -2421,7 +2405,7 @@ rpmts_add_install (RpmOstreeContext *self,
 
   if (!noscripts)
     {
-      if (!rpmostree_script_txn_validate (pkg, hdr, ignore_scripts, cancellable, error))
+      if (!rpmostree_script_txn_validate (pkg, hdr, cancellable, error))
         return FALSE;
     }
 
@@ -2464,7 +2448,7 @@ run_posttrans_sync (RpmOstreeContext *self,
   if (!get_package_metainfo (self, path, &hdr, NULL, error))
     return FALSE;
 
-  if (!rpmostree_posttrans_run_sync (pkg, hdr, self->ignore_scripts, rootfs_dfd,
+  if (!rpmostree_posttrans_run_sync (pkg, hdr, rootfs_dfd,
                                      cancellable, error))
     return FALSE;
 
@@ -2484,8 +2468,7 @@ run_pre_sync (RpmOstreeContext *self,
   if (!get_package_metainfo (self, path, &hdr, NULL, error))
     return FALSE;
 
-  if (!rpmostree_pre_run_sync (pkg, hdr, self->ignore_scripts,
-                               rootfs_dfd, cancellable, error))
+  if (!rpmostree_pre_run_sync (pkg, hdr, rootfs_dfd, cancellable, error))
     return FALSE;
 
   return TRUE;
@@ -2700,7 +2683,7 @@ add_install (RpmOstreeContext *self,
   if (!checkout_pkg_metadata_by_dnfpkg (self, pkg, cancellable, error))
     return FALSE;
 
-  if (!rpmts_add_install (self, ts, pkg, is_upgrade, noscripts, self->ignore_scripts,
+  if (!rpmts_add_install (self, ts, pkg, is_upgrade, noscripts,
                           cancellable, error))
     return FALSE;
 
@@ -3040,7 +3023,7 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
       DnfPackage *pkg = overlays->pdata[i];
 
       /* Set noscripts since we already validated them above */
-      if (!rpmts_add_install (self, rpmdb_ts, pkg, FALSE, TRUE, NULL, cancellable, error))
+      if (!rpmts_add_install (self, rpmdb_ts, pkg, FALSE, TRUE, cancellable, error))
         return FALSE;
     }
 
@@ -3049,7 +3032,7 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
       DnfPackage *pkg = overrides_replace->pdata[i];
 
       /* Set noscripts since we already validated them above */
-      if (!rpmts_add_install (self, rpmdb_ts, pkg, TRUE, TRUE, NULL, cancellable, error))
+      if (!rpmts_add_install (self, rpmdb_ts, pkg, TRUE, TRUE, cancellable, error))
         return FALSE;
     }
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -72,8 +72,6 @@ void rpmostree_context_set_sepolicy (RpmOstreeContext *self,
                                      OstreeSePolicy   *sepolicy);
 void rpmostree_context_set_passwd_dir (RpmOstreeContext *self,
                                        const char *passwd_dir);
-void rpmostree_context_set_ignore_scripts (RpmOstreeContext *self,
-                                           GHashTable   *ignore_scripts);
 
 void rpmostree_dnf_add_checksum_goal (GChecksum *checksum, HyGoal goal);
 char *rpmostree_context_get_state_sha512 (RpmOstreeContext *self);

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -243,7 +243,7 @@ impl_run_rpm_script (const KnownRpmScriptKind *rpmscript,
   if (headerGet (hdr, rpmscript->progtag, &td, (HEADERGET_ALLOC|HEADERGET_ARGV)))
     args = td.data;
 
-  const char *interp = args && args[0] ? args[0] : "/bin/sh";
+  const char *interp = (args && args[0]) ? args[0] : "/bin/sh";
   /* Check for lua; see also https://github.com/projectatomic/rpm-ostree/issues/749 */
   static const char lua_builtin[] = "<lua>";
   if (g_strcmp0 (interp, lua_builtin) == 0)

--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -45,21 +45,15 @@ struct RpmOstreePackageScriptHandler {
 
 const struct RpmOstreePackageScriptHandler* rpmostree_script_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
-gboolean rpmostree_script_ignore_hash_from_strv (const char *const *strv,
-                                                 GHashTable **out_hash,
-                                                 GError **error);
-
 gboolean
 rpmostree_script_txn_validate (DnfPackage    *package,
                                Header         hdr,
-                               GHashTable    *ignore_scripts,
                                GCancellable  *cancellable,
                                GError       **error);
 
 gboolean
 rpmostree_posttrans_run_sync (DnfPackage    *pkg,
                               Header         hdr,
-                              GHashTable    *ignore_scripts,
                               int            rootfs_fd,
                               GCancellable  *cancellable,
                               GError       **error);
@@ -67,7 +61,6 @@ rpmostree_posttrans_run_sync (DnfPackage    *pkg,
 gboolean
 rpmostree_pre_run_sync (DnfPackage    *pkg,
                         Header         hdr,
-                        GHashTable    *ignore_scripts,
                         int            rootfs_fd,
                         GCancellable  *cancellable,
                         GError       **error);

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -377,7 +377,7 @@ Summary: %{name}
 License: GPLv2+
 EOF
 
-    local build= install= files= pretrans= pre= post= posttrans= post_interp=
+    local build= install= files= pretrans= pre= post= posttrans= post_args=
     while [ $# -ne 0 ]; do
         local section=$1; shift
         local arg=$1; shift
@@ -388,8 +388,8 @@ EOF
             echo "Provides: $arg" >> $spec;;
         conflicts)
             echo "Conflicts: $arg" >> $spec;;
-        post_interp)
-            post_interp="$arg"; post="$1"; shift;;
+        post_args)
+            post_args="$arg"; post="$1"; shift;;
         version|release|arch|build|install|files|pretrans|pre|post|posttrans)
             declare $section="$arg";;
         *)
@@ -417,7 +417,7 @@ $pretrans
 ${pre:+%pre}
 $pre
 
-${post:+%post} ${post_interp:+-p ${post_interp}}
+${post:+%post} ${post_args}
 $post
 
 ${posttrans:+%posttrans}

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -389,7 +389,7 @@ EOF
         conflicts)
             echo "Conflicts: $arg" >> $spec;;
         post_args)
-            post_args="$arg"; post="$1"; shift;;
+            post_args="$arg";;
         version|release|arch|build|install|files|pretrans|pre|post|posttrans)
             declare $section="$arg";;
         *)

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -32,7 +32,8 @@ vm_build_rpm scriptpkg1 \
   pre "groupadd -r scriptpkg1" \
   pretrans "# http://lists.rpm.org/pipermail/rpm-ecosystem/2016-August/000391.html
             echo i should've been ignored && exit 1" \
-  post_args "-p /usr/bin/python" 'open("/usr/lib/rpmostreetestinterp", "w")' \
+  post_args "-p /usr/bin/python" \
+  post 'open("/usr/lib/rpmostreetestinterp", "w")' \
   posttrans "# Firewalld; https://github.com/projectatomic/rpm-ostree/issues/638
              . /etc/os-release || :
              # See https://github.com/projectatomic/rpm-ostree/pull/647
@@ -64,7 +65,8 @@ vm_has_files "/usr/lib/rpmostreetestinterp"
 echo "ok interp"
 
 vm_build_rpm scriptpkg2 \
-             post_args "-e" 'echo %%{_prefix} > /usr/lib/prefixtest.txt'
+             post_args "-e" \
+             post 'echo %%{_prefix} > /usr/lib/prefixtest.txt'
 vm_build_rpm scriptpkg3 \
              post 'echo %%{_prefix} > /usr/lib/noprefixtest.txt'
 vm_rpmostree pkg-add scriptpkg{2,3}


### PR DESCRIPTION

This is required for glibc-all-langpacks at least:
https://bugzilla.redhat.com/show_bug.cgi?id=1367585

Otherwise, its usage is...extraordinarily rare. In fact looking at a snapshot of
`rpm-specs-20170518.tar.xz` from Fedora, the only other use is in
`postfix.spec`, and it appears bogus (the value is already expanded at build
time).

But the glibc case is special, as the value of `install_langs` is indeed
potentially dynamic per system.

