### PR TITLE
bin/compose: Suppress kernel.rpm's dracut run

### DIFF
--- a/tests/compose
+++ b/tests/compose
@@ -60,7 +60,8 @@ if [ -n "${RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO:-}" ]; then
 fi
 
 # Delete the default ref, since we want to use subrefs of it
-(rm ${repobuild}/refs/heads/* -rf
+(set -x
+ rm ${repobuild}/refs/heads/* -rf
  rpm-ostree compose --repo=${repobuild} tree --dry-run --cachedir=${test_compose_datadir}/cache ${dn}/composedata/fedora-base.json
  rm ${repobuild}/refs/heads/* -rf) &>> ${LOG}
 


### PR DESCRIPTION
Finally got around to implementing the bit from
https://github.com/systemd/systemd/pull/4174
however suboptimal it is; need the unified core
so we can cleanly ignore the posttrans like
we do others.

Note I intentionally keep the file around in the generated tree so that
installing a kernel RPM per client doesn't try to do any of this either.
