### PR TITLE
tree-wide: Some misc libglnx porting

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -666,10 +666,7 @@ impl_compose_tree (const char      *treefile_pathstr,
     {
       self->cachedir_dfd = fcntl (self->workdir_dfd, F_DUPFD_CLOEXEC, 3);
       if (self->cachedir_dfd < 0)
-        {
-          glnx_set_error_from_errno (error);
-          return FALSE;
-        }
+        return glnx_throw_errno_prefix (error, "fcntl");
     }
 
   g_autoptr(GHashTable) metadata_hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, (GDestroyNotify)g_variant_unref);
@@ -707,10 +704,7 @@ impl_compose_tree (const char      *treefile_pathstr,
     }
 
   if (fchdir (self->workdir_dfd) != 0)
-    {
-      glnx_set_error_from_errno (error);
-      return FALSE;
-    }
+    return glnx_throw_errno_prefix (error, "fchdir");
 
   self->corectx = rpmostree_context_new_compose (self->cachedir_dfd, cancellable, error);
   if (!self->corectx)

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1154,10 +1154,7 @@ remove_directory_content_if_exists (int dfd,
   if (fd < 0)
     {
       if (errno != ENOENT)
-        {
-          glnx_set_error_from_errno (error);
-          return FALSE;
-        }
+        return glnx_throw_errno_prefix (error, "opendir(%s)", path);
     }
   else
     {

--- a/src/libpriv/rpmostree-kernel.c
+++ b/src/libpriv/rpmostree-kernel.c
@@ -59,10 +59,7 @@ find_kernel_and_initramfs_in_bootdir (int          rootfs_dfd,
       if (errno == ENOENT)
         return TRUE;
       else
-        {
-          glnx_set_error_from_errno (error);
-          return FALSE;
-        }
+        return glnx_throw_errno_prefix (error, "opendir(%s)", bootdir);
     }
   if (!glnx_dirfd_iterator_init_take_fd (&dfd, &dfd_iter, error))
     return FALSE;
@@ -252,11 +249,8 @@ rpmostree_finalize_kernel (int rootfs_dfd,
   initramfs_final_path = g_strconcat (bootdir, "/", "initramfs-", kver, ".img-", boot_checksum_str, NULL);
 
   /* Put the kernel in the final location */
-  if (renameat (rootfs_dfd, kernel_path, rootfs_dfd, kernel_final_path) < 0)
-    {
-      glnx_set_error_from_errno (error);
-      return FALSE;
-    }
+  if (!glnx_renameat (rootfs_dfd, kernel_path, rootfs_dfd, kernel_final_path, error))
+    return FALSE;
   /* Link the initramfs directly to its final destination */
   if (!glnx_link_tmpfile_at (initramfs_tmpf, GLNX_LINK_TMPFILE_NOREPLACE,
                              rootfs_dfd, initramfs_final_path,

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -688,16 +688,10 @@ hardlink_recurse (int                src_dfd,
         {
           mode_t perms = stbuf.st_mode & ~S_IFMT;
 
-          if (mkdirat (dest_target_dfd, dent->d_name, perms) < 0)
-            {
-              glnx_set_error_from_errno (error);
-              return FALSE;
-            }
+          if (!glnx_ensure_dir (dest_target_dfd, dent->d_name, perms, error))
+            return FALSE;
           if (fchmodat (dest_target_dfd, dent->d_name, perms, 0) < 0)
-            {
-              glnx_set_error_from_errno (error);
-              return FALSE;
-            }
+            return glnx_throw_errno_prefix (error, "fchmodat");
           if (!hardlink_recurse (dfd_iter.fd, dent->d_name,
                                  dest_target_dfd, dent->d_name,
                                  cancellable, error))
@@ -707,10 +701,7 @@ hardlink_recurse (int                src_dfd,
         {
           if (linkat (dfd_iter.fd, dent->d_name,
                       dest_target_dfd, dent->d_name, 0) < 0)
-            {
-              glnx_set_error_from_errno (error);
-              return FALSE;
-            }
+            return glnx_throw_errno_prefix (error, "linkat");
         }
     }
 


### PR DESCRIPTION
Port away from `glnx_set_error_from_errno` to prefixing errors or libglnx
wrappers as appropriate.
