### PR TITLE
tree-wide: Port to ostree_repo_{open,create}_at()

### DIFF
--- a/src/app/rpmostree-builtin-db.c
+++ b/src/app/rpmostree-builtin-db.c
@@ -78,10 +78,8 @@ rpmostree_db_option_context_parse (GOptionContext *context,
     }
   else
     {
-      g_autoptr(GFile) repo_file = g_file_new_for_path (opt_repo);
-
-      repo = ostree_repo_new (repo_file);
-      if (!ostree_repo_open (repo, cancellable, error))
+      repo = ostree_repo_open_at (AT_FDCWD, opt_repo, cancellable, error);
+      if (!repo)
         return FALSE;
     }
 

--- a/src/app/rpmostree-ex-builtin-unpack.c
+++ b/src/app/rpmostree-ex-builtin-unpack.c
@@ -84,13 +84,9 @@ rpmostree_ex_builtin_unpack (int             argc,
   target = argv[1];
   rpmpath = argv[2];
 
-  {
-    g_autoptr(GFile) ostree_repo_file = g_file_new_for_path (target);
-
-    ostree_repo = ostree_repo_new (ostree_repo_file);
-    if (!ostree_repo_open (ostree_repo, cancellable, error))
-      goto out;
-  }
+  ostree_repo = ostree_repo_open_at (AT_FDCWD, target, cancellable, error);
+  if (!ostree_repo)
+    goto out;
 
   if (opt_ostree_convention)
     flags |= RPMOSTREE_UNPACKER_FLAGS_OSTREE_CONVENTION;

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -388,12 +388,8 @@ rpmostree_context_new_internal (int           userroot_dfd,
     }
   else
     {
-      g_autofree char *repopath_str = glnx_fdrel_abspath (userroot_dfd, "repo");
-      g_autoptr(GFile) repopath = g_file_new_for_path (repopath_str);
-
-      ret->ostreerepo = ostree_repo_new (repopath);
-
-      if (!ostree_repo_open (ret->ostreerepo, cancellable, error))
+      ret->ostreerepo = ostree_repo_open_at (userroot_dfd, "repo", cancellable, error);
+      if (!ret->ostreerepo)
         return NULL;
     }
 

--- a/tests/check/test-utils.c
+++ b/tests/check/test-utils.c
@@ -119,10 +119,11 @@ test_variant_to_nevra(void)
   GError *error = NULL;
 
   g_autoptr(GFile) repo_path = g_file_new_for_path ("repo");
-  g_autoptr(OstreeRepo) repo = ostree_repo_new (repo_path);
-  ret = ostree_repo_create (repo, OSTREE_REPO_MODE_BARE_USER, NULL, &error);
+  g_autoptr(OstreeRepo) repo =
+    ostree_repo_create_at (AT_FDCWD, "repo", OSTREE_REPO_MODE_BARE_USER,
+                           NULL, NULL, &error);
+  g_assert (repo);
   g_assert_no_error (error);
-  g_assert (ret);
 
   const char *nevra = "foo-1.0-1.x86_64";
   const char *name = "foo";


### PR DESCRIPTION
A lot of code gets nicer.
