### PR TITLE
bin/rebase: Add -b and -m options

### DIFF
--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -247,12 +247,24 @@ Boston, MA 02111-1307, USA.
           </para>
           <para>
             The full syntax is <literal>rebase REMOTENAME:BRANCHNAME</literal>.
-            Specifying just <literal>BRANCHNAME</literal> will reuse the same
-            remote. You may also omit one of <literal>REMOTENAME</literal> or
-            <literal>BRANCHNAME</literal> (keeping the colon). In the former
-            case, the branch refers to a local branch; in the latter case, the
-            same branch will be used on a different remote.
+            Alternatively, you can use the <command>--branch</command> or
+            <command>--remote</command> options mentioned below. With the
+            argument syntax, specifying just <literal>BRANCHNAME</literal> will
+            reuse the same remote. You may also omit one of
+            <literal>REMOTENAME</literal> or <literal>BRANCHNAME</literal>
+            (keeping the colon). In the former case, the branch refers to a
+            local branch; in the latter case, the same branch will be used on a
+            different remote.
           </para>
+          <para>
+            <command>--branch</command> or <command>-b</command> to
+            to pick a branch name.
+          </para>
+          <para>
+            <command>--remote</command> or <command>-m</command> to
+            to pick a remote name.
+          </para>
+
         </listitem>
       </varlistentry>
 


### PR DESCRIPTION
The rebase command syntax has confused people a lot.  Let's follow
git here and add a `-b/--branch` option and encourage people to use
that.  The case of switching remotes is `-m/--remote`; it's definitely
unfortunate that `-r` is already taken for `--reboot`.

One thing I'm a little bit unhappy about is how we're doing logic
on the client side here.  Changing the DBus API for this would
also be awkward though.

Closes: https://github.com/projectatomic/rpm-ostree/issues/886
