### PR TITLE
libpriv+daemon: Use autocleanup to abort ostree txn

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2214,7 +2214,9 @@ relabel_one_package (OstreeRepo     *repo,
   if (!relabel_rootfs (repo, tmpdir.fd, sepolicy, inout_n_changed, cancellable, error))
     return FALSE;
 
-  if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
+  g_autoptr(_OstreeRepoAutoTransaction) txn =
+    _ostree_repo_auto_transaction_start (repo, cancellable, error);
+  if (!txn)
     return FALSE;
 
   /* write to the tree */
@@ -3157,7 +3159,9 @@ rpmostree_context_commit_tmprootfs (RpmOstreeContext      *self,
 
   rpmostree_output_task_begin ("Writing OSTree commit");
 
-  if (!ostree_repo_prepare_transaction (self->ostreerepo, NULL, cancellable, error))
+  g_autoptr(_OstreeRepoAutoTransaction) txn =
+    _ostree_repo_auto_transaction_start (self->ostreerepo, cancellable, error);
+  if (!txn)
     return FALSE;
 
   { glnx_unref_object OstreeMutableTree *mtree = NULL;

--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -790,29 +790,24 @@ rpmostree_unpacker_unpack_to_ostree (RpmOstreeUnpacker *self,
                                      GCancellable      *cancellable,
                                      GError           **error)
 {
-  gboolean ret = FALSE;
+  g_autoptr(_OstreeRepoAutoTransaction) txn =
+    _ostree_repo_auto_transaction_start (repo, cancellable, error);
+  if (!txn)
+    return FALSE;
+
   g_autofree char *csum = NULL;
-  const char *branch = NULL;
-
-  if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
-    goto out;
-
   if (!import_rpm_to_repo (self, repo, sepolicy, &csum, cancellable, error))
-    goto out;
+    return FALSE;
 
-  branch = rpmostree_unpacker_get_ostree_branch (self);
+  const char *branch = rpmostree_unpacker_get_ostree_branch (self);
   ostree_repo_transaction_set_ref (repo, NULL, branch, csum);
 
   if (!ostree_repo_commit_transaction (repo, NULL, cancellable, error))
-    goto out;
+    return FALSE;
 
   if (out_csum)
     *out_csum = g_steal_pointer (&csum);
-
-  ret = TRUE;
- out:
-  ostree_repo_abort_transaction (repo, cancellable, NULL);
-  return ret;
+  return TRUE;
 }
 
 char *

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -120,3 +120,24 @@ rpmostree_decompose_sha256_nevra (const char **nevra,
 
 char *
 rpmostree_cache_branch_to_nevra (const char *cachebranch);
+
+/* https://github.com/ostreedev/ostree/pull/1132 */
+typedef OstreeRepo _OstreeRepoAutoTransaction;
+static inline void
+_ostree_repo_auto_transaction_cleanup (void *p)
+{
+  OstreeRepo *repo = p;
+  if (repo)
+    (void) ostree_repo_abort_transaction (repo, NULL, NULL);
+}
+
+static inline _OstreeRepoAutoTransaction *
+_ostree_repo_auto_transaction_start (OstreeRepo     *repo,
+                                     GCancellable   *cancellable,
+                                     GError        **error)
+{
+  if (!ostree_repo_prepare_transaction (repo, NULL, cancellable, error))
+    return NULL;
+  return (_OstreeRepoAutoTransaction *)repo;
+}
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (_OstreeRepoAutoTransaction, _ostree_repo_auto_transaction_cleanup)


### PR DESCRIPTION
This allows porting one function each in the unpacker and sysroot to new style.
There were also two cases in the core where we were missing an
`abort_transaction()` invocation.

libostree version in: https://github.com/ostreedev/ostree/pull/1132
Prep for: https://github.com/projectatomic/rpm-ostree/pull/970
