### PR TITLE
dbus: don't register if not active

### DIFF
--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -50,8 +50,12 @@ if vm_cmd_as testuser rpm-ostree pkg-add foo &> err.txt; then
     assert_not_reached "Was able to install a package as non-root!"
 fi
 assert_file_has_content err.txt 'PkgChange not allowed for user'
-echo "ok layering requires root"
+echo "ok layering requires root or auth"
 
 # Assert that we can do status as non-root
 vm_cmd_as testuser rpm-ostree status
 echo "ok status doesn't require root"
+
+# Also check that we can do status as non-root non-active
+vm_cmd runuser -u bin rpm-ostree status
+echo "ok status doesn't require active PAM session"


### PR DESCRIPTION
Follow-up tweak to #894. Make the client smarter so we only register
when we know we can. We could be more sophisticated here and e.g.
introduce the concept of "read-only" clients in the daemon to only allow
access to non-mutating methods, though let's delay that discussion at
least until the daemon learns to auto-exit.

Closes: #898