### PR TITLE
app: Set GSETTINGS_BACKEND=memory early on if root

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -354,6 +354,9 @@ main (int    argc,
 
   /* avoid gvfs (http://bugzilla.gnome.org/show_bug.cgi?id=526454) */
   g_setenv ("GIO_USE_VFS", "local", TRUE);
+  /* There's not really a "root dconf" right now */
+  if (getuid () == 0)
+    g_assert (g_setenv ("GSETTINGS_BACKEND", "memory", TRUE));
   g_set_prgname (argv[0]);
 
   setlocale (LC_ALL, "");

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -354,7 +354,12 @@ main (int    argc,
 
   /* avoid gvfs (http://bugzilla.gnome.org/show_bug.cgi?id=526454) */
   g_setenv ("GIO_USE_VFS", "local", TRUE);
-  /* There's not really a "root dconf" right now */
+  /* There's not really a "root dconf" right now; otherwise we might
+   * try to spawn one via GSocketClient → GProxyResolver → GSettings.
+   *
+   * https://github.com/projectatomic/rpm-ostree/pull/312
+   * https://bugzilla.gnome.org/show_bug.cgi?id=767183
+   **/
   if (getuid () == 0)
     g_assert (g_setenv ("GSETTINGS_BACKEND", "memory", TRUE));
   g_set_prgname (argv[0]);

--- a/src/app/rpmostree-builtin-start-daemon.c
+++ b/src/app/rpmostree-builtin-start-daemon.c
@@ -299,9 +299,6 @@ rpmostree_builtin_start_daemon (int             argc,
   g_autoptr(GOptionContext) opt_context = g_option_context_new (" - start the daemon process");
   g_option_context_add_main_entries (opt_context, opt_entries, NULL);
 
-  /* There's not really a "root dconf" right now */
-  g_assert (g_setenv ("GSETTINGS_BACKEND", "memory", TRUE));
-
   if (!g_option_context_parse (opt_context, &argc, &argv, error))
     return EXIT_FAILURE;
 


### PR DESCRIPTION
I was about to copy this bit from the daemon for subprocess work, so let's
centralize it. Further, we should invoke `setenv()` as early as possible; see
<https://sourceware.org/bugzilla/show_bug.cgi?id=15607#c2>.
