### PR TITLE
tree-wide: Port to new libglnx tmpdir API

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -98,7 +98,7 @@ typedef struct {
   GFile *treefile;
   GFile *previous_root;
   GFile *workdir;
-  gboolean workdir_is_tmp;
+  GLnxTmpDir workdir_tmp;
   int workdir_dfd;
   int cachedir_dfd;
   OstreeRepo *repo;
@@ -115,11 +115,11 @@ rpm_ostree_tree_compose_context_free (RpmOstreeTreeComposeContext *ctx)
   g_clear_object (&ctx->corectx);
   g_clear_object (&ctx->treefile);
   g_clear_object (&ctx->previous_root);
-  if (ctx->workdir_is_tmp)
-    (void) glnx_shutil_rm_rf_at (AT_FDCWD, gs_file_get_path_cached (ctx->workdir), NULL, NULL);
-  g_clear_object (&ctx->workdir);
-  if (ctx->workdir_dfd != -1)
+  /* Only close workdir_dfd if it's not owned by the tmpdir */
+  if (!ctx->workdir_tmp.initialized && ctx->workdir_dfd != -1)
     (void) close (ctx->workdir_dfd);
+  glnx_tmpdir_clear (&ctx->workdir_tmp);
+  g_clear_object (&ctx->workdir);
   if (ctx->cachedir_dfd != -1)
     (void) close (ctx->cachedir_dfd);
   g_clear_object (&ctx->repo);
@@ -663,11 +663,19 @@ impl_compose_tree (const char      *treefile_pathstr,
     g_print ("note: --workdir-tmpfs is deprecated and will be ignored\n");
   if (!opt_workdir)
     {
-      if (!rpmostree_mkdtemp ("/var/tmp/rpm-ostree.XXXXXX", &opt_workdir, NULL, error))
+      if (!glnx_mkdtempat (AT_FDCWD, "/var/tmp/rpm-ostree.XXXXXX", 0700, &self->workdir_tmp, error))
         return FALSE;
-      self->workdir_is_tmp = TRUE;
+      self->workdir = g_file_new_for_path (self->workdir_tmp.path);
+      /* Note special handling of this aliasing in _finalize() */
+      self->workdir_dfd = self->workdir_tmp.fd;
     }
-  self->workdir = g_file_new_for_path (opt_workdir);
+  else
+    {
+      self->workdir = g_file_new_for_path (opt_workdir);
+      if (!glnx_opendirat (AT_FDCWD, gs_file_get_path_cached (self->workdir),
+                           FALSE, &self->workdir_dfd, error))
+        return FALSE;
+    }
 
   self->treefile_context_dirs = g_ptr_array_new_with_free_func ((GDestroyNotify)g_object_unref);
   self->repo = ostree_repo_open_at (AT_FDCWD, opt_repo, cancellable, error);
@@ -675,10 +683,6 @@ impl_compose_tree (const char      *treefile_pathstr,
     return FALSE;
 
   self->treefile = g_file_new_for_path (treefile_pathstr);
-
-  if (!glnx_opendirat (AT_FDCWD, gs_file_get_path_cached (self->workdir),
-                       FALSE, &self->workdir_dfd, error))
-    return FALSE;
 
   if (opt_cachedir)
     {

--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -267,22 +267,16 @@ rpmostree_container_builtin_assemble (int             argc,
     return EXIT_FAILURE;
 
   g_autofree char *commit = NULL;
-  { g_autofree char *tmprootfs = g_strdup ("tmp/rpmostree-commit-XXXXXX");
-    glnx_fd_close int tmprootfs_dfd = -1;
+  { g_auto(GLnxTmpDir) tmpdir = { 0, };
 
-    if (!glnx_mkdtempat (rocctx->userroot_dfd, tmprootfs, 0755, error))
+    if (!glnx_mkdtempat (rocctx->userroot_dfd, "tmp/rpmostree-commit-XXXXXX", 0755,
+                         &tmpdir, error))
       return EXIT_FAILURE;
 
-    if (!glnx_opendirat (rocctx->userroot_dfd, tmprootfs, TRUE,
-                         &tmprootfs_dfd, error))
-      return EXIT_FAILURE;
-
-    if (!rpmostree_context_assemble_commit (rocctx->ctx, tmprootfs_dfd, NULL,
+    if (!rpmostree_context_assemble_commit (rocctx->ctx, tmpdir.fd, NULL,
                                             NULL, RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE,
                                             FALSE, &commit, cancellable, error))
       return EXIT_FAILURE;
-
-    glnx_shutil_rm_rf_at (rocctx->userroot_dfd, tmprootfs, cancellable, NULL);
   }
 
   g_print ("Checking out %s @ %s...\n", name, commit);
@@ -461,23 +455,17 @@ rpmostree_container_builtin_upgrade (int argc, char **argv,
     return EXIT_FAILURE;
 
   g_autofree char *new_commit_checksum = NULL;
-  { g_autofree char *tmprootfs = g_strdup ("tmp/rpmostree-commit-XXXXXX");
-    glnx_fd_close int tmprootfs_dfd = -1;
+  { g_auto(GLnxTmpDir) tmpdir = { 0, };
 
-    if (!glnx_mkdtempat (rocctx->userroot_dfd, tmprootfs, 0755, error))
+    if (!glnx_mkdtempat (rocctx->userroot_dfd, "tmp/rpmostree-commit-XXXXXX", 0755,
+                         &tmpdir, error))
       return EXIT_FAILURE;
 
-    if (!glnx_opendirat (rocctx->userroot_dfd, tmprootfs, TRUE,
-                         &tmprootfs_dfd, error))
-      return EXIT_FAILURE;
-
-    if (!rpmostree_context_assemble_commit (rocctx->ctx, tmprootfs_dfd, NULL,
+    if (!rpmostree_context_assemble_commit (rocctx->ctx, tmpdir.fd, NULL,
                                             NULL, RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE,
                                             TRUE, &new_commit_checksum,
                                             cancellable, error))
       return EXIT_FAILURE;
-
-    glnx_shutil_rm_rf_at (rocctx->userroot_dfd, tmprootfs, cancellable, NULL);
   }
 
   g_print ("Checking out %s @ %s...\n", name, new_commit_checksum);

--- a/src/libpriv/rpmostree-refsack.h
+++ b/src/libpriv/rpmostree-refsack.h
@@ -22,16 +22,16 @@
 #pragma once
 
 #include <libdnf/libdnf.h>
+#include "libglnx.h"
 
 typedef struct {
   volatile gint refcount;
   DnfSack *sack;
-  int temp_base_dfd;
-  char *temp_path;
+  GLnxTmpDir tmpdir;
 } RpmOstreeRefSack;
 
 RpmOstreeRefSack *
-rpmostree_refsack_new (DnfSack *sack, int temp_base_dfd, const char *temp_path);
+rpmostree_refsack_new (DnfSack *sack, GLnxTmpDir *tmpdir);
 
 RpmOstreeRefSack *
 rpmostree_refsack_ref (RpmOstreeRefSack *rsack);

--- a/src/libpriv/rpmostree-refts.h
+++ b/src/libpriv/rpmostree-refts.h
@@ -22,16 +22,16 @@
 #pragma once
 
 #include <libdnf/libdnf.h>
+#include "libglnx.h"
 
 typedef struct {
   volatile gint refcount;
   rpmts ts;
-  int temp_base_dfd;
-  char *temp_path;
+  GLnxTmpDir tmpdir;
 } RpmOstreeRefTs;
 
 RpmOstreeRefTs *
-rpmostree_refts_new (rpmts ts, int temp_base_dfd, const char *temp_path);
+rpmostree_refts_new (rpmts ts, GLnxTmpDir *tmpdir);
 
 RpmOstreeRefTs *
 rpmostree_refts_ref (RpmOstreeRefTs *rts);

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -91,15 +91,6 @@ const char *rpmrev_get_commit (struct RpmRevisionData *self);
 void rpmrev_free (struct RpmRevisionData *ptr);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmRevisionData, rpmrev_free);
 
-gboolean
-rpmostree_checkout_only_rpmdb_tempdir (OstreeRepo       *repo,
-                                       const char       *ref,
-                                       const char       *template,
-                                       char            **out_tempdir,
-                                       int              *out_tempdir_dfd,
-                                       GCancellable     *cancellable,
-                                       GError          **error);
-
 RpmOstreeRefSack *
 rpmostree_get_refsack_for_commit (OstreeRepo                *repo,
                                   const char                *ref,

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -56,45 +56,6 @@ _rpmostree_vardict_lookup_value_required (GVariantDict *dict,
   return r;
 }
 
-gboolean
-rpmostree_mkdtemp (const char   *template,
-                   char        **out_tmpdir,
-                   int          *out_tmpdir_dfd,  /* allow-none */
-                   GError      **error)
-{
-  gboolean ret = FALSE;
-  g_autofree char *tmpdir = g_strdup (template);
-  gboolean created_tmpdir = FALSE;
-  glnx_fd_close int ret_tmpdir_dfd = -1;
-
-  if (mkdtemp (tmpdir) == NULL)
-    {
-      glnx_set_error_from_errno (error);
-      goto out;
-    }
-  created_tmpdir = TRUE;
-
-  if (out_tmpdir_dfd)
-    {
-      if (!glnx_opendirat (AT_FDCWD, tmpdir, FALSE, &ret_tmpdir_dfd, error))
-        goto out;
-    }
-
-  ret = TRUE;
-  *out_tmpdir = g_steal_pointer (&tmpdir);
-  if (out_tmpdir_dfd)
-    {
-      *out_tmpdir_dfd = ret_tmpdir_dfd;
-      ret_tmpdir_dfd = -1;
-    }
- out:
-  if (created_tmpdir && tmpdir)
-    {
-     (void) glnx_shutil_rm_rf_at (AT_FDCWD, tmpdir, NULL, NULL);
-    }
-  return ret;
-}
-
 /* Given a string of the form
  * "bla blah ${foo} blah ${bar}"
  * and a hash table of variables, substitute the variable values.

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -37,11 +37,6 @@ GVariant *_rpmostree_vardict_lookup_value_required (GVariantDict *dict,
                                                     const GVariantType *fmt,
                                                     GError     **error);
 
-gboolean rpmostree_mkdtemp (const char   *template,
-                             char       **out_tmpdir,
-                             int         *out_tmpdir_dfd,  /* allow-none */
-                             GError     **error);
-
 char *
 _rpmostree_varsubst_string (const char *instr,
                             GHashTable *substitutions,


### PR DESCRIPTION
Lots of cleanups, and this also allows us to fully port to new style in several
places.
