### PR TITLE
Spawn pkttyagent to allow auth on the TTY

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -50,6 +50,8 @@ rpm_ostree_SOURCES = src/app/main.c \
 	src/app/rpmostree-ex-builtin-unpack.c \
 	src/app/rpmostree-libbuiltin.c \
 	src/app/rpmostree-libbuiltin.h \
+	src/app/rpmostree-polkit-agent.c \
+	src/app/rpmostree-polkit-agent.h \
 	$(NULL)
 
 if BUILDOPT_COMPOSE_TOOLING

--- a/src/app/rpmostree-builtin-override.c
+++ b/src/app/rpmostree-builtin-override.c
@@ -24,14 +24,11 @@
 #include "rpmostree-override-builtins.h"
 
 static RpmOstreeCommand override_subcommands[] = {
-  { "replace", RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT |
-               RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+  { "replace", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
     rpmostree_override_builtin_replace },
-  { "remove", RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT |
-              RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+  { "remove", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
     rpmostree_override_builtin_remove },
-  { "reset", RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT |
-             RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+  { "reset", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
     rpmostree_override_builtin_reset },
   { NULL, 0, NULL }
 };

--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -161,16 +161,11 @@ rpmostree_load_sysroot (gchar *sysroot,
   if (sysroot_proxy == NULL)
     return FALSE;
 
-  /* This tells the daemon not to auto-exit as long as we are alive; but we can
-   * only do this as root.
-   */
-  if (getuid () == 0)
-    {
-      if (!rpmostree_sysroot_call_register_client_sync (sysroot_proxy,
-                                                        g_variant_builder_end (options_builder),
-                                                        cancellable, error))
-        return FALSE;
-    }
+  /* this tells the daemon not to auto-exit as long as we are alive */
+  if (!rpmostree_sysroot_call_register_client_sync (sysroot_proxy,
+                                                    g_variant_builder_end (options_builder),
+                                                    cancellable, error))
+    return FALSE;
 
   *out_sysroot_proxy = g_steal_pointer (&sysroot_proxy);
   *out_peer_pid = peer_pid; peer_pid = 0;

--- a/src/app/rpmostree-polkit-agent.c
+++ b/src/app/rpmostree-polkit-agent.c
@@ -1,0 +1,255 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2011 Lennart Poettering <lennart@poettering.net>
+ * Copyright (C) 2012 Matthias Klumpp <matthias@tenstral.net>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with systemd; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* snipped from PackageKit/systemd */
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/prctl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <dirent.h>
+#include <signal.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <err.h>
+#include <inttypes.h>
+#include <sys/poll.h>
+#include <sys/wait.h>
+#include <glib.h>
+
+#include "rpmostree-polkit-agent.h"
+
+#define memzero(x,l) (memset((x), 0, (l)))
+#define zero(x) (memzero(&(x), sizeof(x)))
+
+#define POLKIT_TTY_AGENT_BINARY_PATH "/usr/bin/pkttyagent"
+
+static pid_t agent_pid = 0;
+
+static int
+fork_agent (pid_t *pid, const char *path, ...)
+{
+  pid_t parent_pid, n_agent_pid;
+  int fd;
+  gboolean stdout_is_tty, stderr_is_tty;
+  unsigned n, i;
+  va_list ap;
+  char **l;
+
+  g_return_val_if_fail (pid != 0, 0);
+  g_assert (path);
+
+  parent_pid = getpid ();
+
+  /* Spawns a temporary TTY agent, making sure it goes away when
+   * we go away */
+
+  n_agent_pid = fork ();
+  if (n_agent_pid < 0)
+    return -errno;
+
+  if (n_agent_pid != 0)
+    {
+      *pid = n_agent_pid;
+      return 0;
+    }
+
+  /* In the child:
+   *
+   * Make sure the agent goes away when the parent dies */
+  if (prctl (PR_SET_PDEATHSIG, SIGTERM) < 0)
+    err (EXIT_FAILURE, "prctl");
+
+  /* Check whether our parent died before we were able
+   * to set the death signal */
+  if (getppid () != parent_pid)
+    _exit (EXIT_SUCCESS);
+
+  /* TODO: it might be more clean to close all FDs so we don't leak them to the agent */
+
+  stdout_is_tty = isatty (STDOUT_FILENO);
+  stderr_is_tty = isatty (STDERR_FILENO);
+
+  if (!stdout_is_tty || !stderr_is_tty)
+    {
+      /* Detach from stdout/stderr. and reopen
+       * /dev/tty for them. This is important to
+       * ensure that when systemctl is started via
+       * popen() or a similar call that expects to
+       * read EOF we actually do generate EOF and
+       * not delay this indefinitely by because we
+       * keep an unused copy of stdin around. */
+      fd = open("/dev/tty", O_WRONLY);
+      if (fd < 0)
+        err (EXIT_FAILURE, "Failed to open /dev/tty");
+
+      if (!stdout_is_tty)
+        dup2(fd, STDOUT_FILENO);
+
+      if (!stderr_is_tty)
+        dup2(fd, STDERR_FILENO);
+
+      if (fd > 2)
+        close(fd);
+    }
+
+  /* Count arguments */
+  va_start (ap, path);
+  for (n = 0; va_arg(ap, char*); n++)
+    ;
+  va_end(ap);
+
+  /* Allocate strv */
+  l = alloca (sizeof(char *) * (n + 1));
+
+  /* Fill in arguments */
+  va_start (ap, path);
+  for (i = 0; i <= n; i++)
+    l[i] = va_arg (ap, char*);
+  va_end (ap);
+
+  execv (path, l);
+  err (EXIT_FAILURE, "Failed to exec %s", path);
+}
+
+static int
+close_nointr (int fd)
+{
+  g_assert (fd >= 0);
+
+  for (;;)
+    {
+      int r;
+
+      r = close (fd);
+      if (r >= 0)
+        return r;
+
+      if (errno != EINTR)
+        return -errno;
+    }
+}
+
+static void
+close_nointr_nofail (int fd)
+{
+  int saved_errno = errno;
+
+  /* cannot fail, and guarantees errno is unchanged */
+
+  g_assert (close_nointr (fd) == 0);
+
+  errno = saved_errno;
+}
+
+static int
+fd_wait_for_event (int fd, int event, uint64_t t)
+{
+  struct pollfd pollfd;
+  int r;
+
+  zero(pollfd);
+  pollfd.fd = fd;
+  pollfd.events = event;
+
+  r = poll(&pollfd, 1, t == (uint64_t) -1 ? -1 : (int) (t / 1000));
+  if (r < 0)
+    return -errno;
+
+  if (r == 0)
+    return 0;
+
+  return pollfd.revents;
+}
+
+static int
+wait_for_terminate (pid_t pid)
+{
+  int status;
+  g_assert (pid >= 1);
+
+  for (;;)
+    {
+      if (waitpid(pid, &status, 0) < 0) {
+        if (errno == EINTR)
+          continue;
+        return -errno;
+      }
+      return 0;
+    }
+}
+
+int
+rpmostree_polkit_agent_open (void)
+{
+  int r;
+  int pipe_fd[2];
+  char notify_fd[10 + 1];
+
+  if (agent_pid > 0)
+    return 0;
+
+  /* We check STDIN here, not STDOUT, since this is about input,
+   * not output */
+  if (!isatty (STDIN_FILENO))
+    return 0;
+
+  if (pipe (pipe_fd) < 0)
+    return -errno;
+
+  snprintf (notify_fd, sizeof (notify_fd), "%i", pipe_fd[1]);
+  notify_fd[sizeof (notify_fd) -1] = 0;
+
+  r = fork_agent (&agent_pid,
+                  POLKIT_TTY_AGENT_BINARY_PATH,
+                  POLKIT_TTY_AGENT_BINARY_PATH,
+                  "--notify-fd", notify_fd,
+                  "--fallback", NULL);
+
+  /* Close the writing side, because that's the one for the agent */
+  close_nointr_nofail (pipe_fd[1]);
+
+  if (r < 0)
+    g_warning ("Failed to fork TTY ask password agent: %s", strerror (-r));
+  else
+    /* Wait until the agent closes the fd */
+    fd_wait_for_event (pipe_fd[0], POLLHUP, (uint64_t) -1);
+
+  close_nointr_nofail (pipe_fd[0]);
+
+  return r;
+}
+
+void
+rpmostree_polkit_agent_close (void)
+{
+
+  if (agent_pid <= 0)
+    return;
+
+  /* Inform agent that we are done */
+  kill (agent_pid, SIGTERM);
+  kill (agent_pid, SIGCONT);
+  wait_for_terminate (agent_pid);
+  agent_pid = 0;
+}

--- a/src/app/rpmostree-polkit-agent.h
+++ b/src/app/rpmostree-polkit-agent.h
@@ -1,0 +1,25 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2011 Lennart Poettering <lennart@poettering.net>
+ * Copyright (C) 2012 Matthias Klumpp <matthias@tenstral.net>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with systemd; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+int rpmostree_polkit_agent_open(void);
+void rpmostree_polkit_agent_close(void);

--- a/src/daemon/org.projectatomic.rpmostree1.conf
+++ b/src/daemon/org.projectatomic.rpmostree1.conf
@@ -35,7 +35,6 @@
            send_interface="org.projectatomic.rpmostree1.OS"/>
 
     <allow send_destination="org.projectatomic.rpmostree1"
-           send_interface="org.projectatomic.rpmostree1.Sysroot"
-           send_member="GetOS"/>
+           send_interface="org.projectatomic.rpmostree1.Sysroot"/>
   </policy>
 </busconfig>

--- a/src/daemon/org.projectatomic.rpmostree1.policy
+++ b/src/daemon/org.projectatomic.rpmostree1.policy
@@ -117,4 +117,15 @@
       <allow_active>auth_admin_keep</allow_active>
     </defaults>
   </action>
+
+  <action id="org.projectatomic.rpmostree1.client-management">
+    <description>Register and unregister as a sysroot client</description>
+    <message>Authentication is required to register as a sysroot client</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin_keep</allow_any>
+      <allow_inactive>auth_admin_keep</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
 </policyconfig>

--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -29,9 +29,15 @@
 
 GType              rpmostreed_daemon_get_type       (void) G_GNUC_CONST;
 RpmostreedDaemon * rpmostreed_daemon_get            (void);
-void               rpmostreed_daemon_add_client     (RpmostreedDaemon *self, const char *client);
-void               rpmostreed_daemon_remove_client  (RpmostreedDaemon *self, const char *client);
-char *             rpmostreed_daemon_client_get_string  (RpmostreedDaemon *self, const char *client);
+gboolean           rpmostreed_get_client_uid        (RpmostreedDaemon *self,
+                                                     const char       *client,
+                                                     uid_t            *out_uid);
+void               rpmostreed_daemon_add_client     (RpmostreedDaemon *self,
+                                                      const char *client);
+void               rpmostreed_daemon_remove_client  (RpmostreedDaemon *self,
+                                                     const char *client);
+char *             rpmostreed_daemon_client_get_string (RpmostreedDaemon *self,
+                                                        const char *client);
 void               rpmostreed_daemon_exit_now       (RpmostreedDaemon *self);
 void               rpmostreed_daemon_run_until_idle_exit (RpmostreedDaemon *self);
 void               rpmostreed_daemon_publish        (RpmostreedDaemon *self,

--- a/src/daemon/rpmostreed-sysroot.h
+++ b/src/daemon/rpmostreed-sysroot.h
@@ -20,6 +20,7 @@
 
 #include "ostree.h"
 #include "rpmostreed-types.h"
+#include <polkit/polkit.h>
 
 #define RPMOSTREED_TYPE_SYSROOT   (rpmostreed_sysroot_get_type ())
 #define RPMOSTREED_SYSROOT(o)     (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_SYSROOT, RpmostreedSysroot))
@@ -39,6 +40,8 @@ gboolean            rpmostreed_sysroot_reload           (RpmostreedSysroot *self
 
 OstreeSysroot *     rpmostreed_sysroot_get_root         (RpmostreedSysroot *self);
 OstreeRepo *        rpmostreed_sysroot_get_repo         (RpmostreedSysroot *self);
+PolkitAuthority *   rpmostreed_sysroot_get_polkit_authority (RpmostreedSysroot *self);
+gboolean            rpmostreed_sysroot_is_on_session_bus    (RpmostreedSysroot *self);
 
 gboolean            rpmostreed_sysroot_load_state       (RpmostreedSysroot *self,
                                                          GCancellable *cancellable,

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -48,7 +48,7 @@ if test -z "${INSIDE_VM:-}"; then
 
     vm_rsync
 
-    $SSH "env INSIDE_VM=1 /var/roothome/sync/tests/vmcheck/overlay.sh"
+    vm_cmd env INSIDE_VM=1 /var/roothome/sync/tests/vmcheck/overlay.sh
     vm_reboot
     exit 0
 fi

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -77,8 +77,9 @@ ostree checkout $commit vmcheck --fsync=0
 rm -f vmcheck/usr/etc/{.pwd.lock,passwd-,group-,shadow-,gshadow-,subuid-,subgid-}
 # ✀✀✀ END hack for https://github.com/projectatomic/rpm-ostree/pull/693 ✀✀✀
 rm vmcheck/etc -rf
-# Now, overlay our built binaries
+# Now, overlay our built binaries & config files
 rsync -rlv /var/roothome/sync/insttree/usr/ vmcheck/usr/
+rsync -rlv /var/roothome/sync/insttree/etc/ vmcheck/usr/etc/
 ostree refs --delete vmcheck || true
 ostree commit -b vmcheck -s '' --tree=dir=vmcheck --link-checkout-speedup
 ostree admin deploy vmcheck

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -77,9 +77,13 @@ ostree checkout $commit vmcheck --fsync=0
 rm -f vmcheck/usr/etc/{.pwd.lock,passwd-,group-,shadow-,gshadow-,subuid-,subgid-}
 # ✀✀✀ END hack for https://github.com/projectatomic/rpm-ostree/pull/693 ✀✀✀
 rm vmcheck/etc -rf
+
 # Now, overlay our built binaries & config files
-rsync -rlv /var/roothome/sync/insttree/usr/ vmcheck/usr/
-rsync -rlv /var/roothome/sync/insttree/etc/ vmcheck/usr/etc/
+INSTTREE=/var/roothome/sync/insttree
+rsync -rlv $INSTTREE/usr/ vmcheck/usr/
+if [ -d $INSTTREE/etc ]; then # on CentOS, the dbus service file is in /usr
+  rsync -rlv $INSTTREE/etc/ vmcheck/usr/etc/
+fi
 ostree refs --delete vmcheck || true
 ostree commit -b vmcheck -s '' --tree=dir=vmcheck --link-checkout-speedup
 ostree admin deploy vmcheck

--- a/tests/vmcheck/sync.sh
+++ b/tests/vmcheck/sync.sh
@@ -38,7 +38,7 @@ if test -z "${INSIDE_VM:-}"; then
     make install DESTDIR=${VMCHECK_INSTTREE}
     vm_rsync
 
-    $SSH "env INSIDE_VM=1 /var/roothome/sync/tests/vmcheck/sync.sh"
+    vm_cmd env INSIDE_VM=1 /var/roothome/sync/tests/vmcheck/sync.sh
     exit 0
 else
 

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -38,9 +38,11 @@ echo "ok empty pkg arrays in status json"
 vm_cmd getent passwd bin
 
 # Make sure we can't layer as non-root
-if vm_cmd "runuser -u bin rpm-ostree pkg-add foo-1.0"; then
+vm_build_rpm foo
+if vm_cmd "runuser -u bin rpm-ostree pkg-add foo" &> err.txt; then
     assert_not_reached "Was able to install a package as non-root!"
 fi
+assert_file_has_content err.txt 'PkgChange not allowed for user'
 echo "ok layering requires root"
 
 # Assert that we can do status as non-root


### PR DESCRIPTION
```
$ id
uid=1000(cloud-user) gid=1000(cloud-user) groups=1000(cloud-user),10(wheel) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
$ rpm-ostree status
State: idle
Deployments:
  fedora-atomic:fedora-atomic/25/x86_64/testing/docker-host
                   Version: 25.180 (2017-07-23 06:19:17)
                    Commit: 99afb33f761385b0f792d66c6152efbdac182db10e12c36ec3a88fa84c660bcf

* fedora-atomic:fedora-atomic/25/x86_64/testing/docker-host
                   Version: 25.179 (2017-07-20 22:41:48)
                    Commit: 572b2fb819e6b3fb1b62da3ef70f98a589dd1c39fcddc2190a0a36a9b8d82ff8
                  Unlocked: development
$ rpm-ostree upgrade
==== AUTHENTICATING FOR org.projectatomic.rpmostree1.upgrade ===
Authentication is required to update software
Authenticating as: Fedora (cloud-user)
Password:
==== AUTHENTICATION COMPLETE ===
1 metadata, 0 content objects fetched; 292 B transferred in 1 seconds
No upgrade available.
```