### PR TITLE
daemon: Add a sanitycheck(/bin/true) before we deploy a tree

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1021,7 +1021,7 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
    * and might save someone in the future.  The RPMOSTREE_SKIP_SANITYCHECK
    * environment variable is just used by test-basic.sh currently.
    */
-  if (!self->final_revision && !getenv ("RPMOSTREE_SKIP_SANITYCHECK"))
+  if (!self->final_revision)
     {
       g_autofree char *deployment_path = ostree_sysroot_get_deployment_dirpath (self->sysroot, new_deployment);
       glnx_fd_close int deployment_dfd = -1;

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1018,9 +1018,10 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
     return FALSE;
 
   /* Also do a sanitycheck even if there's no local mutation; it's basically free
-   * and might save someone in the future.
+   * and might save someone in the future.  The RPMOSTREE_SKIP_SANITYCHECK
+   * environment variable is just used by test-basic.sh currently.
    */
-  if (!self->final_revision)
+  if (!self->final_revision && !getenv ("RPMOSTREE_SKIP_SANITYCHECK"))
     {
       g_autofree char *deployment_path = ostree_sysroot_get_deployment_dirpath (self->sysroot, new_deployment);
       glnx_fd_close int deployment_dfd = -1;

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2984,6 +2984,12 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
             return FALSE;
         }
 
+      /* We want this to be the first error message if something went wrong
+       * with a script; see https://github.com/projectatomic/rpm-ostree/pull/888
+       */
+      if (!rpmostree_deployment_sanitycheck (tmprootfs_dfd, cancellable, error))
+        return FALSE;
+
       if (have_systemctl)
         {
           if (renameat (tmprootfs_dfd, "usr/bin/systemctl.rpmostreesave",
@@ -2996,6 +3002,12 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
           if (!rpmostree_passwd_complete_rpm_layering (tmprootfs_dfd, error))
             return FALSE;
         }
+    }
+  else
+    {
+      /* Also do a sanity check even if we have no layered packages */
+      if (!rpmostree_deployment_sanitycheck (tmprootfs_dfd, cancellable, error))
+        return FALSE;
     }
 
   g_clear_pointer (&ordering_ts, rpmtsFree);

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -366,7 +366,11 @@ rpmostree_deployment_sanitycheck (int           rootfs_fd,
                                   GCancellable *cancellable,
                                   GError      **error)
 {
-  GLNX_AUTO_PREFIX_ERROR("sanitycheck", error);
+  /* Used by the test suite */
+  if (getenv ("RPMOSTREE_SKIP_SANITYCHECK"))
+    return TRUE;
+
+  GLNX_AUTO_PREFIX_ERROR ("sanitycheck", error);
   g_autoptr(RpmOstreeBwrap) bwrap =
     rpmostree_bwrap_new (rootfs_fd, RPMOSTREE_BWRAP_IMMUTABLE, error,
                          "--ro-bind", "./usr/etc", "/etc",

--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -64,3 +64,8 @@ rpmostree_pre_run_sync (DnfPackage    *pkg,
                         int            rootfs_fd,
                         GCancellable  *cancellable,
                         GError       **error);
+
+gboolean
+rpmostree_deployment_sanitycheck (int           rootfs_fd,
+                                  GCancellable *cancellable,
+                                  GError      **error);

--- a/tests/check/test-ucontainer.sh
+++ b/tests/check/test-ucontainer.sh
@@ -42,6 +42,7 @@ cat > foo.conf <<EOF
 ref=foo
 packages=foo
 repos=test-repo
+skip-sanity-check=true
 EOF
 
 rpm-ostree ex container assemble foo.conf

--- a/tests/utils/setup-session.sh
+++ b/tests/utils/setup-session.sh
@@ -61,5 +61,6 @@ EOF
 
 # Tell rpm-ostree to connect to the session bus instead of system
 export RPMOSTREE_USE_SESSION_BUS=1
+export RPMOSTREE_SKIP_SANITYCHECK=1
 
 exec dbus-run-session --config-file=${test_tmpdir}/session.conf $@

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -94,4 +94,4 @@ if vm_rpmostree install rmrf 2>err.txt; then
 fi
 vm_cmd test -f /home/testuser/somedata -a -f /etc/fstab -a -f /tmp/sometmpfile -a -f /var/tmp/sometmpfile
 # This is the error today, we may improve it later
-assert_file_has_content err.txt 'renameat(usr/bin/systemctl): No such file or directory'
+assert_file_has_content err.txt 'error: sanitycheck: Executing bwrap(/usr/bin/true)'


### PR DESCRIPTION
This is a followup to https://github.com/projectatomic/rpm-ostree/pull/888
but more comprehensive; in the layering case, the sanitycheck runs
after all the `%posttrans` scripts, so we'll get a consistent error message
for the `rm -rf /` test.

We also do the sanitycheck for the "pure ostree" case, as well as cases
where we didn't actually layer packages (including `ex override remove` as
well as simply regenerating an initrd).

There's obviously a lot more we could do in a sanitycheck; as I say in the
comment it's tempting to consider trying to boot systemd (in a fully volatile
config), but for now let's do this. In the end of course the admin has rollback
too.
