### PR TITLE
hacking: make it easier to use a custom tree

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -18,7 +18,7 @@ On Fedora, you can install those with the command `dnf builddep rpm-ostree`.
 
 So the build process now looks like any other autotools program:
 
-```
+```sh
 env NOCONFIGURE=1 ./autogen.sh
 ./configure --prefix=/usr --libdir=/usr/lib64 --sysconfdir=/etc
 make
@@ -28,14 +28,14 @@ At this point you can run some of the unit tests with `make check`.
 For more information on this, see `CONTRIBUTING.md`.
 
 Doing builds in a container
-===================================
+===========================
 
 First, we recommend building in a container (for example `docker`); you can use
 other container tools obviously.  See `ci/build.sh` for build and test
 dependencies.
 
 Testing
-=========
+=======
 
 You can use `make check` in a container to run the unit tests.  However,
 if you want to test the daemon in a useful way, you'll need virtualization.
@@ -45,8 +45,18 @@ source directory toplevel.  You can provision a VM however you want; libvirt
 directly, vagrant, a remote OpenStack/EC2 instance, etc.  If you choose
 vagrant for example, do something like this:
 
-```
+```sh
 vagrant ssh-config > /path/to/src/rpm-ostree/ssh-config
+```
+
+The host is expected to be called `vmcheck` in the
+`ssh-config`. You can specify multiple hosts and parallelize
+the `make vmcheck` testsuite run through the `HOSTS`
+variable. For example, if you have three nodes named
+`vmcheck[123]`, you can use:
+
+```sh
+make vmcheck HOSTS='vmcheck1 vmcheck2 vmcheck3'
 ```
 
 Once you have a `ssh-config` set up:
@@ -56,10 +66,47 @@ into the VM.
 
 `make vmoverlay` will do a non-live overlay, and reboot the VM.
 
-For convenience, the `make vmshell` command does the same
-as `make vmsync` but additionally places you in a shell,
-ready to test your changes.
+Note that by default, these commands will retrieve the latest version of ostree
+from the build environment and include those binaries when syncing to the VM.
 
-Note that by default, all the commands above try to re-use
-the same configuration files to save speed. If you want to
-force a cleanup, you can use `VMCLEAN=1`.
+Ideally, you should be installing `ostree` from streams like
+[FAHC](https://pagure.io/fedora-atomic-host-continuous/) and
+[CAHC](https://wiki.centos.org/SpecialInterestGroup/Atomic/Devel), which closely
+track ostree's git master. This allows you to not have to worry about using
+libostree APIs that are not yet released.
+
+Testing with a custom libdnf
+============================
+
+Since rpm-ostree uses libdnf as a submodule for the time being, you can simply
+edit the libdnf submodule directly and the various `make` targets will pick up
+the changes and recompile.
+
+Testing with a custom ostree
+============================
+
+It is sometimes necessary to develop against a version of ostree which is not
+even yet in git master. In such situations, one can simply do:
+
+```sh
+$ # from the rpm-ostree build dir
+$ INSTTREE=$PWD/insttree
+$ rm -rf $INSTTREE
+$ # from the ostree build dir
+$ make
+$ make install DESTDIR=$INSTTREE
+$ # from the rpm-ostree build dir
+$ make
+$ make install DESTDIR=$INSTTREE
+```
+
+At this point, simply set `SKIP_INSTALL=1` when running `vmsync` and `vmoverlay`
+to reuse the installation tree and sync the installed binaries there:
+
+```sh
+$ make vmsync SKIP_INSTALL=1
+$ make vmoverlay SKIP_INSTALL=1
+```
+
+Of course, you can use this pattern for not just ostree but whatever else you'd
+like to install into the VM (e.g. bubblewrap, libsolv, etc...).

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -63,16 +63,17 @@ check-local:
 	@echo "  *** NOTE ***"
 	@echo "  *** NOTE ***"
 
-.PHONY: vmsync vmoverlay vmshell vmcheck testenv
-
-vmsync:
-	@env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/sync.sh
+.PHONY: vmsync vmoverlay vmcheck testenv
 
 HOSTS ?= "vmcheck"
 
+vmsync:
+	@env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/build.sh; \
+	env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/sync.sh
+
 vmoverlay:
 	@if [ -z "$(SKIP_VMOVERLAY)" ]; then \
-	  rm -rf $(abs_top_srcdir)/insttree; \
+	  env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/build.sh; \
 	  echo -n "$(HOSTS)" | xargs -P 0 -n 1 -d ' ' -I {} \
 	    env $(BASE_TESTS_ENVIRONMENT) VM={} \
 	      ./tests/vmcheck/overlay.sh; \

--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -14,7 +14,7 @@ git clean -dfx
 
 # And now a clang build to find unused variables
 export CC=clang
-export CFLAGS='-Werror=unused-variable'
+export CFLAGS='-Werror=unused-variable -Werror=maybe-uninitialized'
 build_default
 # don't actually run the tests, just compile them
 /usr/bin/make check TESTS=

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -488,6 +488,8 @@ rpmostree_script_run_sync (DnfPackage    *pkg,
     case RPMOSTREE_SCRIPT_POSTTRANS:
       scriptkind = &posttrans_script;
       break;
+    default:
+      g_assert_not_reached ();
     }
 
   gboolean did_run = FALSE;

--- a/tests/vmcheck/build.sh
+++ b/tests/vmcheck/build.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # and testing is against git master ostree and that the build container is
 # tracking e.g. CAHC or FAHC (see HACKING.md for more details).
 
-DESTDIR=${abs_top_srcdir}/insttree
+DESTDIR=${topsrcdir}/insttree
 
 rm -rf ${DESTDIR}
 mkdir -p ${DESTDIR}

--- a/tests/vmcheck/build.sh
+++ b/tests/vmcheck/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+# This is just a small wrapper for `make install`, but with the added logic to
+# pull in ostree packages from the build container. We always assume development
+# and testing is against git master ostree and that the build container is
+# tracking e.g. CAHC or FAHC (see HACKING.md for more details).
+
+DESTDIR=${abs_top_srcdir}/insttree
+
+rm -rf ${DESTDIR}
+mkdir -p ${DESTDIR}
+
+ostree --version
+for pkg in ostree{,-libs,-grub2}; do
+
+    rpm -q $pkg
+
+    # We do not have perms to read /etc/grub2 as non-root. In the prebuilt
+    # container case, manpages are missing. Ignore that.
+    rpm -ql $pkg | grep -vE "^/(etc|usr/share/(doc|man))/" >  list.txt
+
+    # Also chown everything to writable, due to
+    # https://bugzilla.redhat.com/show_bug.cgi?id=517575
+    chmod -R u+w ${DESTDIR}/
+
+    # Note we cant use --ignore-missing-args here since it was added in
+    # rsync 3.1.0, but CentOS7 only has rsync 3.0.9. Anyway, we expect
+    # everything in list.txt to be present (otherwise, tweak grep above).
+    rsync -l --files-from=list.txt / ${DESTDIR}/
+
+    rm -f list.txt
+done
+
+make install DESTDIR=${DESTDIR}

--- a/tests/vmcheck/sync.sh
+++ b/tests/vmcheck/sync.sh
@@ -12,55 +12,35 @@ if test -z "${INSIDE_VM:-}"; then
       exit 1
     fi
 
-    set -x
-
-    cd ${topsrcdir}
-    export VMCHECK_INSTTREE=${VMCHECK_INSTTREE:-$(pwd)/insttree}
-
-    # Always pull ostree from the build container; we assume development and
-    # testing is against git master. See also overlay.sh and build.sh.
-    ostree --version
-    for pkg in ostree{,-libs,-grub2}; do
-       rpm -q $pkg
-       # We do not have perms to read /etc/grub2 as non-root. In the prebuilt
-       # container case, manpages are missing. Ignore that.
-       rpm -ql $pkg | grep -vE '^/(etc|usr/share/(doc|man))/' >  list.txt
-       # Also chown everything to writable, due to
-       # https://bugzilla.redhat.com/show_bug.cgi?id=517575
-       chmod -R u+w ${VMCHECK_INSTTREE}/
-       # Note we can't use --ignore-missing-args here since it was added in
-       # rsync 3.1.0, but CentOS7 only has rsync 3.0.9. Anyway, we expect
-       # everything in list.txt to be present (otherwise, tweak grep above).
-       rsync -l --files-from=list.txt / ${VMCHECK_INSTTREE}/
-       rm -f list.txt
-    done
-
-    make install DESTDIR=${VMCHECK_INSTTREE}
     vm_rsync
-
     vm_cmd env INSIDE_VM=1 /var/roothome/sync/tests/vmcheck/sync.sh
     exit 0
-else
+fi
 
-    # then do this in the VM
-    set -x
-    ostree admin unlock || :
+set -x
 
-    # Now, overlay our built binaries & config files
-    INSTTREE=/var/roothome/sync/insttree
-    rsync -rlv $INSTTREE/usr/ /usr/
-    if [ -d $INSTTREE/etc ]; then # on CentOS, the dbus service file is in /usr
-      rsync -rlv $INSTTREE/etc/ /etc/
-    fi
+# And then this code path in the VM
 
-    restorecon -v /usr/bin/rpm-ostree
-    restorecon -v /usr/libexec/rpm-ostreed
-    mkdir -p /etc/systemd/system/rpm-ostreed.service.d
-    # For our test suite at least, to catch things like https://github.com/projectatomic/rpm-ostree/issues/826
-    cat > /etc/systemd/system/rpm-ostreed.service.d/fatal-warnings.conf << EOF
+ostree admin unlock || :
+
+# Now, overlay our built binaries & config files
+INSTTREE=/var/roothome/sync/insttree
+rsync -rlv $INSTTREE/usr/ /usr/
+if [ -d $INSTTREE/etc ]; then # on CentOS, the dbus service file is in /usr
+  rsync -rlv $INSTTREE/etc/ /etc/
+fi
+
+restorecon -v /usr/bin/ostree
+restorecon -v /usr/bin/rpm-ostree
+restorecon -v /usr/libexec/rpm-ostreed
+mkdir -p /etc/systemd/system/rpm-ostreed.service.d
+
+# For our test suite at least, to catch things like
+# https://github.com/projectatomic/rpm-ostree/issues/826
+cat > /etc/systemd/system/rpm-ostreed.service.d/fatal-warnings.conf << EOF
 [Service]
 Environment=G_DEBUG=fatal-warnings
 EOF
-    systemctl daemon-reload
-    systemctl restart rpm-ostreed
-fi
+
+systemctl daemon-reload
+systemctl restart rpm-ostreed

--- a/tests/vmcheck/sync.sh
+++ b/tests/vmcheck/sync.sh
@@ -30,13 +30,11 @@ if [ -d $INSTTREE/etc ]; then # on CentOS, the dbus service file is in /usr
   rsync -rlv $INSTTREE/etc/ /etc/
 fi
 
-restorecon -v /usr/bin/ostree
-restorecon -v /usr/bin/rpm-ostree
-restorecon -v /usr/libexec/rpm-ostreed
-mkdir -p /etc/systemd/system/rpm-ostreed.service.d
+restorecon -v /usr/bin/{rpm-,}ostree /usr/libexec/rpm-ostreed
 
 # For our test suite at least, to catch things like
 # https://github.com/projectatomic/rpm-ostree/issues/826
+mkdir -p /etc/systemd/system/rpm-ostreed.service.d
 cat > /etc/systemd/system/rpm-ostreed.service.d/fatal-warnings.conf << EOF
 [Service]
 Environment=G_DEBUG=fatal-warnings


### PR DESCRIPTION
Let's make using a custom install tree easier and document the process. We split out the insttree step into `build.sh` so that we no longer have to `flock(1)` around it, and also share between `overlay.sh` and `sync.sh`.

---

🚌 This PR brought to you by Plymouth and Brockton Street Railway Co. -- providing safe, convenient, reliable transportation since 1888. 🚌