### PR TITLE
rollback: allow users to undo a rollback

### DIFF
--- a/src/daemon/rpmostree-sysroot-core.c
+++ b/src/daemon/rpmostree-sysroot-core.c
@@ -386,48 +386,6 @@ rpmostree_syscore_add_deployment (OstreeSysroot      *sysroot,
   return g_steal_pointer (&new_deployments);
 }
 
-/* Find the pending and rollback deployments (if any) for @osname. */
-void
-rpmostree_syscore_query_deployments (OstreeSysroot      *sysroot,
-                                     const char         *osname,
-                                     OstreeDeployment  **out_pending,
-                                     OstreeDeployment  **out_rollback)
-{
-  g_autoptr(GPtrArray) deployments = ostree_sysroot_get_deployments (sysroot);
-  OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);
-  g_autoptr(OstreeDeployment) ret_pending = NULL;
-  g_autoptr(OstreeDeployment) ret_rollback = NULL;
-
-  gboolean found_booted = FALSE;
-  for (guint i = 0; i < deployments->len; i++)
-    {
-      OstreeDeployment *deployment = deployments->pdata[i];
-
-      /* Is this deployment booted?  If so, note we're past the booted */
-      if (booted_deployment != NULL &&
-          ostree_deployment_equal (deployment, booted_deployment))
-        {
-          found_booted = TRUE;
-          continue;
-        }
-
-      /* Ignore deployments not for this osname */
-      if (strcmp (ostree_deployment_get_osname (deployment), osname) != 0)
-          continue;
-
-      if (!found_booted && !ret_pending)
-        ret_pending = g_object_ref (deployment);
-
-      if (found_booted && !ret_rollback)
-        ret_rollback = g_object_ref (deployment);
-    }
-  if (out_pending)
-    *out_pending = g_steal_pointer (&ret_pending);
-  if (out_rollback)
-    *out_rollback = g_steal_pointer (&ret_rollback);
-}
-
-
 /* Also a variant of ostree_sysroot_simple_write_deployment(), but here we are
  * just trying to remove a pending and/or rollback.
  */

--- a/src/daemon/rpmostree-sysroot-core.h
+++ b/src/daemon/rpmostree-sysroot-core.h
@@ -65,11 +65,6 @@ GPtrArray *rpmostree_syscore_add_deployment (OstreeSysroot      *sysroot,
                                              gboolean            pushing_rollback,
                                              GError            **error);
 
-void rpmostree_syscore_query_deployments (OstreeSysroot      *sysroot,
-                                          const char         *osname,
-                                          OstreeDeployment  **out_pending,
-                                          OstreeDeployment  **out_rollback);
-
 GPtrArray *rpmostree_syscore_filter_deployments (OstreeSysroot      *sysroot,
                                                  const char         *osname,
                                                  gboolean            remove_pending,

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -1461,9 +1461,9 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
   if (booted)
     {
       g_autoptr(OstreeDeployment) rollback = NULL;
-
-      rpmostree_syscore_query_deployments (ot_sysroot, ostree_deployment_get_osname (booted),
-                                           NULL, &rollback);
+      ostree_sysroot_query_deployments_for (ot_sysroot,
+                                            ostree_deployment_get_osname (booted),
+                                            NULL, &rollback);
 
       if (rollback)
         {

--- a/src/daemon/rpmostreed-transaction-livefs.c
+++ b/src/daemon/rpmostreed-transaction-livefs.c
@@ -379,8 +379,8 @@ get_rollback_deployment (OstreeSysroot *sysroot,
   const char *booted_csum = ostree_deployment_get_csum (booted);
 
   g_autoptr(OstreeDeployment) rollback_deployment = NULL;
-  rpmostree_syscore_query_deployments (sysroot, ostree_deployment_get_osname (booted),
-                                       NULL, &rollback_deployment);
+  ostree_sysroot_query_deployments_for (sysroot, ostree_deployment_get_osname (booted),
+                                        NULL, &rollback_deployment);
   /* If no rollback found, we're done */
   if (!rollback_deployment)
     return NULL;

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -326,11 +326,22 @@ rollback_transaction_execute (RpmostreedTransaction *transaction,
 {
   RollbackTransaction *self = (RollbackTransaction *) transaction;
   OstreeSysroot *sysroot = rpmostreed_transaction_get_sysroot (transaction);
+  OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);
 
+  g_autoptr(OstreeDeployment) pending_deployment = NULL;
   g_autoptr(OstreeDeployment) rollback_deployment = NULL;
-  ostree_sysroot_query_deployments_for (sysroot, self->osname, NULL, &rollback_deployment);
-  if (!rollback_deployment)
+  ostree_sysroot_query_deployments_for (sysroot, self->osname,
+                                        &pending_deployment, &rollback_deployment);
+
+  if (!rollback_deployment && !pending_deployment) /* i.e. do we just have 1 deployment? */
     return glnx_throw (error, "No rollback deployment found");
+  else if (!rollback_deployment)
+    {
+      /* If there isn't a rollback deployment, but there *is* a pending deployment, then we
+       * want "rpm-ostree rollback" to put the currently booted deployment back on top. This
+       * also allows users to effectively undo a rollback operation. */
+      rollback_deployment = g_object_ref (booted_deployment);
+    }
 
   g_autoptr(GPtrArray) old_deployments =
     ostree_sysroot_get_deployments (sysroot);
@@ -348,7 +359,7 @@ rollback_transaction_execute (RpmostreedTransaction *transaction,
   for (guint i = 0; i < old_deployments->len; i++)
     {
       OstreeDeployment *deployment = old_deployments->pdata[i];
-      if (deployment != rollback_deployment)
+      if (!ostree_deployment_equal (deployment, rollback_deployment))
         g_ptr_array_add (new_deployments, g_object_ref (deployment));
     }
 

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -328,7 +328,7 @@ rollback_transaction_execute (RpmostreedTransaction *transaction,
   OstreeSysroot *sysroot = rpmostreed_transaction_get_sysroot (transaction);
 
   g_autoptr(OstreeDeployment) rollback_deployment = NULL;
-  rpmostree_syscore_query_deployments (sysroot, self->osname, NULL, &rollback_deployment);
+  ostree_sysroot_query_deployments_for (sysroot, self->osname, NULL, &rollback_deployment);
   if (!rollback_deployment)
     return glnx_throw (error, "No rollback deployment found");
 

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -30,16 +30,16 @@ if test -z "${INSIDE_VM:-}"; then
        ostree --version
        for pkg in ostree{,-libs,-grub2}; do
           rpm -q $pkg
-          # We do not have perms to read /etc/grub2 as non-root
-          rpm -ql $pkg | grep -v '^/etc/' | sed "s/^/+ /" >  list.txt
-          echo "- *" >> list.txt
-          # In the prebuilt container case, manpages are missing.  Ignore that.
-          # Also chown everything to writable, due to https://bugzilla.redhat.com/show_bug.cgi?id=517575
+          # We do not have perms to read /etc/grub2 as non-root. In the prebuilt
+          # container case, manpages are missing. Ignore that.
+          rpm -ql $pkg | grep -vE "^/(etc|usr/share/(doc|man))/" >  list.txt
+          # Also chown everything to writable, due to
+          # https://bugzilla.redhat.com/show_bug.cgi?id=517575
           chmod -R u+w ${DESTDIR}/
-          # The --ignore-missing-args option was added in rsync 3.1.0,
-          # but CentOS7 only has rsync 3.0.9.  Can simulate the behavior
-          # with --include-from and the way we constructed list.txt.
-          rsync -l --include-from=list.txt / ${DESTDIR}/
+          # Note we cant use --ignore-missing-args here since it was added in
+          # rsync 3.1.0, but CentOS7 only has rsync 3.0.9. Anyway, we expect
+          # everything in list.txt to be present (otherwise, tweak grep above).
+          rsync -l --files-from=list.txt / ${DESTDIR}/
           rm -f list.txt
        done
        make install DESTDIR=${DESTDIR}

--- a/tests/vmcheck/sync.sh
+++ b/tests/vmcheck/sync.sh
@@ -45,9 +45,14 @@ else
     # then do this in the VM
     set -x
     ostree admin unlock || :
-    # only copy /usr and /etc
-    rsync -rlv /var/roothome/sync/insttree/usr/ /usr/
-    rsync -rlv /var/roothome/sync/insttree/etc/ /etc/
+
+    # Now, overlay our built binaries & config files
+    INSTTREE=/var/roothome/sync/insttree
+    rsync -rlv $INSTTREE/usr/ /usr/
+    if [ -d $INSTTREE/etc ]; then # on CentOS, the dbus service file is in /usr
+      rsync -rlv $INSTTREE/etc/ /etc/
+    fi
+
     restorecon -v /usr/bin/rpm-ostree
     restorecon -v /usr/libexec/rpm-ostreed
     mkdir -p /etc/systemd/system/rpm-ostreed.service.d

--- a/tests/vmcheck/sync.sh
+++ b/tests/vmcheck/sync.sh
@@ -22,16 +22,16 @@ if test -z "${INSIDE_VM:-}"; then
     ostree --version
     for pkg in ostree{,-libs,-grub2}; do
        rpm -q $pkg
-       # We do not have perms to read /etc/grub2 as non-root
-       rpm -ql $pkg | grep -v '^/etc/' | sed "s/^/+ /" >  list.txt
-       echo "- *" >> list.txt
-       # In the prebuilt container case, manpages are missing.  Ignore that.
-       # Also chown everything to writable, due to https://bugzilla.redhat.com/show_bug.cgi?id=517575
+       # We do not have perms to read /etc/grub2 as non-root. In the prebuilt
+       # container case, manpages are missing. Ignore that.
+       rpm -ql $pkg | grep -vE '^/(etc|usr/share/(doc|man))/' >  list.txt
+       # Also chown everything to writable, due to
+       # https://bugzilla.redhat.com/show_bug.cgi?id=517575
        chmod -R u+w ${VMCHECK_INSTTREE}/
-       # The --ignore-missing-args option was added in rsync 3.1.0,
-       # but CentOS7 only has rsync 3.0.9.  Can simulate the behavior
-       # with --include-from and the way we constructed list.txt.
-       rsync -l --include-from=list.txt / ${VMCHECK_INSTTREE}/
+       # Note we can't use --ignore-missing-args here since it was added in
+       # rsync 3.1.0, but CentOS7 only has rsync 3.0.9. Anyway, we expect
+       # everything in list.txt to be present (otherwise, tweak grep above).
+       rsync -l --files-from=list.txt / ${VMCHECK_INSTTREE}/
        rm -f list.txt
     done
 

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -73,3 +73,13 @@ vm_build_rpm foo
 vm_rpmostree install foo
 vm_assert_status_jq ".deployments[0][\"endoflife\"] == \"${META_ENDOFLIFE_MESSAGE}\""
 echo "ok layered commit inherits the endoflife attribute"
+
+vm_assert_status_jq ".deployments[0][\"booted\"] == false" \
+                    ".deployments[1][\"booted\"] == true"
+vm_rpmostree rollback
+vm_assert_status_jq ".deployments[0][\"booted\"] == true" \
+                    ".deployments[1][\"booted\"] == false"
+vm_rpmostree rollback
+vm_assert_status_jq ".deployments[0][\"booted\"] == false" \
+                    ".deployments[1][\"booted\"] == true"
+echo "ok rollback"


### PR DESCRIPTION
The new API to find pending and rollback deployments do so relative to
the booted deployment. This caused an interesting behaviour: the first
time a user uses `rpm-ostree rollback`, it would (as expected) move the
previous deployment first. but the second call to `rpm-ostree rollback`
would fail since there were now no more rollback deployments.

We fine tune the logic here to allow this, as well as the more general
case of putting the booted deployment back on top.

This fixes a subtle regression from b7cf58e
(https://github.com/projectatomic/rpm-ostree/pull/767).

Closes: https://github.com/projectatomic/rpm-ostree/issues/906