### PR TITLE
tests: Add a test case for a %post that does rm -rf /

### DIFF
--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -89,7 +89,9 @@ vm_rpmostree uninstall scriptpkg{1,2,3}
 vm_cmd 'useradd testuser || true'
 vm_cmd touch /home/testuser/somedata /tmp/sometmpfile /var/tmp/sometmpfile
 vm_build_rpm rmrf post "rm --no-preserve-root -rf / &>/dev/null || true"
-if vm_rpmostree install rmrf; then
+if vm_rpmostree install rmrf 2>err.txt; then
     assert_not_reached "rm -rf / worked?  Uh oh."
 fi
 vm_cmd test -f /home/testuser/somedata -a -f /etc/fstab -a -f /tmp/sometmpfile -a -f /var/tmp/sometmpfile
+# This is the error today, we may improve it later
+assert_file_has_content err.txt 'renameat(usr/bin/systemctl): No such file or directory'

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -83,3 +83,13 @@ vm_build_rpm rofiles-violation \
 if vm_rpmostree install rofiles-violation; then
     assert_not_reached "installed test-post-rofiles-violation!"
 fi
+
+# We really need a reset command to go back to the base layer
+vm_rpmostree uninstall scriptpkg{1,2,3}
+vm_cmd 'useradd testuser || true'
+vm_cmd touch /home/testuser/somedata /tmp/sometmpfile /var/tmp/sometmpfile
+vm_build_rpm rmrf post "rm --no-preserve-root -rf / &>/dev/null || true"
+if vm_rpmostree install rmrf; then
+    assert_not_reached "rm -rf / worked?  Uh oh."
+fi
+vm_cmd test -f /home/testuser/somedata -a -f /etc/fstab -a -f /tmp/sometmpfile -a -f /var/tmp/sometmpfile


### PR DESCRIPTION
I was thinking today about our script handling, and I realized
an excellent way to showcase the advancement rpm-ostree makes
over traditional package managers is the fact that we survive a
`%post` script that does `rm -rf /`!

See e.g. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=858521

It's been this way ever since we first implemented package layering;
the fact that we construct a new root and use bubblewrap to sandbox
makes us very resilient to this type of thing.

But, let's add a test case for this to be sure we preserve this behavior; for
example, if in the future we for some reason we decide to leak some host state
into the scripts.
