### PR TITLE
ci: stop working around updates-source mirrors

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -28,9 +28,6 @@ env:
 tests:
   - ci/ci-commitmessage-submodules.sh
   - ci/codestyle.sh
-  # updates-source mirrors are being flaky
-  - sed -i '/metalink=.*updates-released-source.*/ d' /etc/yum.repos.d/fedora-updates.repo
-  - sed -i '/SRPMS/ s/^#baseurl/baseurl/' /etc/yum.repos.d/fedora-updates.repo
   - ci/build-check.sh
   - make vmcheck
 


### PR DESCRIPTION
I initially did this because mirrors weren't stable before the F26
release. But now, the canonical source itself is unstable, so let's try
our luck again with mirrors. Might have better luck now that it's
released.