### PR TITLE
Update libglnx, do some fstatat-noent porting

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -256,12 +256,10 @@ libcontainer_prep_dev (int         rootfs_dfd,
     {
       const char *nodename = devnodes[i];
       struct stat stbuf;
-      if (fstatat (src_fd, nodename, &stbuf, 0) == -1)
-        {
-          if (errno == ENOENT)
-            continue;
-          return glnx_throw_errno (error);
-        }
+      if (!glnx_fstatat_allow_noent (src_fd, nodename, &stbuf, 0, error))
+        return FALSE;
+      if (errno == ENOENT)
+        continue;
 
       if (mknodat (dest_fd, nodename, stbuf.st_mode, stbuf.st_rdev) != 0)
         return glnx_throw_errno (error);

--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -1017,17 +1017,9 @@ rootfs_has_usrlib_passwd (int rootfs_dfd,
   /* Does this rootfs have a usr/lib/passwd?  We might be doing a
    * container or something else.
    */
-  if (fstatat (rootfs_dfd, "usr/lib/passwd", &stbuf, 0) < 0)
-    {
-      if (errno == ENOENT)
-        {
-          *out_have_passwd = FALSE;
-          return TRUE;
-        }
-      else
-        return glnx_throw_errno_prefix (error, "fstatat");
-    }
-  *out_have_passwd = TRUE;
+  if (!glnx_fstatat_allow_noent (rootfs_dfd, "usr/lib/passwd", &stbuf, 0, error))
+    return FALSE;
+  *out_have_passwd = (errno == 0);
   return TRUE;
 }
 


### PR DESCRIPTION
Started on porting to the new `glnx_fstatat_allow_noent()`.  The
usage varies a lot and it felt easy to screw up, so I'm just
starting by doing a few of them.

Update submodule: libglnx
