### PR TITLE
scripts: Support overriding lua, use for glibc-all-langpacks

### DIFF
--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -103,6 +103,22 @@ vm_cmd cat /usr/lib/prefixtest.txt > prefixtest.txt
 assert_file_has_content prefixtest.txt "/usr"
 echo "ok script expansion"
 
+# script overrides (also one that expands)
+vm_build_rpm rpmostree-lua-override-test \
+             post_args "-p <lua>" \
+             post 'posix.stat("/")'
+vm_build_rpm rpmostree-lua-override-test-expand \
+             post_args "-e -p <lua>" \
+             post 'posix.stat("/")'
+vm_rpmostree install rpmostree-lua-override-test{,-expand}
+vm_rpmostree ex livefs
+vm_cmd cat /usr/share/rpmostree-lua-override-test > lua-override.txt
+assert_file_has_content lua-override.txt _install_langs
+vm_cmd rpm --eval '%{_install_langs}' > install-langs.txt
+vm_cmd cat /usr/share/rpmostree-lua-override-test-expand > lua-override-expand.txt
+diff -u install-langs.txt lua-override-expand.txt
+echo "ok script override"
+
 vm_rpmostree rollback
 vm_reboot
 vm_rpmostree cleanup -p


### PR DESCRIPTION
Today in Fedora the `glibc-all-langpacks.posttrans` is implemented
in lua, for no good reason.  See:
https://bugzilla.redhat.com/show_bug.cgi?id=1367585

Since that's stalled out, let's add support for overrides.  This
is obviously a much bigger step with more long term maintenance
implications over our current "ignore scripts" list.  But we can't
block either.

This is needed for unified core work:
https://github.com/projectatomic/rpm-ostree/issues/729

(We also override `fedora-release-atomichost` but I'll likely
 submit a patch for that upstream)
