### PR TITLE
scripts: fix argument ordering

### DIFF
--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -95,8 +95,8 @@ static const KnownRpmScriptKind unsupported_scripts[] = {
 };
 
 static gboolean
-fail_if_interp_is_lua (const char *pkg_name,
-                       const char *interp,
+fail_if_interp_is_lua (const char *interp,
+                       const char *pkg_name,
                        const char *script_desc,
                        GError    **error)
 {


### PR DESCRIPTION
Just noticed this while trying out the unified core work. We were
passing arguments in the wrong order (or alternatively, receiving them
in the wrong order).