### PR TITLE
test/core: detect file name conflict before rpmdb

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1826,7 +1826,7 @@ checkout_package (OstreeRepo   *repo,
                   GError      **error)
 {
   OstreeRepoCheckoutAtOptions opts = { OSTREE_REPO_CHECKOUT_MODE_USER,
-                                       OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES, };
+                                       OSTREE_REPO_CHECKOUT_OVERWRITE_DISJOINT_UNION_FILES, };
 
   /* We want the checkout to match the repo type so that we get hardlinks. */
   if (ostree_repo_get_mode (repo) == OSTREE_REPO_MODE_BARE)


### PR DESCRIPTION
This is the follow up for issue https://github.com/projectatomic/rpm-ostree/issues/365
and https://github.com/ostreedev/ostree/pull/1116

Now, when installing packages containing conflicting files, the
error will be detected at the ostree side instead.

A test is added for future regression.



