### PR TITLE
app: add more rpm-ostree -h output

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -136,12 +136,13 @@ option_context_new_with_commands (RpmOstreeCommandInvocation *invocation,
         {
           g_string_append_printf (summary, "\n  %s", command->name);
           if (command->description != NULL)
-            { /* add padding for description alignment */
-              guint max_command_len = 13;
-              guint pad = max_command_len - strlen(command->name);
+            {
+              /* add padding for description alignment */
+              guint max_command_len = 15;
+              guint pad = max_command_len - strlen (command->name);
 
               for (guint padding_num = 0; padding_num < pad + 2; padding_num++)
-                g_string_append_printf (summary, " ");
+                g_string_append (summary, " ");
 
               g_string_append_printf (summary, "%s", command->description);
             }

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -85,11 +85,11 @@ static RpmOstreeCommand commands[] = {
   /* Hidden */
   { "ex", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD |
           RPM_OSTREE_BUILTIN_FLAG_HIDDEN,
-    NULL,rpmostree_builtin_ex },
+    "Commands still under experiment", rpmostree_builtin_ex },
   { "start-daemon", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD |
                     RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT |
                     RPM_OSTREE_BUILTIN_FLAG_HIDDEN,
-    "start the daemon process", rpmostree_builtin_start_daemon },
+    NULL, rpmostree_builtin_start_daemon },
   { NULL }
 };
 
@@ -124,8 +124,14 @@ option_context_new_with_commands (RpmOstreeCommandInvocation *invocation,
   g_autoptr(GString) summary = g_string_new (NULL);
 
   if (invocation)
-    g_string_append_printf (summary, "Builtin \"%s\" Commands:",
-                            invocation->command->name);
+    {
+      if (invocation->command->description != NULL)
+        g_string_append_printf (summary, "%s\n\n",
+                                invocation->command->description);
+
+      g_string_append_printf (summary, "Builtin \"%s\" Commands:",
+                              invocation->command->name);
+    }
   else /* top level */
     g_string_append (summary, "Builtin Commands:");
 
@@ -165,17 +171,11 @@ rpmostree_option_context_parse (GOptionContext *context,
   if (invocation && invocation->command->description != NULL)
     {
       /* The extra summary explanation is only provided for commands with description */
-      g_autoptr(GString) context_summary = g_string_new (g_option_context_get_summary(context));
+      const char* context_summary = g_option_context_get_summary (context);
 
-      /* handle differently if a command has subcommands */
-      const gchar *line_separator = !(*context_summary->str) ? "" : "\n\n";
-
-      g_string_append_printf (context_summary,
-                              "%sCommand Description: \n  %s",
-                              line_separator,
-                              invocation->command->description);
-
-      g_option_context_set_summary(context, context_summary->str);
+      /* check whether the summary has been set earlier */
+      if (context_summary == NULL)
+       g_option_context_set_summary (context, invocation->command->description);
     }
 
   if (main_entries != NULL)

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -38,46 +38,58 @@ static RpmOstreeCommand commands[] = {
 #ifdef HAVE_COMPOSE_TOOLING
   { "compose", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD |
                RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
-    rpmostree_builtin_compose },
+    NULL, rpmostree_builtin_compose },
 #endif
   { "cleanup", 0,
+    "Clear cached/pending data",
     rpmostree_builtin_cleanup },
   { "db", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    rpmostree_builtin_db },
+    NULL, rpmostree_builtin_db },
   { "deploy", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+    "Deploy a specific commit",
     rpmostree_builtin_deploy },
   { "rebase", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+    "Switch to a different tree",
     rpmostree_builtin_rebase },
   { "rollback", 0,
+    "Revert to the previously booted tree",
     rpmostree_builtin_rollback },
   { "status", 0,
+    "Get the version of the booted system",
     rpmostree_builtin_status },
   { "upgrade", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+    "Perform a system upgrade",
     rpmostree_builtin_upgrade },
   { "reload", 0,
+    "Reload configuration",
     rpmostree_builtin_reload },
   { "initramfs", 0,
+    "Enable or disable local initramfs regeneration",
     rpmostree_builtin_initramfs },
   { "install", 0,
+    "Download and install layered RPM packages",
     rpmostree_builtin_install },
   { "uninstall", 0,
+    "Remove one or more overlay packages",
     rpmostree_builtin_uninstall },
   /* Legacy aliases */
   { "pkg-add", RPM_OSTREE_BUILTIN_FLAG_HIDDEN,
+    "Download and install layered RPM packages",
     rpmostree_builtin_install },
   { "pkg-remove", RPM_OSTREE_BUILTIN_FLAG_HIDDEN,
+    "Remove one or more overlay packages",
     rpmostree_builtin_uninstall },
   { "rpm", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD |
            RPM_OSTREE_BUILTIN_FLAG_HIDDEN,
-    rpmostree_builtin_db },
+    NULL, rpmostree_builtin_db },
   /* Hidden */
   { "ex", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD |
           RPM_OSTREE_BUILTIN_FLAG_HIDDEN,
-    rpmostree_builtin_ex },
+    NULL,rpmostree_builtin_ex },
   { "start-daemon", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD |
                     RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT |
                     RPM_OSTREE_BUILTIN_FLAG_HIDDEN,
-    rpmostree_builtin_start_daemon },
+    "start the daemon process", rpmostree_builtin_start_daemon },
   { NULL }
 };
 
@@ -121,7 +133,19 @@ option_context_new_with_commands (RpmOstreeCommandInvocation *invocation,
     {
       gboolean hidden = (command->flags & RPM_OSTREE_BUILTIN_FLAG_HIDDEN) > 0;
       if (!hidden)
-        g_string_append_printf (summary, "\n  %s", command->name);
+        {
+          g_string_append_printf (summary, "\n  %s", command->name);
+          if (command->description != NULL)
+            { /* add padding for description alignment */
+              guint max_command_len = 13;
+              guint pad = max_command_len - strlen(command->name);
+
+              for (guint padding_num = 0; padding_num < pad + 2; padding_num++)
+                g_string_append_printf (summary, " ");
+
+              g_string_append_printf (summary, "%s", command->description);
+            }
+        }
     }
 
   g_option_context_set_summary (context, summary->str);

--- a/src/app/rpmostree-builtin-cleanup.c
+++ b/src/app/rpmostree-builtin-cleanup.c
@@ -52,7 +52,7 @@ rpmostree_builtin_cleanup (int             argc,
                            GCancellable   *cancellable,
                            GError        **error)
 {
-  g_autoptr(GOptionContext) context = g_option_context_new ("- Clear cached/pending data");
+  g_autoptr(GOptionContext) context = g_option_context_new ("");
   g_autoptr(GPtrArray) cleanup_types = g_ptr_array_new ();
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;

--- a/src/app/rpmostree-builtin-compose.c
+++ b/src/app/rpmostree-builtin-compose.c
@@ -30,8 +30,9 @@
 
 static RpmOstreeCommand compose_subcommands[] = {
   { "tree", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
+    "Install packages and commit the result to an OSTree repository",
     rpmostree_compose_builtin_tree },
-  { NULL, 0, NULL }
+  { NULL, 0, NULL, NULL }
 };
 
 int

--- a/src/app/rpmostree-builtin-container.c
+++ b/src/app/rpmostree-builtin-container.c
@@ -25,12 +25,12 @@
 
 static RpmOstreeCommand container_subcommands[] = {
   { "init", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    NULL, rpmostree_container_builtin_init },
+    "Initialize a local container", rpmostree_container_builtin_init },
   { "assemble", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    NULL, rpmostree_container_builtin_assemble },
+    "Assemble a local container", rpmostree_container_builtin_assemble },
   /* { "start", rpmostree_container_builtin_start }, */
   { "upgrade", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    NULL, rpmostree_container_builtin_upgrade },
+    "Perform a local container upgrade", rpmostree_container_builtin_upgrade },
   { NULL, 0, NULL, NULL }
 };
 

--- a/src/app/rpmostree-builtin-container.c
+++ b/src/app/rpmostree-builtin-container.c
@@ -25,13 +25,13 @@
 
 static RpmOstreeCommand container_subcommands[] = {
   { "init", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    rpmostree_container_builtin_init },
+    NULL, rpmostree_container_builtin_init },
   { "assemble", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    rpmostree_container_builtin_assemble },
+    NULL, rpmostree_container_builtin_assemble },
   /* { "start", rpmostree_container_builtin_start }, */
   { "upgrade", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    rpmostree_container_builtin_upgrade },
-  { NULL, 0, NULL }
+    NULL, rpmostree_container_builtin_upgrade },
+  { NULL, 0, NULL, NULL }
 };
 
 int

--- a/src/app/rpmostree-builtin-db.c
+++ b/src/app/rpmostree-builtin-db.c
@@ -25,12 +25,15 @@
 
 static RpmOstreeCommand rpm_subcommands[] = {
   { "diff", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+    "Show package changes between two commits",
     rpmostree_db_builtin_diff },
   { "list", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+    "List packages within commits",
     rpmostree_db_builtin_list },
   { "version", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+    "Show rpmdb version of packages within the commits",
     rpmostree_db_builtin_version },
-  { NULL, 0, NULL }
+  { NULL, 0, NULL, NULL }
 };
 
 static char *opt_repo;

--- a/src/app/rpmostree-builtin-deploy.c
+++ b/src/app/rpmostree-builtin-deploy.c
@@ -68,7 +68,7 @@ rpmostree_builtin_deploy (int            argc,
   const char *const *install_pkgs = NULL;
   const char *const *uninstall_pkgs = NULL;
 
-  context = g_option_context_new ("REVISION - Deploy a specific commit");
+  context = g_option_context_new ("REVISION");
 
   if (!rpmostree_option_context_parse (context,
                                        option_entries,

--- a/src/app/rpmostree-builtin-ex.c
+++ b/src/app/rpmostree-builtin-ex.c
@@ -27,11 +27,11 @@ static RpmOstreeCommand ex_subcommands[] = {
     "Apply pending deployment changes to booted deployment",
     rpmostree_ex_builtin_livefs },
   { "override", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    NULL, rpmostree_ex_builtin_override },
+    "Manage base overrides", rpmostree_ex_builtin_override },
   { "unpack", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    NULL, rpmostree_ex_builtin_unpack },
+    "unpack RPM into local OSTree repo", rpmostree_ex_builtin_unpack },
   { "container", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    NULL, rpmostree_builtin_container },
+    "Assemble local unprivileged containers", rpmostree_builtin_container },
   { NULL, 0, NULL, NULL }
 };
 

--- a/src/app/rpmostree-builtin-ex.c
+++ b/src/app/rpmostree-builtin-ex.c
@@ -24,14 +24,15 @@
 
 static RpmOstreeCommand ex_subcommands[] = {
   { "livefs", RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
+    "Apply pending deployment changes to booted deployment",
     rpmostree_ex_builtin_livefs },
   { "override", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    rpmostree_ex_builtin_override },
+    NULL, rpmostree_ex_builtin_override },
   { "unpack", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    rpmostree_ex_builtin_unpack },
+    NULL, rpmostree_ex_builtin_unpack },
   { "container", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    rpmostree_builtin_container },
-  { NULL, 0, NULL }
+    NULL, rpmostree_builtin_container },
+  { NULL, 0, NULL, NULL }
 };
 
 /*

--- a/src/app/rpmostree-builtin-initramfs.c
+++ b/src/app/rpmostree-builtin-initramfs.c
@@ -62,7 +62,7 @@ rpmostree_builtin_initramfs (int             argc,
                              GCancellable   *cancellable,
                              GError        **error)
 {
-  g_autoptr(GOptionContext) context = g_option_context_new ("- Enable or disable local initramfs regeneration");
+  g_autoptr(GOptionContext) context = g_option_context_new ("");
 
   _cleanup_peer_ GPid peer_pid = 0;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;

--- a/src/app/rpmostree-builtin-livefs.c
+++ b/src/app/rpmostree-builtin-livefs.c
@@ -59,7 +59,7 @@ rpmostree_ex_builtin_livefs (int             argc,
 {
   _cleanup_peer_ GPid peer_pid = 0;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  g_autoptr(GOptionContext) context = g_option_context_new ("- Apply pending deployment changes to booted deployment");
+  g_autoptr(GOptionContext) context = g_option_context_new ("");
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
                                        &argc, &argv,

--- a/src/app/rpmostree-builtin-override.c
+++ b/src/app/rpmostree-builtin-override.c
@@ -25,12 +25,15 @@
 
 static RpmOstreeCommand override_subcommands[] = {
   { "replace", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+    "Remove packages from the base layer",
     rpmostree_override_builtin_replace },
   { "remove", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+    "Remove packages from the base layer",
     rpmostree_override_builtin_remove },
   { "reset", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
+    "Reset currently active package overrides",
     rpmostree_override_builtin_reset },
-  { NULL, 0, NULL }
+  { NULL, 0, NULL, NULL }
 };
 
 int

--- a/src/app/rpmostree-builtin-override.c
+++ b/src/app/rpmostree-builtin-override.c
@@ -25,7 +25,7 @@
 
 static RpmOstreeCommand override_subcommands[] = {
   { "replace", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
-    "Remove packages from the base layer",
+    "Replace packages in the base layer",
     rpmostree_override_builtin_replace },
   { "remove", RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS,
     "Remove packages from the base layer",

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -59,7 +59,7 @@ rpmostree_builtin_rebase (int             argc,
   /* forced blank for now */
   const char *packages[] = { NULL };
 
-  g_autoptr(GOptionContext) context = g_option_context_new ("REFSPEC [REVISION] - Switch to a different tree");
+  g_autoptr(GOptionContext) context = g_option_context_new ("REFSPEC [REVISION]");
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   g_autofree char *transaction_address = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;

--- a/src/app/rpmostree-builtin-reload.c
+++ b/src/app/rpmostree-builtin-reload.c
@@ -40,7 +40,7 @@ rpmostree_builtin_reload (int             argc,
                           GCancellable   *cancellable,
                           GError        **error)
 {
-  g_autoptr(GOptionContext) context = g_option_context_new ("- Reload configuration");
+  g_autoptr(GOptionContext) context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   _cleanup_peer_ GPid peer_pid = 0;
 

--- a/src/app/rpmostree-builtin-rollback.c
+++ b/src/app/rpmostree-builtin-rollback.c
@@ -54,7 +54,7 @@ rpmostree_builtin_rollback (int             argc,
                             GCancellable   *cancellable,
                             GError        **error)
 {
-  GOptionContext *context = g_option_context_new ("- Revert to the previously booted tree");
+  GOptionContext *context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autofree char *transaction_address = NULL;

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -585,7 +585,7 @@ rpmostree_builtin_status (int             argc,
                           GCancellable   *cancellable,
                           GError        **error)
 {
-  g_autoptr(GOptionContext) context = g_option_context_new ("- Get the version of the booted system");
+  g_autoptr(GOptionContext) context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autoptr(GVariant) deployments = NULL;

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -57,7 +57,7 @@ rpmostree_builtin_upgrade (int             argc,
                            GCancellable   *cancellable,
                            GError        **error)
 {
-  g_autoptr(GOptionContext) context = g_option_context_new ("- Perform a system upgrade");
+  g_autoptr(GOptionContext) context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   g_autoptr(GVariant) previous_default_deployment = NULL;

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -43,6 +43,7 @@ typedef struct RpmOstreeCommandInvocation RpmOstreeCommandInvocation;
 struct RpmOstreeCommand {
   const char *name;
   RpmOstreeBuiltinFlags flags;
+  const char *description; /* a short decription to describe the functionality */
   int (*fn) (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
 };
 

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -984,7 +984,7 @@ rpmostree_compose_builtin_tree (int             argc,
                                 GCancellable   *cancellable,
                                 GError        **error)
 {
-  g_autoptr(GOptionContext) context = g_option_context_new ("TREEFILE - Install packages and commit the result to an OSTree repository");
+  g_autoptr(GOptionContext) context = g_option_context_new ("TREEFILE");
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
                                        &argc, &argv,

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -39,7 +39,7 @@ rpmostree_db_builtin_diff (int argc, char **argv,
                            GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context =
-    g_option_context_new ("COMMIT COMMIT - Show package changes between two commits");
+    g_option_context_new ("COMMIT COMMIT");
 
   g_autoptr(OstreeRepo) repo = NULL;
   if (!rpmostree_db_option_context_parse (context, option_entries, &argc, &argv, invocation, &repo,

--- a/src/app/rpmostree-db-builtin-list.c
+++ b/src/app/rpmostree-db-builtin-list.c
@@ -84,7 +84,7 @@ rpmostree_db_builtin_list (int argc, char **argv,
                            GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context =
-    g_option_context_new ("[PREFIX-PKGNAME...] COMMIT... - List packages within commits");
+    g_option_context_new ("[PREFIX-PKGNAME...] COMMIT...");
 
   g_autoptr(OstreeRepo) repo = NULL;
   if (!rpmostree_db_option_context_parse (context, option_entries, &argc, &argv,

--- a/src/app/rpmostree-db-builtin-version.c
+++ b/src/app/rpmostree-db-builtin-version.c
@@ -89,7 +89,7 @@ rpmostree_db_builtin_version (int argc, char **argv,
                               GCancellable *cancellable, GError **error)
 {
   g_autoptr(GOptionContext) context =
-    g_option_context_new ("COMMIT... - Show rpmdb version of packages within the commits");
+    g_option_context_new ("COMMIT...");
 
   g_autoptr(OstreeRepo) repo = NULL;
   if (!rpmostree_db_option_context_parse (context, db_version_entries, &argc,

--- a/src/app/rpmostree-override-builtins.c
+++ b/src/app/rpmostree-override-builtins.c
@@ -155,7 +155,7 @@ rpmostree_override_builtin_remove (int argc, char **argv,
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   _cleanup_peer_ GPid peer_pid = 0;
 
-  context = g_option_context_new ("PACKAGE [PACKAGE...] - ");
+  context = g_option_context_new ("PACKAGE [PACKAGE...]");
 
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
@@ -196,7 +196,7 @@ rpmostree_override_builtin_reset (int argc, char **argv,
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   _cleanup_peer_ GPid peer_pid = 0;
 
-  context = g_option_context_new ("PACKAGE [PACKAGE...] - ");
+  context = g_option_context_new ("PACKAGE [PACKAGE...]");
 
   g_option_context_add_main_entries (context, reset_option_entries, NULL);
 

--- a/src/app/rpmostree-override-builtins.c
+++ b/src/app/rpmostree-override-builtins.c
@@ -114,8 +114,7 @@ rpmostree_override_builtin_replace (int argc, char **argv,
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   _cleanup_peer_ GPid peer_pid = 0;
 
-  context = g_option_context_new ("PACKAGE [PACKAGE...] - "
-                                  "Remove packages from the base layer");
+  context = g_option_context_new ("PACKAGE [PACKAGE...]");
 
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
@@ -156,8 +155,7 @@ rpmostree_override_builtin_remove (int argc, char **argv,
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   _cleanup_peer_ GPid peer_pid = 0;
 
-  context = g_option_context_new ("PACKAGE [PACKAGE...] - "
-                                  "Remove packages from the base layer");
+  context = g_option_context_new ("PACKAGE [PACKAGE...] - ");
 
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
@@ -198,8 +196,7 @@ rpmostree_override_builtin_reset (int argc, char **argv,
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   _cleanup_peer_ GPid peer_pid = 0;
 
-  context = g_option_context_new ("PACKAGE [PACKAGE...] - "
-                                  "Reset currently active package overrides");
+  context = g_option_context_new ("PACKAGE [PACKAGE...] - ");
 
   g_option_context_add_main_entries (context, reset_option_entries, NULL);
 

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -154,7 +154,7 @@ rpmostree_builtin_install (int            argc,
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   _cleanup_peer_ GPid peer_pid = 0;
 
-  context = g_option_context_new ("PACKAGE [PACKAGE...] - Download and install layered RPM packages");
+  context = g_option_context_new ("PACKAGE [PACKAGE...]");
 
   g_option_context_add_main_entries (context, uninstall_option_entry, NULL);
 
@@ -197,7 +197,7 @@ rpmostree_builtin_uninstall (int            argc,
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
   _cleanup_peer_ GPid peer_pid = 0;
 
-  context = g_option_context_new ("PACKAGE [PACKAGE...] - Remove one or more overlay packages");
+  context = g_option_context_new ("PACKAGE [PACKAGE...]");
 
   g_option_context_add_main_entries (context, install_option_entry, NULL);
 


### PR DESCRIPTION
This is brought up by https://github.com/projectatomic/rpm-ostree/issues/806.

When user types in rpm-ostree [subcommands] -h, the user can now see
more useful information for the subcommands.