### PR TITLE
lib: Add version macros and version checking function

### DIFF
--- a/Makefile-lib-defines.am
+++ b/Makefile-lib-defines.am
@@ -20,6 +20,7 @@
 
 librpmostree_public_headers = \
 	src/lib/rpmostree.h \
+	src/lib/rpmostree-version.h \
 	src/lib/rpmostree-db.h \
 	src/lib/rpmostree-package.h \
 	$(NULL)

--- a/Makefile-lib.am
+++ b/Makefile-lib.am
@@ -23,7 +23,6 @@ lib_LTLIBRARIES += librpmostree-1.la
 
 librpmostreeincludedir = $(includedir)/rpm-ostree-1
 librpmostreeinclude_HEADERS = $(librpmostree_public_headers)
-GITIGNOREFILES += src/lib/rpmostree-version.h
 
 librpmostree_1_la_SOURCES = \
 	src/lib/rpmostree.c \

--- a/Makefile-lib.am
+++ b/Makefile-lib.am
@@ -23,6 +23,7 @@ lib_LTLIBRARIES += librpmostree-1.la
 
 librpmostreeincludedir = $(includedir)/rpm-ostree-1
 librpmostreeinclude_HEADERS = $(librpmostree_public_headers)
+GITIGNOREFILES += src/lib/rpmostree-version.h
 
 librpmostree_1_la_SOURCES = \
 	src/lib/rpmostree.c \

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,10 @@ dnl To do a release, increment this number, commit, then submit it as a PR
 dnl to merge via homu.  After that, do `git pull origin && git reset --hard origin/master`.
 dnl Then use https://github.com/cgwalters/git-evtag to sign.
 dnl Then, git push origin v201X.XX
-AC_INIT([rpm-ostree], [2017.7], [walters@verbum.org])
+m4_define([year_version], [2017])
+m4_define([release_version], [7])
+m4_define([package_version], [year_version.release_version])
+AC_INIT([rpm-ostree], [package_version], [atomic-devel@projectatomic.io])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])
@@ -195,6 +198,7 @@ AC_CONFIG_FILES([
 Makefile
 api-doc/Makefile
 src/lib/rpm-ostree-1.pc
+src/lib/rpmostree-version.h
 ])
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,10 @@ AC_INIT([rpm-ostree], [package_version], [atomic-devel@projectatomic.io])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])
+dnl Versioning information
+AC_SUBST([YEAR_VERSION], [year_version])
+AC_SUBST([RELEASE_VERSION], [release_version])
+AC_SUBST([PACKAGE_VERSION], [package_version])
 
 AM_INIT_AUTOMAKE([1.11 -Wno-portability foreign no-define tar-ustar no-dist-gzip dist-xz subdir-objects])
 AM_MAINTAINER_MODE([enable])

--- a/src/lib/rpmostree-version.h.in
+++ b/src/lib/rpmostree-version.h.in
@@ -1,0 +1,93 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+/**
+ * SECTION:rpm-ostree-version
+ * @short_description: Version checking
+ *
+ * Macros to check the version of the library at compile-time.
+ */
+
+/**
+ * RPM_OSTREE_YEAR_VERSION:
+ *
+ * Year version component (e.g. 2017 if %RPM_OSTREE_VERSION is 2017.2)
+ *
+ * Since: 2017.8
+ */
+#define RPM_OSTREE_YEAR_VERSION (@YEAR_VERSION@)
+
+/**
+ * RPM_OSTREE_RELEASE_VERSION:
+ *
+ * Release version component (e.g. 2 if %RPM_OSTREE_VERSION is 2017.2)
+ *
+ * Since: 2017.8
+ */
+#define RPM_OSTREE_RELEASE_VERSION (@RELEASE_VERSION@)
+
+/**
+ * RPM_OSTREE_VERSION
+ *
+ * Since: 2017.8
+ */
+#define RPM_OSTREE_VERSION (@VERSION@)
+
+/**
+ * RPM_OSTREE_VERSION_S:
+ *
+ * Version encoded as a string, useful for printing and concatenation.
+ *
+ * Since: 2017.8
+ */
+#define RPM_OSTREE_VERSION_S "@VERSION@"
+
+#define RPM_OSTREE_ENCODE_VERSION(year,release) \
+        ((year) << 16 | (release))
+
+/**
+ * RPM_OSTREE_VERSION_HEX:
+ *
+ * ostree version, encoded as an hexadecimal number, useful for
+ * integer comparisons.
+ *
+ * Since: 2017.8
+ */
+#define RPM_OSTREE_VERSION_HEX \
+        (RPM_OSTREE_ENCODE_VERSION (RPM_OSTREE_YEAR_VERSION, RPM_OSTREE_RELEASE_VERSION))
+
+/**
+ * RPM_OSTREE_CHECK_VERSION:
+ * @year: required year version
+ * @release: required release version
+ *
+ * Compile-time version checking. Evaluates to %TRUE if the version
+ * of ostree is equal or greater than the required one.
+ *
+ * Since: 2017.8
+ */
+#define RPM_OSTREE_CHECK_VERSION(year,release)   \
+        (RPM_OSTREE_YEAR_VERSION > (year) || \
+         (RPM_OSTREE_YEAR_VERSION == (year) && RPM_OSTREE_RELEASE_VERSION >= (release)))
+
+gboolean rpm_ostree_check_version (guint required_year, guint required_release);

--- a/src/lib/rpmostree-version.h.in
+++ b/src/lib/rpmostree-version.h.in
@@ -31,7 +31,7 @@
 /**
  * RPM_OSTREE_YEAR_VERSION:
  *
- * Year version component (e.g. 2017 if %RPM_OSTREE_VERSION is 2017.2)
+ * Year version component (e.g. 2017 if %RPM_OSTREE_VERSION is 2017.9)
  *
  * Since: 2017.8
  */
@@ -40,7 +40,7 @@
 /**
  * RPM_OSTREE_RELEASE_VERSION:
  *
- * Release version component (e.g. 2 if %RPM_OSTREE_VERSION is 2017.2)
+ * Release version component (e.g. 9 if %RPM_OSTREE_VERSION is 2017.9)
  *
  * Since: 2017.8
  */

--- a/src/lib/rpmostree-version.h.in
+++ b/src/lib/rpmostree-version.h.in
@@ -89,5 +89,3 @@
 #define RPM_OSTREE_CHECK_VERSION(year,release)   \
         (RPM_OSTREE_YEAR_VERSION > (year) || \
          (RPM_OSTREE_YEAR_VERSION == (year) && RPM_OSTREE_RELEASE_VERSION >= (release)))
-
-gboolean rpm_ostree_check_version (guint required_year, guint required_release);

--- a/src/lib/rpmostree.c
+++ b/src/lib/rpmostree.c
@@ -77,5 +77,5 @@ rpm_ostree_varsubst_basearch (const char *src, GError **error)
 gboolean
 rpm_ostree_check_version (guint required_year, guint required_release)
 {
-  return OSTREE_CHECK_VERSION(required_year, required_release);
+  return RPM_OSTREE_CHECK_VERSION(required_year, required_release);
 }

--- a/src/lib/rpmostree.c
+++ b/src/lib/rpmostree.c
@@ -62,3 +62,20 @@ rpm_ostree_varsubst_basearch (const char *src, GError **error)
   g_autoptr(GHashTable) varsubsts = rpmostree_dnfcontext_get_varsubsts (ctx);
   return _rpmostree_varsubst_string (src, varsubsts, error);
 }
+
+/**
+ * rpm_ostree_check_version:
+ * @required_year: Major/year required
+ * @required_release: Release version required
+ *
+ * The `RPM_OSTREE_CHECK_VERSION` macro operates at compile time, whereas
+ * this function operates at runtime.  The distinction is most useful for
+ * things that are dynamic, such as scripting language callers.
+ *
+ * Returns: %TRUE if current library has at least the requested version, %FALSE otherwise
+ */
+gboolean
+rpm_ostree_check_version (guint required_year, guint required_release)
+{
+  return OSTREE_CHECK_VERSION(required_year, required_release);
+}

--- a/src/lib/rpmostree.h
+++ b/src/lib/rpmostree.h
@@ -26,6 +26,7 @@
 
 #include <rpmostree-db.h>
 #include <rpmostree-package.h>
+#include <rpmostree-version.h>
 
 G_BEGIN_DECLS
 
@@ -34,5 +35,8 @@ char *rpm_ostree_get_basearch (void);
 
 _RPMOSTREE_EXTERN
 char *rpm_ostree_varsubst_basearch (const char *src, GError **error);
+
+_RPMOSTREE_EXTERN
+gboolean rpm_ostree_check_version (guint required_year, guint required_release);
 
 G_END_DECLS

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -24,7 +24,7 @@ export RPMOSTREE_SUPPRESS_REQUIRES_ROOT_CHECK=yes
 
 ensure_dbus
 
-echo "1..22"
+echo "1..23"
 
 setup_os_repository "archive-z2" "syslinux"
 
@@ -182,7 +182,7 @@ fi
 assert_file_has_content err.txt 'Unknown.*command'
 echo "ok error on unknown command"
 
-cat >test-rpmostree-gi <<EOF
+cat >test-rpmostree-gi-arch <<EOF
 #!/usr/bin/python2
 import gi
 gi.require_version("RpmOstree", "1.0")
@@ -190,9 +190,22 @@ from gi.repository import RpmOstree
 assert RpmOstree.get_basearch() == 'x86_64'
 assert RpmOstree.varsubst_basearch('http://example.com/foo/\${basearch}/bar') == 'http://example.com/foo/x86_64/bar'
 EOF
-chmod a+x test-rpmostree-gi
+chmod a+x test-rpmostree-gi-arch
 case $(arch) in
-    x86_64) ./test-rpmostree-gi;;
+    x86_64) ./test-rpmostree-gi-arch;;
     *) echo "Skipping RPM architecture test on $(arch)"
 esac
 echo "ok rpmostree arch"
+
+cat >test-rpmostree-gi <<EOF
+#!/usr/bin/python2
+import gi
+gi.require_version("RpmOstree", "1.0")
+from gi.repository import RpmOstree
+assert RpmOstree.check_version(2017, 6)
+# If this fails for you, please come back in a time machine and say hi
+assert not RpmOstree.check_version(3000, 1)
+EOF
+chmod a+x test-rpmostree-gi
+./test-rpmostree-gi
+echo "ok rpmostree version"


### PR DESCRIPTION
The version checking function in particular is really useful for people doing
`from gi.repository import RpmOstree`, which we'd like at least some things like
Anaconda and Pungi to do.
