### PR TITLE
daemon/upgrader: Use new libostree timestamp-check option

### DIFF
--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -83,3 +83,12 @@ vm_rpmostree rollback
 vm_assert_status_jq ".deployments[0][\"booted\"] == false" \
                     ".deployments[1][\"booted\"] == true"
 echo "ok rollback"
+
+# https://github.com/ostreedev/ostree/pull/1055
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --timestamp=\"October 25 1985\"
+if vm_rpmostree upgrade 2>err.txt; then
+    fatal "upgraded to older commit?"
+fi
+assert_file_has_content err.txt "chronologically older"
+echo "ok failed to upgrade to older commit"
+


### PR DESCRIPTION
Since we have a copy of this libostree code, pick up the new
changes from <https://github.com/ostreedev/ostree/pull/1055>.

Note the added test doesn't really test our logic since
we're only doing local pulls, but at least we have something.
