### PR TITLE
daemon: make use of the new deployment flags

### DIFF
--- a/src/daemon/rpmostree-sysroot-core.h
+++ b/src/daemon/rpmostree-sysroot-core.h
@@ -48,30 +48,23 @@ gboolean rpmostree_syscore_bump_mtime (OstreeSysroot *self, GError **error);
 
 gboolean rpmostree_syscore_deployment_get_live (OstreeSysroot   *sysroot,
                                                 OstreeDeployment *deployment,
-                                                int               deployment_dfd,
                                                 char            **out_inprogress_checksum,
                                                 char            **out_livereplaced_checksum,
                                                 GError          **error);
 
 gboolean rpmostree_syscore_deployment_is_live (OstreeSysroot   *sysroot,
                                                OstreeDeployment *deployment,
-                                               int               deployment_dfd,
                                                gboolean         *out_is_live,
                                                GError          **error);
-
-GPtrArray *rpmostree_syscore_add_deployment (OstreeSysroot      *sysroot,
-                                             OstreeDeployment   *new_deployment,
-                                             OstreeDeployment   *merge_deployment,
-                                             gboolean            pushing_rollback,
-                                             GError            **error);
 
 GPtrArray *rpmostree_syscore_filter_deployments (OstreeSysroot      *sysroot,
                                                  const char         *osname,
                                                  gboolean            remove_pending,
                                                  gboolean            remove_rollback);
 
-gboolean rpmostree_syscore_write_deployments (OstreeSysroot          *sysroot,
-                                              OstreeRepo              *repo,
-                                              GPtrArray              *new_deployments,
-                                              GCancellable           *cancellable,
-                                              GError                **error);
+gboolean rpmostree_syscore_write_deployment (OstreeSysroot           *sysroot,
+                                             OstreeDeployment        *new_deployment,
+                                             OstreeDeployment        *merge_deployment,
+                                             gboolean                 pushing_rollback,
+                                             GCancellable            *cancellable,
+                                             GError                 **error);

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1100,7 +1100,8 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
    */
   if (!self->final_revision)
     {
-      g_autofree char *deployment_path = ostree_sysroot_get_deployment_dirpath (self->sysroot, new_deployment);
+      g_autofree char *deployment_path =
+        ostree_sysroot_get_deployment_dirpath (self->sysroot, new_deployment);
       glnx_fd_close int deployment_dfd = -1;
       if (!glnx_opendirat (ostree_sysroot_get_fd (self->sysroot), deployment_path, TRUE,
                            &deployment_dfd, error))
@@ -1121,13 +1122,9 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
         return FALSE;
     }
 
-  g_autoptr(GPtrArray) new_deployments =
-    rpmostree_syscore_add_deployment (self->sysroot, new_deployment,
-                                      self->cfg_merge_deployment, FALSE, error);
-  if (!new_deployments)
-    return FALSE;
-  if (!rpmostree_syscore_write_deployments (self->sysroot, self->repo, new_deployments,
-                                            cancellable, error))
+  if (!rpmostree_syscore_write_deployment (self->sysroot, new_deployment,
+                                           self->cfg_merge_deployment, FALSE,
+                                           cancellable, error))
     return FALSE;
 
   return TRUE;

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -275,9 +275,8 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
       variant_add_commit_details (&dict, "pending-base-", pending_base_commit);
     }
 
-  if (!rpmostree_syscore_deployment_get_live (sysroot, deployment, -1,
-                                              &live_inprogress, &live_replaced,
-                                              error))
+  if (!rpmostree_syscore_deployment_get_live (sysroot, deployment, &live_inprogress,
+                                              &live_replaced, error))
     return NULL;
 
   if (live_inprogress)

--- a/src/daemon/rpmostreed-transaction-livefs.c
+++ b/src/daemon/rpmostreed-transaction-livefs.c
@@ -422,12 +422,8 @@ prepare_rollback_deployment (OstreeSysroot  *sysroot,
   /* Inherit kernel arguments */
   ostree_deployment_set_bootconfig (new_deployment, new_bootconfig);
 
-  g_autoptr(GPtrArray) new_deployments =
-    rpmostree_syscore_add_deployment (sysroot, new_deployment, booted_deployment, TRUE, error);
-  if (!new_deployments)
-    return FALSE;
-  if (!rpmostree_syscore_write_deployments (sysroot, repo, new_deployments,
-                                            cancellable, error))
+  if (!rpmostree_syscore_write_deployment (sysroot, new_deployment, booted_deployment,
+                                           TRUE, cancellable, error))
     return FALSE;
 
   return TRUE;
@@ -519,9 +515,8 @@ livefs_transaction_execute_inner (LiveFsTransaction *self,
   /* Find out whether we already have a live overlay */
   g_autofree char *live_inprogress = NULL;
   g_autofree char *live_replaced = NULL;
-  if (!rpmostree_syscore_deployment_get_live (sysroot, booted_deployment, -1,
-                                              &live_inprogress, &live_replaced,
-                                              error))
+  if (!rpmostree_syscore_deployment_get_live (sysroot, booted_deployment, &live_inprogress,
+                                              &live_replaced, error))
     return FALSE;
   const char *resuming_overlay = NULL;
   if (live_inprogress != NULL)


### PR DESCRIPTION
Now that we have the semantics we need in libostree, let's just use that
and drop the logic here.

Requires: https://github.com/ostreedev/ostree/pull/1110