### PR TITLE
ci: run the improved-sanity-test

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -104,3 +104,30 @@ tests:
 
 artifacts:
   - compose.log
+
+---
+
+branches:
+  - master
+  - auto
+  - try
+
+cluster:
+  hosts:
+    - name: testnode
+      distro: fedora/26/atomic
+  container:
+    image: registry.fedoraproject.org/fedora:26
+
+context: f26-sanity
+
+packages:
+  - ansible
+  - git
+  - rsync
+
+tests:
+  - git clone https://github.com/projectatomic/atomic-host-tests
+  - ci/build.sh
+  - make vmoverlay HOSTS=testnode
+  - cd atomic-host-tests && ./.test_director

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -78,9 +78,6 @@ vmoverlay:
 	      ./tests/vmcheck/overlay.sh; \
 	fi
 
-vmshell: vmsync
-	ssh -F ssh-config vmcheck
-
 # set up test environment to somewhat resemble uninstalled tests
 vmcheck: vmoverlay
 	@env VMTESTS=1 $(BASE_TESTS_ENVIRONMENT) PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
Start running the improved-sanity-test from atomic-host-tests to make
sure the system works. This is an easy way to get PR-level comprehensive
integration tests for free.

But note that we *don't* mark it as required since the tests are not
stored here and it can happen that they need to be adjusted for new
rpm-ostree behaviours. In this way, this added check also allows us to
give a heads-up that breaking changes are coming.