### PR TITLE
lib: Log task output for pre/post scripts

### DIFF
--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -55,12 +55,14 @@ gboolean
 rpmostree_posttrans_run_sync (DnfPackage    *pkg,
                               Header         hdr,
                               int            rootfs_fd,
+                              guint         *out_n_run,
                               GCancellable  *cancellable,
                               GError       **error);
 
 gboolean
 rpmostree_transfiletriggers_run_sync (Header         hdr,
                                       int            rootfs_fd,
+                                      guint         *out_n_run,
                                       GCancellable  *cancellable,
                                       GError       **error);
 
@@ -68,6 +70,7 @@ gboolean
 rpmostree_pre_run_sync (DnfPackage    *pkg,
                         Header         hdr,
                         int            rootfs_fd,
+                        guint         *out_n_run,
                         GCancellable  *cancellable,
                         GError       **error);
 


### PR DESCRIPTION
Some of the scripts can be expensive (`shared-mime-info` for example), and we
appear to be hanging for at least a few seconds even on fast hardware. I'd like
to have a lot more logging here...potentially something like showing
individual package names live in the terminal, but this is a start.
