### PR TITLE
lib: Expose new API around basearch

### DIFF
--- a/Makefile-lib.am
+++ b/Makefile-lib.am
@@ -25,6 +25,7 @@ librpmostreeincludedir = $(includedir)/rpm-ostree-1
 librpmostreeinclude_HEADERS = $(librpmostree_public_headers)
 
 librpmostree_1_la_SOURCES = \
+	src/lib/rpmostree.c \
 	src/lib/rpmostree-db.c \
 	src/lib/rpmostree-package.c \
 	$(NULL)

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -11,7 +11,7 @@ AM_TESTS_ENVIRONMENT = \
 # we consume libdnf as a submodule, but we may not have installed it yet (and we
 # don't want it to fall back to the system libhif if it's also installed)
 AM_TESTS_ENVIRONMENT += \
-	LD_LIBRARY_PATH=$(abs_builddir)/libdnf-build/libdnf \
+	LD_LIBRARY_PATH=$(abs_builddir)/libdnf-build/libdnf:$$(cd $(top_builddir)/.libs && pwd)$${LD_LIBRARY_PATH:+:$${LD_LIBRARY_PATH}} \
 	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH} \
 	$(NULL)
 if BUILDOPT_ASAN

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -12,6 +12,7 @@ AM_TESTS_ENVIRONMENT = \
 # don't want it to fall back to the system libhif if it's also installed)
 AM_TESTS_ENVIRONMENT += \
 	LD_LIBRARY_PATH=$(abs_builddir)/libdnf-build/libdnf \
+	GI_TYPELIB_PATH=$$(cd $(top_builddir) && pwd)$${GI_TYPELIB_PATH:+:$$GI_TYPELIB_PATH} \
 	$(NULL)
 if BUILDOPT_ASAN
 AM_TESTS_ENVIRONMENT += ASAN_OPTIONS=detect_leaks=false

--- a/api-doc/rpmostree-sections.txt
+++ b/api-doc/rpmostree-sections.txt
@@ -1,4 +1,10 @@
 <SECTION>
+<FILE>librpmostree-core</FILE>
+rpm_ostree_get_basearch
+rpm_ostree_varsubst_basearch
+</SECTION>
+
+<SECTION>
 <FILE>librpmostree-dbquery</FILE>
 rpm_ostree_db_query
 </SECTION>

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -21,7 +21,7 @@ install_builddeps rpm-ostree
 
 # Mostly dependencies for tests
 yum install -y ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML clang \
-    libubsan libasan libtsan elfutils fuse sudo python3-gobject-base
+    libubsan libasan libtsan elfutils fuse sudo python-gobject-base
 
 # create an unprivileged user for testing
 adduser testuser

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -19,8 +19,9 @@ fi
 
 install_builddeps rpm-ostree
 
+# Mostly dependencies for tests
 yum install -y ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML clang \
-    libubsan libasan libtsan elfutils fuse sudo
+    libubsan libasan libtsan elfutils fuse sudo python3-gobject-base
 
 # create an unprivileged user for testing
 adduser testuser

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -19,6 +19,7 @@ fi
 
 install_builddeps rpm-ostree
 
+yum install -y /usr/bin/g-ir-scanner # Accidentally omitted
 # Mostly dependencies for tests
 yum install -y ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML clang \
     libubsan libasan libtsan elfutils fuse sudo python-gobject-base

--- a/configure.ac
+++ b/configure.ac
@@ -203,6 +203,7 @@ echo "
 
     nts name:	        $enable_new_name
     compose tooling:	$enable_compose_tooling
+    introspection:      $found_introspection
     bubblewrap:         $with_bubblewrap
     gtk-doc:            $enable_gtk_doc
 "

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -783,7 +783,7 @@ rpmostree_compose_builtin_tree (int             argc,
   if (!corectx)
     goto out;
 
-  varsubsts = rpmostree_context_get_varsubsts (corectx);
+  varsubsts = rpmostree_dnfcontext_get_varsubsts (rpmostree_context_get_hif (corectx));
 
   treefile_parser = json_parser_new ();
   if (!json_parser_load_from_file (treefile_parser,

--- a/src/lib/rpmostree.c
+++ b/src/lib/rpmostree.c
@@ -1,0 +1,64 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Colin Walters <walters@verbum.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "config.h"
+
+#include "string.h"
+
+#include "rpmostree.h"
+#include "rpmostree-core.h"
+#include "rpmostree-util.h"
+
+/**
+ * SECTION:librpmostree
+ * @title: Global high level APIs
+ * @short_description: APIs for accessing global state
+ *
+ * These APIs access generic global state.
+ */
+
+/**
+ * rpm_ostree_get_basearch:
+ *
+ * Returns: A string for RPM's architecture, commonly used for e.g. $basearch in URLs
+ * Since: 2017.8
+ */
+char *
+rpm_ostree_get_basearch (void)
+{
+  g_autoptr(DnfContext) ctx = dnf_context_new ();
+  /* Need to strdup since we unref the context */
+  return g_strdup (dnf_context_get_base_arch (ctx));
+}
+
+/**
+ * rpm_ostree_varsubst_basearch:
+ * @src: String (commonly a URL)
+ *
+ * Returns: A copy of @src with all references for `${basearch}` replaced with `rpmostree_get_basearch()`, or %NULL on error
+ * Since: 2017.8
+ */
+char *
+rpm_ostree_varsubst_basearch (const char *src, GError **error)
+{
+  g_autoptr(DnfContext) ctx = dnf_context_new ();
+  g_autoptr(GHashTable) varsubsts = rpmostree_dnfcontext_get_varsubsts (ctx);
+  return _rpmostree_varsubst_string (src, varsubsts, error);
+}

--- a/src/lib/rpmostree.h
+++ b/src/lib/rpmostree.h
@@ -26,3 +26,13 @@
 
 #include <rpmostree-db.h>
 #include <rpmostree-package.h>
+
+G_BEGIN_DECLS
+
+_RPMOSTREE_EXTERN
+char *rpm_ostree_get_basearch (void);
+
+_RPMOSTREE_EXTERN
+char *rpm_ostree_varsubst_basearch (const char *src, GError **error);
+
+G_END_DECLS

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -481,11 +481,11 @@ rpmostree_context_get_hif (RpmOstreeContext *self)
 }
 
 GHashTable *
-rpmostree_context_get_varsubsts (RpmOstreeContext *context)
+rpmostree_dnfcontext_get_varsubsts (DnfContext *context)
 {
   GHashTable *r = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 
-  g_hash_table_insert (r, g_strdup ("basearch"), g_strdup (dnf_context_get_base_arch (context->hifctx)));
+  g_hash_table_insert (r, g_strdup ("basearch"), g_strdup (dnf_context_get_base_arch (context)));
 
   return r;
 }

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -51,7 +51,7 @@ RpmOstreeTreespec *rpmostree_treespec_new_from_keyfile (GKeyFile *keyfile, GErro
 RpmOstreeTreespec *rpmostree_treespec_new_from_path (const char *path, GError  **error);
 RpmOstreeTreespec *rpmostree_treespec_new (GVariant   *variant);
 
-GHashTable *rpmostree_context_get_varsubsts (RpmOstreeContext *context);
+GHashTable *rpmostree_dnfcontext_get_varsubsts (DnfContext *context);
 
 GVariant *rpmostree_treespec_to_variant (RpmOstreeTreespec *spec);
 const char *rpmostree_treespec_get_ref (RpmOstreeTreespec *spec);

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -24,7 +24,7 @@ export RPMOSTREE_SUPPRESS_REQUIRES_ROOT_CHECK=yes
 
 ensure_dbus
 
-echo "1..21"
+echo "1..22"
 
 setup_os_repository "archive-z2" "syslinux"
 
@@ -181,3 +181,16 @@ if rpm-ostree nosuchcommand --nosuchoption 2>err.txt; then
 fi
 assert_file_has_content err.txt 'Unknown.*command'
 echo "ok error on unknown command"
+
+cat >rpmostree-gi.py <<EOF
+import gi
+gi.require_version("RpmOstree", "1.0")
+from gi.repository import RpmOstree
+assert RpmOstree.get_basearch() == 'x86_64'
+assert RpmOstree.varsubst_basearch('http://example.com/foo/\${basearch}/bar') == 'http://example.com/foo/x86_64/bar'
+EOF
+case $(arch) in
+    x86_64) env GI_TYPELIB_PATH=$(pwd) python rpmostree-gi.py;;
+    *) echo "Skipping RPM architecture test on $(arch)"
+esac
+echo "ok rpmostree arch"

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -182,15 +182,17 @@ fi
 assert_file_has_content err.txt 'Unknown.*command'
 echo "ok error on unknown command"
 
-cat >rpmostree-gi.py <<EOF
+cat >test-rpmostree-gi <<EOF
+#!/usr/bin/python3
 import gi
 gi.require_version("RpmOstree", "1.0")
 from gi.repository import RpmOstree
 assert RpmOstree.get_basearch() == 'x86_64'
 assert RpmOstree.varsubst_basearch('http://example.com/foo/\${basearch}/bar') == 'http://example.com/foo/x86_64/bar'
 EOF
+chmod a+x test-rpmostree-gi
 case $(arch) in
-    x86_64) env GI_TYPELIB_PATH=$(pwd) python rpmostree-gi.py;;
+    x86_64) ./test-rpmostree-gi;;
     *) echo "Skipping RPM architecture test on $(arch)"
 esac
 echo "ok rpmostree arch"

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -183,7 +183,7 @@ assert_file_has_content err.txt 'Unknown.*command'
 echo "ok error on unknown command"
 
 cat >test-rpmostree-gi <<EOF
-#!/usr/bin/python3
+#!/usr/bin/python2
 import gi
 gi.require_version("RpmOstree", "1.0")
 from gi.repository import RpmOstree


### PR DESCRIPTION

For https://pagure.io/atomic-wg/issue/299 we need to make it
more convenient to substitute the architecture in an installation
context.  I plan to use this API inside `rpmostreepayload` in Anaconda,
so we can substitute the same value of `${basearch}` we use in treefiles
since https://github.com/projectatomic/rpm-ostree/pull/305

Now, you might wonder - why do we need an API wrapping libdnf? It's because
libdnf is not API stable yet. We're just exposing a tiny subset. In theory we
could use the Python dnf bindings in Anaconda, but things get slightly weird if
rpmostreepayload depends on dnf. Perhaps we'll do that down the road, but for
now this a small API surface to maintain (forever).
