### PR TITLE
lib/bwrap: Use --die-with-parent

### DIFF
--- a/src/libpriv/rpmostree-bwrap.c
+++ b/src/libpriv/rpmostree-bwrap.c
@@ -219,6 +219,7 @@ rpmostree_bwrap_new (int rootfs_fd,
                                      "--ro-bind", "/sys/class", "/sys/class",
                                      "--ro-bind", "/sys/dev", "/sys/dev",
                                      "--ro-bind", "/sys/devices", "/sys/devices",
+                                     "--die-with-parent", /* Since 0.1.8 */
                                      /* Here we do all namespaces except the user one.
                                       * Down the line we want to do a userns too I think,
                                       * but it may need some mapping work.


### PR DESCRIPTION
See <https://github.com/projectatomic/bubblewrap/pull/165>; really every
bwrap use case I can think of should specify this (including ours), it's
just not the default out of conservatism.

This way if the daemon happens to e.g. SEGV it'll also cleanly `SIGKILL` any
outstanding scripts.

Was just looking at our bwrap usage for multiprocess work.
