### PR TITLE
libvm: set up ControlPath socket in /var/tmp

### DIFF
--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -23,7 +23,7 @@ vm_setup() {
   export VM=${VM:-vmcheck}
   local sshopts="-o User=root \
                  -o ControlMaster=auto \
-                 -o ControlPath=${topsrcdir}/ssh-$VM.sock \
+                 -o ControlPath=/var/tmp/ssh-$VM-$(date +%s%N).sock \
                  -o ControlPersist=yes"
 
   # If we're provided with an ssh-config, make sure we tell


### PR DESCRIPTION
It turns out there's a much smaller limit than `PATH_MAX` for Unix
sockets. On Linux, it's 108 characters. It took me some time to figure
out why `vmcheck` would sometimes fail depending on where the src
directory is and how `${topsrcdir}` is defined. Let's just make things
safer by just using `/var/tmp`.