### PR TITLE
daemon: Check for updated 🆕 rpms when upgrading

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -895,7 +895,6 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
        definitely changed */
     self->layering_changed = TRUE;
 
-  self->layering_initialized = TRUE;
   return TRUE;
 }
 
@@ -1064,7 +1063,15 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
       return TRUE;
     }
 
-  /* rpmostree_sysroot_upgrader_prep_layering() must have been invoked */
+  /* Invoke prep_layering() if not done already */
+  if (!self->layering_initialized)
+    {
+      RpmOstreeSysrootUpgraderLayeringType layering_type;
+      gboolean layering_changed = FALSE;
+      if (!rpmostree_sysroot_upgrader_prep_layering (self, &layering_type, &layering_changed,
+                                                     cancellable, error))
+        return FALSE;
+    }
   g_assert (self->layering_initialized);
   /* Generate the final ostree commit */
   if (!perform_local_assembly (self, cancellable, error))

--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -53,6 +53,16 @@ typedef enum {
   RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGOVERLAY_NOSCRIPTS = (1 << 4)
 } RpmOstreeSysrootUpgraderFlags;
 
+/* _NONE means we're doing pure ostree, no client-side computation.
+ * _LOCAL is just e.g. rpm-ostree initramfs
+ * _RPMMD_REPOS is where we're downloading data from /etc/yum.repos.d
+ */
+typedef enum {
+  RPMOSTREE_SYSROOT_UPGRADER_LAYERING_NONE = 0,
+  RPMOSTREE_SYSROOT_UPGRADER_LAYERING_LOCAL = 1,
+  RPMOSTREE_SYSROOT_UPGRADER_LAYERING_RPMMD_REPOS = 2,
+} RpmOstreeSysrootUpgraderLayeringType;
+
 GType rpmostree_sysroot_upgrader_get_type (void);
 
 GType rpmostree_sysroot_upgrader_flags_get_type (void);
@@ -76,13 +86,31 @@ const char *
 rpmostree_sysroot_upgrader_get_base (RpmOstreeSysrootUpgrader *self);
 
 gboolean
-rpmostree_sysroot_upgrader_pull (RpmOstreeSysrootUpgrader  *self,
-                                 const char             *dir_to_pull,
-                                 OstreeRepoPullFlags     flags,
-                                 OstreeAsyncProgress    *progress,
-                                 gboolean               *out_changed,
-                                 GCancellable           *cancellable,
-                                 GError                **error);
+rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
+                                      const char             *dir_to_pull,
+                                      OstreeRepoPullFlags     flags,
+                                      OstreeAsyncProgress    *progress,
+                                      gboolean               *out_changed,
+                                      GCancellable           *cancellable,
+                                      GError                **error);
+
+gboolean
+rpmostree_sysroot_upgrader_prep_layering (RpmOstreeSysrootUpgrader *self,
+                                          RpmOstreeSysrootUpgraderLayeringType *out_layering,
+                                          gboolean                 *out_changed,
+                                          GCancellable             *cancellable,
+                                          GError                  **error);
+
+gboolean
+rpmostree_sysroot_upgrader_pull_repos (RpmOstreeSysrootUpgrader  *self,
+                                       const char             *dir_to_pull,
+                                       OstreeRepoPullFlags     flags,
+                                       OstreeAsyncProgress    *progress,
+                                       gboolean               *out_changed,
+                                       GCancellable           *cancellable,
+                                       GError                **error);
+
+
 
 gboolean
 rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader  *self,

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -809,8 +809,6 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
 
   rpmostree_sysroot_upgrader_set_origin (upgrader, origin);
 
-  RpmOstreeSysrootUpgraderLayeringType layering_type;
-  gboolean layering_changed = FALSE;
   /* Mainly for the `install` and `override` commands */
   if (!(self->flags & RPMOSTREE_TRANSACTION_DEPLOY_FLAG_NO_PULL_BASE))
     {
@@ -868,6 +866,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
       changed = TRUE;
     }
 
+  RpmOstreeSysrootUpgraderLayeringType layering_type;
+  gboolean layering_changed = FALSE;
   if (!rpmostree_sysroot_upgrader_prep_layering (upgrader, &layering_type, &layering_changed,
                                                  cancellable, error))
     return FALSE;
@@ -1056,12 +1056,6 @@ initramfs_state_transaction_execute (RpmostreedTransaction *transaction,
 
   rpmostree_origin_set_regenerate_initramfs (origin, self->regenerate, self->args);
   rpmostree_sysroot_upgrader_set_origin (upgrader, origin);
-
-  RpmOstreeSysrootUpgraderLayeringType layering_type;
-  gboolean layering_changed = FALSE;
-  if (!rpmostree_sysroot_upgrader_prep_layering (upgrader, &layering_type, &layering_changed,
-                                                 cancellable, error))
-    return FALSE;
 
   if (!rpmostree_sysroot_upgrader_deploy (upgrader, cancellable, error))
     return FALSE;

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1459,6 +1459,7 @@ install_pkg_from_cache (RpmOstreeContext *self,
   return TRUE;
 }
 
+/* Check for/download new rpm-md, then depsolve */
 gboolean
 rpmostree_context_prepare (RpmOstreeContext *self,
                            GCancellable     *cancellable,

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -122,7 +122,6 @@ vm_rpmostree upgrade | tee output.txt
 assert_not_file_has_content output.txt '^Importing:'
 
 # upgrade with different foo in repos --> should re-import
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
 c1=$(sha256sum ${test_tmpdir}/yumrepo/packages/x86_64/foo-1.0-1.x86_64.rpm)
 vm_build_rpm foo
 c2=$(sha256sum ${test_tmpdir}/yumrepo/packages/x86_64/foo-1.0-1.x86_64.rpm)


### PR DESCRIPTION
This closes a longstanding annoying bug for me.

Closes: https://github.com/projectatomic/rpm-ostree/issues/391
