### PR TITLE
ci: workaround broken fedora:26 image

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -18,12 +18,14 @@ cluster:
   container:
     image: registry.fedoraproject.org/fedora:26
 
-packages:
-  - git
-  - rsync
+# https://bugzilla.redhat.com/show_bug.cgi?id=1483553
+#packages:
+#  - git
+#  - rsync
 
 env:
   HOSTS: vmcheck1 vmcheck2 vmcheck3
+  CI_PKGS: git rsync
 
 tests:
   - ci/ci-commitmessage-submodules.sh
@@ -121,10 +123,14 @@ cluster:
 
 context: f26-sanity
 
-packages:
-  - ansible
-  - git
-  - rsync
+# https://bugzilla.redhat.com/show_bug.cgi?id=1483553
+#packages:
+#  - ansible
+#  - git
+#  - rsync
+
+env:
+  CI_PKGS: ansible git rsync
 
 tests:
   - git clone https://github.com/projectatomic/atomic-host-tests

--- a/.papr.yml
+++ b/.papr.yml
@@ -133,7 +133,7 @@ env:
   CI_PKGS: ansible git rsync
 
 tests:
-  - git clone https://github.com/projectatomic/atomic-host-tests
   - ci/build.sh
+  - git clone https://github.com/projectatomic/atomic-host-tests
   - make vmoverlay HOSTS=testnode
   - cd atomic-host-tests && ./.test_director

--- a/.papr.yml
+++ b/.papr.yml
@@ -25,7 +25,7 @@ cluster:
 
 env:
   HOSTS: vmcheck1 vmcheck2 vmcheck3
-  CI_PKGS: git rsync
+  CI_PKGS: rsync
 
 tests:
   - ci/ci-commitmessage-submodules.sh

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -17,12 +17,18 @@ elif [ "$id" == centos ]; then
     echo -e '[cahc]\nbaseurl=https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/build\ngpgcheck=0\n' > /etc/yum.repos.d/cahc.repo
 fi
 
+pkg_upgrade
+
 install_builddeps rpm-ostree
 
 yum install -y /usr/bin/g-ir-scanner # Accidentally omitted
 # Mostly dependencies for tests
 yum install -y ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML clang \
     libubsan libasan libtsan elfutils fuse sudo python-gobject-base
+
+if [ -n "${CI_PKGS:-}" ]; then
+  pkg_install ${CI_PKGS}
+fi
 
 # create an unprivileged user for testing
 adduser testuser

--- a/ci/ci-commitmessage-submodules.sh
+++ b/ci/ci-commitmessage-submodules.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -xeuo pipefail
 
+dn=$(dirname $0)
+. ${dn}/libbuild.sh
+
 # Copyright 2017 Colin Walters <walters@verbum.org>
 # Licensed under the new-BSD license (http://www.opensource.org/licenses/bsd-license.php)
 
@@ -26,6 +29,9 @@ cleanup_tmp() {
     fi
 }
 trap cleanup_tmp EXIT
+
+pkg_upgrade
+pkg_install git
 
 gitdir=$(realpath $(pwd))
 # Create a temporary copy of this (using cp not git clone) so git doesn't

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/bash
 
+pkg_upgrade() {
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1483553
+    if ! yum -y upgrade 2>err.txt; then
+        ecode=$?
+        if grep -q -F -e "BDB1539 Build signature doesn't match environment" err.txt; then
+            rpm --rebuilddb
+            yum -y upgrade
+        else
+            cat err.txt
+            exit ${ecode}
+        fi
+    fi
+}
+
+pkg_install() {
+  yum -y install "$@"
+}
+
 make() {
     /usr/bin/make -j $(getconf _NPROCESSORS_ONLN) "$@"
 }


### PR DESCRIPTION
This is essentially the same workaround as
https://github.com/ostreedev/ostree/pull/1143.

See https://bugzilla.redhat.com/show_bug.cgi?id=1483553.