### PR TITLE
Deployment: add end-of-life

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -563,6 +563,16 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
           print_kv ("Unlocked", max_key_len, unlocked);
           g_print ("%s%s", bold_suffix, red_suffix);
         }
+      const char *end_of_life_string = NULL;
+      /* look for endoflife attribute in the deployment */
+      g_variant_dict_lookup (dict, "endoflife", "&s", &end_of_life_string);
+
+      if (end_of_life_string)
+        {
+          g_print ("%s%s", red_prefix, bold_prefix);
+          print_kv ("EndOfLife", max_key_len, end_of_life_string);
+          g_print ("%s%s", bold_suffix, red_suffix);
+        }
     }
 
   return TRUE;

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -61,13 +61,15 @@ vm_cmd runuser -u bin rpm-ostree status
 echo "ok status doesn't require active PAM session"
 
 # Add metadata string containing EnfOfLife attribtue
-META_ENDOFLIFE_MESSAGE="this_is_a_test"
+META_ENDOFLIFE_MESSAGE="this is a test for metadata message"
 commit=$(vm_cmd ostree commit -b vmcheck \
-            --tree=ref=vmcheck --add-metadata-string=ostree.endoflife=$META_ENDOFLIFE_MESSAGE)
+            --tree=ref=vmcheck --add-metadata-string=ostree.endoflife=\"${META_ENDOFLIFE_MESSAGE}\")
 vm_rpmostree upgrade
 vm_assert_status_jq ".deployments[0][\"endoflife\"] == \"${META_ENDOFLIFE_MESSAGE}\""
+echo "ok endoflife metadata gets parsed correctly"
 
 # Build a layered commit and check if EndOfLife still present
 vm_build_rpm foo
 vm_rpmostree install foo
 vm_assert_status_jq ".deployments[0][\"endoflife\"] == \"${META_ENDOFLIFE_MESSAGE}\""
+echo "ok layered commit inherits the endoflife attribute"

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -59,3 +59,15 @@ echo "ok status doesn't require root"
 # Also check that we can do status as non-root non-active
 vm_cmd runuser -u bin rpm-ostree status
 echo "ok status doesn't require active PAM session"
+
+# Add metadata string containing EnfOfLife attribtue
+META_ENDOFLIFE_MESSAGE="this_is_a_test"
+commit=$(vm_cmd ostree commit -b vmcheck \
+            --tree=ref=vmcheck --add-metadata-string=ostree.endoflife=$META_ENDOFLIFE_MESSAGE)
+vm_rpmostree upgrade
+vm_assert_status_jq ".deployments[0][\"endoflife\"] == \"${META_ENDOFLIFE_MESSAGE}\""
+
+# Build a layered commit and check if EndOfLife still present
+vm_build_rpm foo
+vm_rpmostree install foo
+vm_assert_status_jq ".deployments[0][\"endoflife\"] == \"${META_ENDOFLIFE_MESSAGE}\""


### PR DESCRIPTION
When metadata contains end-of-life attribute,
its information will be added to the deployment Variant,
which will later be shown in rpm-ostree status command
