### PR TITLE
core: Use fd-relative access to rpmdb

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -3078,7 +3078,7 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
     /* if we were passed an existing tmprootfs, and that tmprootfs already has
      * an rpmdb, we have to make sure to break its hardlinks as librpm mutates
      * the db in place */
-    if (!break_hardlinks_at (AT_FDCWD, rpmdb_abspath, cancellable, error))
+    if (!break_hardlinks_at (tmprootfs_dfd, "usr/share/rpm", cancellable, error))
       return FALSE;
 
     set_rpm_macro_define ("_dbpath", rpmdb_abspath);

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -55,6 +55,9 @@ pkgref=$(head -1 refs.txt)
 vm_cmd ostree --repo=/sysroot/ostree/repo/extensions/rpmostree/pkgcache show --print-metadata-key rpmostree.repo ${pkgref} >refdata.txt
 assert_file_has_content refdata.txt 'id.*test-repo'
 rm -f refs.txt refdata.txt
+# This will cover things like us failing to break hardlinks for the rpmdb,
+# as well as rofiles-fuse
+vm_cmd ostree fsck
 echo "ok pkg-add foo"
 
 vm_reboot


### PR DESCRIPTION
I was linking to this code from elsewhere and noticed that
for our hardlink breaks we were not using fd-relative even
though we can.  Down the line if we fork librpm into a separate
process and do e.g. `--dbpath=.` it'll do it too.

(Side note, I verified that commenting out the hardlink breaking
 here was caught by the `ostree fsck` I added to the test suite)
