### PR TITLE
daemon: Add a policy for reload-config

### DIFF
--- a/src/daemon/org.projectatomic.rpmostree1.policy
+++ b/src/daemon/org.projectatomic.rpmostree1.policy
@@ -96,6 +96,16 @@
     </defaults>
   </action>
 
+  <action id="org.projectatomic.rpmostree1.reload-daemon">
+    <description>Reload the daemon state</description>
+    <message>Authentication is required to reload the rpmostree daemon state</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
   <action id="org.projectatomic.rpmostree1.cleanup">
     <description>Clear cache</description>
     <message>Authentication is required to clear cache / pending data</message>

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -582,6 +582,10 @@ sysroot_authorize_method (GDBusInterfaceSkeleton *interface,
       /* GetOS() is always allowed */
       authorized = TRUE;
     }
+  else if (g_strcmp0 (method_name, "ReloadConfig") == 0)
+    {
+      action = "org.projectatomic.rpmostree1.reload-daemon";
+    }
   else if (g_strcmp0 (method_name, "RegisterClient") == 0 ||
            g_strcmp0 (method_name, "UnregisterClient") == 0)
     {


### PR DESCRIPTION
This fixes `rpm-ostree reload` as root, and supports configuring
it to be enabled for other users as well.  This was overlooked
in the polkit work originally.

Closes: https://github.com/projectatomic/rpm-ostree/issues/976
