### PR TITLE
ci: also compile tests

### DIFF
--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -16,3 +16,5 @@ git clean -dfx
 export CC=clang
 export CFLAGS='-Werror=unused-variable'
 build_default
+# don't actually run the tests, just compile them
+/usr/bin/make check TESTS=


### PR DESCRIPTION
This should make sure we catch test errors such as
https://github.com/GNOME/libglnx/pull/76 when bumping submodules (until
we eventually get a PR tester on libglnx).

Requires: https://github.com/GNOME/libglnx/pull/76