### PR TITLE
core/metadata: Add an extra check when downloading metadata

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -928,6 +928,8 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
 
   g_autoptr(GPtrArray) rpmmd_repos = get_enabled_rpmmd_repos (self->hifctx, DNF_REPO_ENABLED_PACKAGES);
 
+  /* this tells whether the suffix for cache directory matches the current version */
+  gboolean cache_suffix_match = dnf_context_get_cache_suffix_match (self->hifctx);
   g_print ("Enabled rpm-md repositories:");
   for (guint i = 0; i < rpmmd_repos->len; i++)
     {
@@ -945,7 +947,7 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
       if (!dnf_repo_check(repo,
                           dnf_context_get_cache_age (self->hifctx),
                           hifstate,
-                          NULL))
+                          NULL) || !cache_suffix_match)
         {
           dnf_state_reset (hifstate);
           g_autofree char *prefix = g_strdup_printf ("Updating metadata for '%s':",


### PR DESCRIPTION
This is related to https://github.com/rpm-software-management/libdnf/pull/315
and https://github.com/rpm-software-management/libdnf/issues/148.

Now, when user 'rpm-ostree rebase' to a different version of system,
new metadata with the corresponding suffix will be downloaded
