### PR TITLE
core: Run %post before %posttrans

### DIFF
--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -476,7 +476,7 @@ rpmostree_script_run_sync (DnfPackage    *pkg,
                            GCancellable  *cancellable,
                            GError       **error)
 {
-  KnownRpmScriptKind *scriptkind;
+  const KnownRpmScriptKind *scriptkind;
   switch (kind)
     {
     case RPMOSTREE_SCRIPT_PREIN:

--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -45,6 +45,12 @@ struct RpmOstreePackageScriptHandler {
 
 const struct RpmOstreePackageScriptHandler* rpmostree_script_gperf_lookup(const char *key, GPERF_LEN_TYPE length);
 
+typedef enum {
+  RPMOSTREE_SCRIPT_PREIN,
+  RPMOSTREE_SCRIPT_POSTIN,
+  RPMOSTREE_SCRIPT_POSTTRANS,
+} RpmOstreeScriptKind;
+
 gboolean
 rpmostree_script_txn_validate (DnfPackage    *package,
                                Header         hdr,
@@ -52,12 +58,13 @@ rpmostree_script_txn_validate (DnfPackage    *package,
                                GError       **error);
 
 gboolean
-rpmostree_posttrans_run_sync (DnfPackage    *pkg,
-                              Header         hdr,
-                              int            rootfs_fd,
-                              guint         *out_n_run,
-                              GCancellable  *cancellable,
-                              GError       **error);
+rpmostree_script_run_sync (DnfPackage    *pkg,
+                           Header         hdr,
+                           RpmOstreeScriptKind kind,
+                           int            rootfs_fd,
+                           guint         *out_n_run,
+                           GCancellable  *cancellable,
+                           GError       **error);
 
 gboolean
 rpmostree_transfiletriggers_run_sync (Header         hdr,
@@ -65,14 +72,6 @@ rpmostree_transfiletriggers_run_sync (Header         hdr,
                                       guint         *out_n_run,
                                       GCancellable  *cancellable,
                                       GError       **error);
-
-gboolean
-rpmostree_pre_run_sync (DnfPackage    *pkg,
-                        Header         hdr,
-                        int            rootfs_fd,
-                        guint         *out_n_run,
-                        GCancellable  *cancellable,
-                        GError       **error);
 
 gboolean
 rpmostree_deployment_sanitycheck (int           rootfs_fd,

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -63,7 +63,23 @@ echo "ok group scriptpkg1 active"
 
 vm_has_files "/usr/lib/rpmostreetestinterp"
 echo "ok interp"
+# cleanup
+vm_rpmostree uninstall scriptpkg1
+vm_reboot
 
+# post ordering
+vm_build_rpm postorder1 \
+             post 'touch /usr/share/postorder1.post' \
+             posttrans 'test -f /usr/share/postorder1.post && test -f /usr/share/postorder2.post'
+vm_build_rpm postorder2 \
+             requires 'postorder1' \
+             post 'touch /usr/share/postorder2.post' \
+             posttrans 'test -f /usr/share/postorder1.post && test -f /usr/share/postorder2.post'
+vm_rpmostree install postorder{1,2}
+vm_rpmostree cleanup -p
+echo "ok post ordering"
+
+# script expansion
 vm_build_rpm scriptpkg2 \
              post_args "-e" \
              post 'echo %%{_prefix} > /usr/lib/prefixtest.txt'


### PR DESCRIPTION
While working on unified core and the Fedora Atomic Host content set, I hit a
dependency between `docker.posttrans` which tries to read `/etc/os-release`, and
`fedora-release-atomichost.post` which creates that symlink.

It seems best practice to me to run `%post`s strictly before
`%posttrans`; we're not likely to do parallelization anytime
soon anyways.

While here I cleaned things up by having an enum for the script kind,
rather than multiple functions, otherwise we would have had another
wrapper in core.c.
