### PR TITLE
unpacker: Translate /boot → /usr/lib/ostree-boot

### DIFF
--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -131,3 +131,17 @@ fi
 vm_rpmostree upgrade | tee output.txt
 assert_file_has_content output.txt '^Importing:'
 echo "ok invalidate pkgcache from RPM chksum"
+
+# make sure installing in /boot translates to /usr/lib/ostree-boot
+efidir=/boot/EFI/efi/fedora
+vm_build_rpm test-boot \
+             files "${efidir}/*" \
+             install "mkdir -p %{buildroot}/${efidir}/fonts && echo grubenv > %{buildroot}/${efidir}/grubenv && echo unicode > %{buildroot}/${efidir}/fonts/unicode.pf2"
+vm_rpmostree install test-boot
+vm_reboot
+vm_cmd cat /usr/lib/ostree-boot/EFI/efi/fedora/grubenv > grubenv.txt
+assert_file_has_content grubenv.txt grubenv
+vm_cmd cat /usr/lib/ostree-boot/EFI/efi/fedora/fonts/unicode.pf2 > unicode.txt
+assert_file_has_content unicode.txt unicode
+echo "ok failed installed in /boot"
+


### PR DESCRIPTION
At one point `rpm-ostree install libvirt` dragged in libguestfs which in turn
brought in `syslinux-extlinux-nonlinux` which has files in `/boot/extlinux`,
which we rejected.  (That dependency chain appears to have been fixed currently)

For the general case, this is just a partial fix in that we haven't nailed down
the semantics of how updates for `/boot` work.  But in this particular case,
we'll just break libguestfs' `extlinux` verb, which I'm OK with.

Another case is `fwupdate-efi` - we require manual intervention to copy the
data into `/boot` after installing the package.

This is also preparation for [unified core](https://github.com/projectatomic/rpm-ostree/issues/729)
in that we now ensure imported kernels don't end up in `/boot` unless
explicitly configured.

Closes: https://github.com/projectatomic/rpm-ostree/issues/853
