### PR TITLE
daemon: use new journal-msg signal

### DIFF
--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -390,9 +390,10 @@ rpmostree_container_builtin_upgrade (int argc, char **argv,
       return EXIT_FAILURE;
     }
 
-  guint current_version;
+  guint current_version = 2;
   if (!parse_app_version (target_current_root, &current_version, error))
     return EXIT_FAILURE;
+  g_assert_cmpuint (current_version, <, 2);
 
   g_autofree char *commit_checksum = NULL;
   g_autofree char *previous_state_sha512 = NULL;
@@ -429,7 +430,7 @@ rpmostree_container_builtin_upgrade (int argc, char **argv,
     previous_state_sha512 = g_variant_dup_string (previous_sha512_v, NULL);
   }
 
-  guint new_version = current_version == 0 ? 1 : 0;
+  guint new_version = (current_version == 0 ? 1 : 0);
   const char *target_new_root;
   if (new_version == 0)
     target_new_root = glnx_strjoina (name, ".0");

--- a/src/daemon/rpmostree-sysroot-core.c
+++ b/src/daemon/rpmostree-sysroot-core.c
@@ -233,7 +233,8 @@ clean_pkgcache_orphans (OstreeSysroot            *sysroot,
   if (n_freed > 0 || freed_space > 0)
     {
       char *freed_space_str = g_format_size_full (freed_space, 0);
-      g_print ("Freed pkgcache branches: %u size: %s\n", n_freed, freed_space_str);
+      rpmostree_output_message ("Freed pkgcache branches: %u size: %s",
+                                n_freed, freed_space_str);
     }
 
   return TRUE;

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -593,9 +593,9 @@ finalize_removal_overrides (RpmOstreeSysrootUpgrader *self,
 
   if (inactive_removals->len > 0)
     {
-      g_print ("Inactive base removals:\n");
+      rpmostree_output_message ("Inactive base removals:");
       for (guint i = 0; i < inactive_removals->len; i++)
-        g_print ("  %s\n", (const char*)inactive_removals->pdata[i]);
+        rpmostree_output_message ("  %s", (const char*)inactive_removals->pdata[i]);
     }
 
   g_assert (!self->override_remove_packages);
@@ -642,9 +642,9 @@ finalize_replacement_overrides (RpmOstreeSysrootUpgrader *self,
 
   if (inactive_replacements->len > 0)
     {
-      g_print ("Inactive base replacements:\n");
+      rpmostree_output_message ("Inactive base replacements:");
       for (guint i = 0; i < inactive_replacements->len; i++)
-        g_print ("  %s\n", (const char*)inactive_replacements->pdata[i]);
+        rpmostree_output_message ("  %s", (const char*)inactive_replacements->pdata[i]);
     }
 
   g_assert (!self->override_replace_local_packages);
@@ -763,9 +763,9 @@ finalize_overlays (RpmOstreeSysrootUpgrader *self,
 
   if (g_hash_table_size (inactive_requests) > 0)
     {
-      g_print ("Inactive requests:\n");
+      rpmostree_output_message ("Inactive requests:");
       GLNX_HASH_TABLE_FOREACH_KV (inactive_requests, const char*, req, const char*, nevra)
-        g_print ("  %s (already provided by %s)\n", req, nevra);
+        rpmostree_output_message ("  %s (already provided by %s)", req, nevra);
     }
 
   g_assert (!self->overlay_packages);

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -303,6 +303,10 @@ sysroot_output_cb (RpmOstreeOutputType type, void *data, void *opaque)
 
   switch (type)
   {
+  case RPMOSTREE_OUTPUT_MESSAGE:
+    rpmostree_transaction_emit_message (RPMOSTREE_TRANSACTION (transaction),
+                                        ((RpmOstreeOutputMessage*)data)->text);
+    break;
   case RPMOSTREE_OUTPUT_TASK_BEGIN:
     rpmostree_transaction_emit_task_begin (RPMOSTREE_TRANSACTION (transaction),
                                            ((RpmOstreeOutputTaskBegin*)data)->text);

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -79,8 +79,6 @@ struct _RpmostreedSysroot {
 
   GFileMonitor *monitor;
   guint sig_changed;
-
-  guint stdout_source_id;
 };
 
 struct _RpmostreedSysrootClass {
@@ -104,187 +102,6 @@ G_DEFINE_TYPE_WITH_CODE (RpmostreedSysroot,
 static RpmostreedSysroot *_sysroot_instance;
 
 /* ---------------------------------------------------------------------------------------------------- */
-
-typedef struct {
-  GWeakRef sysroot;
-  GOutputStream *real_stdout;
-  GDataInputStream *data_stream;
-} StdoutClosure;
-
-static void
-stdout_closure_free (StdoutClosure *closure)
-{
-  g_weak_ref_set (&closure->sysroot, NULL);
-  g_clear_object (&closure->real_stdout);
-  g_clear_object (&closure->data_stream);
-  g_slice_free (StdoutClosure, closure);
-}
-
-static gboolean
-sysroot_stdout_ready_cb (GPollableInputStream *pollable_stream,
-                         StdoutClosure *closure)
-{
-  glnx_unref_object RpmostreedSysroot *sysroot = NULL;
-  glnx_unref_object RpmostreedTransaction *transaction = NULL;
-  GMemoryInputStream *memory_stream;
-  GBufferedInputStream *buffered_stream;
-  char buffer[1024];
-  gconstpointer stream_buffer;
-  gsize stream_buffer_size;
-  gsize total_bytes_read = 0;
-  gboolean have_line = FALSE;
-  GError *local_error = NULL;
-
-  sysroot = g_weak_ref_get (&closure->sysroot);
-  if (sysroot != NULL)
-    transaction = rpmostreed_transaction_monitor_ref_active_transaction (sysroot->transaction_monitor);
-
-  /* XXX Would very much like g_buffered_input_stream_fill_nonblocking().
-   *     Much of this function is a clumsy and inefficient attempt to
-   *     achieve the same thing.
-   *
-   *     See: https://bugzilla.gnome.org/726797
-   */
-
-  buffered_stream = G_BUFFERED_INPUT_STREAM (closure->data_stream);
-  memory_stream = (GMemoryInputStream *) g_filter_input_stream_get_base_stream (G_FILTER_INPUT_STREAM (buffered_stream));
-
-  while (local_error == NULL)
-    {
-      gssize n_read;
-
-      n_read = g_pollable_input_stream_read_nonblocking (pollable_stream,
-                                                         buffer,
-                                                         sizeof (buffer),
-                                                         NULL, &local_error);
-
-      if (n_read > 0)
-        {
-          /* XXX Gotta use GBytes so the data gets copied. */
-          g_autoptr(GBytes) bytes = g_bytes_new (buffer, n_read);
-          g_memory_input_stream_add_bytes (memory_stream, bytes);
-          total_bytes_read += n_read;
-        }
-    }
-
-  if (!g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK))
-    goto out;
-
-  g_clear_error (&local_error);
-
-read_another_line:
-
-  /* Fill the buffered stream with the data we just put in the
-   * memory stream, then peek at the buffer to see if it's safe
-   * to call g_data_input_stream_read_line() without blocking.
-   *
-   * XXX Oye, there's gotta be an easier way to do this...
-   */
-
-  /* This should never fail since it's just reading from memory. */
-  g_buffered_input_stream_fill (buffered_stream, total_bytes_read, NULL, NULL);
-
-  stream_buffer = g_buffered_input_stream_peek_buffer (buffered_stream, &stream_buffer_size);
-  have_line = (memchr (stream_buffer, '\n', stream_buffer_size) != NULL);
-
-  if (have_line)
-    {
-      g_autofree char *line = NULL;
-      gsize length;
-
-      line = g_data_input_stream_read_line (closure->data_stream,
-                                            &length, NULL, &local_error);
-
-      if (local_error != NULL)
-        goto out;
-
-      /* If there's an active transaction, forward the line to the
-       * transaction's owner through the "Message" signal.  Otherwise
-       * dump it to the non-redirected standard output stream. */
-      if (transaction != NULL)
-        {
-          rpmostree_transaction_emit_message (RPMOSTREE_TRANSACTION (transaction), line);
-        }
-      else
-        {
-          /* This is essentially puts(), don't care about errors. */
-          g_output_stream_write_all (closure->real_stdout,
-                                     line, length, NULL, NULL, NULL);
-          g_output_stream_write_all (closure->real_stdout,
-                                     "\n", 1, NULL, NULL, NULL);
-        }
-
-      goto read_another_line;
-    }
-
-out:
-  if (local_error != NULL)
-    {
-      g_warning ("Failed to read stdout pipe: %s", local_error->message);
-      g_clear_error (&local_error);
-    }
-
-  return G_SOURCE_CONTINUE;
-}
-
-static gboolean
-sysroot_setup_stdout_redirect (RpmostreedSysroot *self,
-                               GError **error)
-{
-  g_autoptr(GInputStream) stream = NULL;
-  g_autoptr(GSource) source = NULL;
-  StdoutClosure *closure;
-  gint pipefd[2];
-  gboolean ret = FALSE;
-
-  /* XXX libostree logs messages to systemd's journal and also to stdout.
-   *     Redirect our own stdout back to ourselves so we can capture those
-   *     messages and pass them on to clients.  Admittedly hokey but avoids
-   *     hacking libostree directly (for now). */
-
-  closure = g_slice_new0 (StdoutClosure);
-  g_weak_ref_set (&closure->sysroot, self);
-
-  /* Save the real stdout before overwriting its file descriptor. */
-  closure->real_stdout = g_unix_output_stream_new (dup (STDOUT_FILENO), FALSE);
-
-  if (pipe (pipefd) < 0)
-    {
-      glnx_set_prefix_error_from_errno (error, "%s", "pipe() failed");
-      goto out;
-    }
-
-  if (dup2 (pipefd[1], STDOUT_FILENO) < 0)
-    {
-      glnx_set_prefix_error_from_errno (error, "%s", "dup2() failed");
-      goto out;
-    }
-
-  stream = g_memory_input_stream_new ();
-  closure->data_stream = g_data_input_stream_new (stream);
-  g_clear_object (&stream);
-
-  stream = g_unix_input_stream_new (pipefd[0], FALSE);
-
-  source = g_pollable_input_stream_create_source (G_POLLABLE_INPUT_STREAM (stream),
-                                                  NULL);
-  /* Transfer ownership of the StdoutClosure. */
-  g_source_set_callback (source,
-                         (GSourceFunc) sysroot_stdout_ready_cb,
-                         closure,
-                         (GDestroyNotify) stdout_closure_free);
-  closure = NULL;
-
-  self->stdout_source_id = g_source_attach (source, NULL);
-
-  ret = TRUE;
-
-out:
-  if (closure != NULL)
-    stdout_closure_free (closure);
-
-  return ret;
-}
 
 static void
 sysroot_output_cb (RpmOstreeOutputType type, void *data, void *opaque)
@@ -674,9 +491,6 @@ sysroot_finalize (GObject *object)
   g_clear_object (&self->cancellable);
   g_clear_object (&self->monitor);
 
-  if (self->stdout_source_id > 0)
-    g_source_remove (self->stdout_source_id);
-
   rpmostree_output_set_callback (NULL, NULL);
 
   G_OBJECT_CLASS (rpmostreed_sysroot_parent_class)->finalize (object);
@@ -720,7 +534,6 @@ static void
 sysroot_constructed (GObject *object)
 {
   RpmostreedSysroot *self = RPMOSTREED_SYSROOT (object);
-  GError *local_error = NULL;
 
   g_object_bind_property_full (self->transaction_monitor,
                                "active-transaction",
@@ -742,14 +555,6 @@ sysroot_constructed (GObject *object)
                                NULL,
                                NULL,
                                NULL);
-
-
-  /* Failure is not fatal, but the client may miss some messages. */
-  if (!sysroot_setup_stdout_redirect (self, &local_error))
-    {
-      g_critical ("%s", local_error->message);
-      g_clear_error (&local_error);
-    }
 
   G_OBJECT_CLASS (rpmostreed_sysroot_parent_class)->constructed (object);
 }

--- a/src/daemon/rpmostreed-transaction-livefs.c
+++ b/src/daemon/rpmostreed-transaction-livefs.c
@@ -348,25 +348,26 @@ static void
 print_commit_diff (CommitDiff *diff)
 {
   /* Print out the results of the two diffs */
-  g_print ("Diff Analysis: %s => %s\n", diff->from, diff->to);
-  g_print ("Files:\n modified: %u\n removed: %u\n added: %u\n",
-           diff->modified->len, diff->removed->len, diff->added->len);
-  g_print ("Packages:\n modified: %u\n removed: %u\n added: %u\n",
-           diff->modified_pkgs_new->len, diff->removed_pkgs->len, diff->added_pkgs->len);
+  rpmostree_output_message ("Diff Analysis: %s => %s", diff->from, diff->to);
+  rpmostree_output_message ("Files: modified: %u removed: %u added: %u",
+                            diff->modified->len, diff->removed->len, diff->added->len);
+  rpmostree_output_message ("Packages: modified: %u removed: %u added: %u",
+                            diff->modified_pkgs_new->len,
+                            diff->removed_pkgs->len,
+                            diff->added_pkgs->len);
 
   if (diff->flags & COMMIT_DIFF_FLAGS_ETC)
     {
-      g_print ("* Configuration changed in /etc\n");
+      rpmostree_output_message ("* Configuration changed in /etc");
     }
   if (diff->flags & COMMIT_DIFF_FLAGS_ROOTFS)
     {
-      g_print ("* Content outside of /usr and /etc is modified\n");
+      rpmostree_output_message ("* Content outside of /usr and /etc is modified");
     }
   if (diff->flags & COMMIT_DIFF_FLAGS_BOOT)
     {
-      g_print ("* Kernel/initramfs changed\n");
+      rpmostree_output_message ("* Kernel/initramfs changed");
     }
-  fflush (stdout);
 }
 
 /* We want to ensure the rollback deployment matches our booted checksum. If it
@@ -406,7 +407,7 @@ prepare_rollback_deployment (OstreeSysroot  *sysroot,
   if (!ostree_sysroot_prepare_cleanup (sysroot, cancellable, error))
     return g_prefix_error (error, "Performing initial cleanup: "), FALSE;
 
-  g_print ("Preparing new rollback matching currently booted deployment\n");
+  rpmostree_output_message ("Preparing new rollback matching currently booted deployment");
 
   if (!ostree_sysroot_deploy_tree (sysroot,
                                    ostree_deployment_get_osname (booted_deployment),
@@ -537,9 +538,9 @@ livefs_transaction_execute_inner (LiveFsTransaction *self,
     }
 
   if (resuming_overlay)
-    g_print ("Note: Resuming interrupted overlay of %s\n", target_csum);
+    rpmostree_output_message ("Note: Resuming interrupted overlay of %s", target_csum);
   if (replacing_overlay)
-    g_print ("Note: Previous overlay: %s\n", replacing_overlay);
+    rpmostree_output_message ("Note: Previous overlay: %s", replacing_overlay);
 
   /* Look at the difference between the two commits - we could also walk the
    * filesystem, but doing it at the ostree level is potentially faster, since
@@ -573,7 +574,7 @@ livefs_transaction_execute_inner (LiveFsTransaction *self,
     return glnx_throw (error, "Replacement mode not implemented yet");
   if ((self->flags & RPMOSTREE_TRANSACTION_LIVEFS_FLAG_DRY_RUN) > 0)
     {
-      g_print ("livefs OK (dry run)\n");
+      rpmostree_output_message ("livefs OK (dry run)");
       /* Note early return */
       return TRUE;
     }

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -72,7 +72,7 @@ change_origin_refspec (OstreeSysroot *sysroot,
     g_strcmp0 (new_remote, current_remote) != 0 &&
     g_strcmp0 (new_branch, current_branch) == 0;
   if (switching_only_remote && new_remote != NULL)
-    g_print ("Rebasing to %s:%s\n", new_remote, current_branch);
+    rpmostree_output_message ("Rebasing to %s:%s", new_remote, current_branch);
 
   if (out_new_refspec != NULL)
     *out_new_refspec = g_steal_pointer (&new_refspec);
@@ -1212,7 +1212,7 @@ cleanup_transaction_execute (RpmostreedTransaction *transaction,
         }
       else
         {
-          g_print ("Deployments unchanged.\n");
+          rpmostree_output_message ("Deployments unchanged.");
         }
     }
   if (self->flags & RPMOSTREE_TRANSACTION_CLEANUP_BASE)

--- a/src/daemon/rpmostreed-transaction.c
+++ b/src/daemon/rpmostreed-transaction.c
@@ -473,6 +473,15 @@ transaction_constructed (GObject *object)
     }
 }
 
+static void
+on_sysroot_journal_msg (OstreeSysroot *sysroot,
+                        const char    *msg,
+                        void          *opaque)
+{
+  rpmostree_transaction_emit_message (RPMOSTREE_TRANSACTION (opaque), msg);
+}
+
+
 static gboolean
 transaction_initable_init (GInitable *initable,
                            GCancellable *cancellable,
@@ -513,6 +522,8 @@ transaction_initable_init (GInitable *initable,
        * everything from disk.
        */
       priv->sysroot = ostree_sysroot_new (tmp_path);
+      g_signal_connect (priv->sysroot, "journal-msg",
+                        G_CALLBACK (on_sysroot_journal_msg), self);
 
       if (!ostree_sysroot_load (priv->sysroot, cancellable, error))
         return FALSE;

--- a/src/libpriv/rpmostree-output.c
+++ b/src/libpriv/rpmostree-output.c
@@ -37,6 +37,9 @@ rpmostree_output_default_handler (RpmOstreeOutputType type,
 {
   switch (type)
   {
+  case RPMOSTREE_OUTPUT_MESSAGE:
+    g_print ("%s\n", ((RpmOstreeOutputMessage*)data)->text);
+    break;
   case RPMOSTREE_OUTPUT_TASK_BEGIN:
     /* XXX: move to libglnx spinner once it's implemented */
     g_print ("%s... ", ((RpmOstreeOutputTaskBegin*)data)->text);
@@ -71,36 +74,33 @@ rpmostree_output_set_callback (void (*cb)(RpmOstreeOutputType, void*, void*),
   active_cb_opaque = opaque;
 }
 
+#define strdup_vprintf(format)                  \
+  ({ va_list args; va_start (args, format);     \
+     char *s = g_strdup_vprintf (format, args); \
+     va_end (args); s; })
+
+void
+rpmostree_output_message (const char *format, ...)
+{
+  g_autofree char *final_msg = strdup_vprintf (format);
+  RpmOstreeOutputMessage task = { final_msg };
+  active_cb (RPMOSTREE_OUTPUT_MESSAGE, &task, active_cb_opaque);
+}
+
 void
 rpmostree_output_task_begin (const char *format, ...)
 {
-  g_autofree char *final = NULL;
-  va_list args;
-
-  va_start (args, format);
-  final = g_strdup_vprintf (format, args);
-  va_end (args);
-
-  {
-    RpmOstreeOutputTaskBegin task = { final };
-    active_cb (RPMOSTREE_OUTPUT_TASK_BEGIN, &task, active_cb_opaque);
-  }
+  g_autofree char *final_msg = strdup_vprintf (format);
+  RpmOstreeOutputTaskBegin task = { final_msg };
+  active_cb (RPMOSTREE_OUTPUT_TASK_BEGIN, &task, active_cb_opaque);
 }
 
 void
 rpmostree_output_task_end (const char *format, ...)
 {
-  g_autofree char *final = NULL;
-  va_list args;
-
-  va_start (args, format);
-  final = g_strdup_vprintf (format, args);
-  va_end (args);
-
-  {
-    RpmOstreeOutputTaskEnd task = { final };
-    active_cb (RPMOSTREE_OUTPUT_TASK_END, &task, active_cb_opaque);
-  }
+  g_autofree char *final_msg = strdup_vprintf (format);
+  RpmOstreeOutputTaskEnd task = { final_msg };
+  active_cb (RPMOSTREE_OUTPUT_TASK_END, &task, active_cb_opaque);
 }
 
 void

--- a/src/libpriv/rpmostree-output.h
+++ b/src/libpriv/rpmostree-output.h
@@ -19,6 +19,7 @@
 #pragma once
 
 typedef enum {
+  RPMOSTREE_OUTPUT_MESSAGE,
   RPMOSTREE_OUTPUT_TASK_BEGIN,
   RPMOSTREE_OUTPUT_TASK_END,
   RPMOSTREE_OUTPUT_PERCENT_PROGRESS,
@@ -33,12 +34,17 @@ rpmostree_output_set_callback (void (*cb)(RpmOstreeOutputType, void*, void*), vo
 
 typedef struct {
   const char *text;
-} RpmOstreeOutputTaskBegin;
+} RpmOstreeOutputMessage;
+
+void
+rpmostree_output_message (const char *format, ...) G_GNUC_PRINTF (1,2);
+
+typedef RpmOstreeOutputMessage RpmOstreeOutputTaskBegin;
 
 void
 rpmostree_output_task_begin (const char *format, ...) G_GNUC_PRINTF (1,2);
 
-typedef RpmOstreeOutputTaskBegin RpmOstreeOutputTaskEnd;
+typedef RpmOstreeOutputMessage RpmOstreeOutputTaskEnd;
 
 void
 rpmostree_output_task_end (const char *format, ...) G_GNUC_PRINTF (1,2);

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include "rpmostree-rpm-util.h"
+#include "rpmostree-output.h"
 
 #include <inttypes.h>
 #include <fnmatch.h>
@@ -960,8 +961,8 @@ print_pkglist (GPtrArray *pkglist)
   for (guint i = 0; i < pkglist->len; i++)
     {
       DnfPackage *pkg = pkglist->pdata[i];
-      g_print ("  %s (%s)\n", dnf_package_get_nevra (pkg),
-                              dnf_package_get_reponame (pkg));
+      rpmostree_output_message ("  %s (%s)", dnf_package_get_nevra (pkg),
+                                             dnf_package_get_reponame (pkg));
     }
 }
 
@@ -981,7 +982,7 @@ rpmostree_print_transaction (DnfContext   *hifctx)
     if (packages->len > 0)
       {
         empty = FALSE;
-        g_print ("Installing %u packages:\n", packages->len);
+        rpmostree_output_message ("Installing %u packages:", packages->len);
         print_pkglist (packages);
       }
   }
@@ -995,13 +996,13 @@ rpmostree_print_transaction (DnfContext   *hifctx)
     if (packages->len > 0)
       {
         empty = FALSE;
-        g_print ("Removing %u packages:\n", packages->len);
+        rpmostree_output_message ("Removing %u packages:", packages->len);
         print_pkglist (packages);
       }
   }
 
   if (empty)
-    g_print ("Empty transaction\n");
+    rpmostree_output_message ("Empty transaction");
 }
 
 struct _cap_struct {


### PR DESCRIPTION
Make use of the new `journal-msg` signal that `OstreeSysroot` emits. This
allows us to drop the outrageous hacks we had to do to watch our own
`stdout`, part of which Coverity didn't like.

Coverity CID: 163694