### PR TITLE
daemon: Avoid "Updating from: (null)" message

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -213,9 +213,12 @@ package_diff_transaction_execute (RpmostreedTransaction *transaction,
 
   rpmostree_sysroot_upgrader_set_origin (upgrader, origin);
 
-  rpmostreed_transaction_emit_message_printf (transaction,
-                                              "Updating from: %s",
-                                              self->refspec);
+  if (self->refspec != NULL)
+    {
+      rpmostreed_transaction_emit_message_printf (transaction,
+                                                  "Updating from: %s",
+                                                  self->refspec);
+    }
 
   gboolean changed = FALSE;
   if (!rpmostree_sysroot_upgrader_pull (upgrader,


### PR DESCRIPTION
Check for a `NULL` refspec before emitting message in `package_diff_transaction_execute()`.

Addresses just a trivial piece of https://github.com/projectatomic/rpm-ostree/issues/864.