### PR TITLE
app/upgrade: use signal to determine if changed

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -68,12 +68,12 @@ check-local:
 HOSTS ?= "vmcheck"
 
 vmsync:
-	@env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/install.sh; \
+	@env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/install.sh && \
 	env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/sync.sh
 
 vmoverlay:
 	@if [ -z "$(SKIP_VMOVERLAY)" ]; then \
-	  env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/install.sh; \
+	  env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/install.sh && \
 	  echo -n "$(HOSTS)" | xargs -P 0 -n 1 -d ' ' -I {} \
 	    env $(BASE_TESTS_ENVIRONMENT) VM={} \
 	      ./tests/vmcheck/overlay.sh; \

--- a/src/app/rpmostree-builtin-deploy.c
+++ b/src/app/rpmostree-builtin-deploy.c
@@ -52,7 +52,7 @@ rpmostree_builtin_deploy (int            argc,
   g_autoptr(GOptionContext) context = NULL;
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  g_autoptr(GVariant) default_deployment = NULL;
+  g_autoptr(GVariant) new_default_deployment = NULL;
   g_autofree char *transaction_address = NULL;
   const char * const packages[] = { NULL };
   const char *revision;
@@ -105,7 +105,7 @@ rpmostree_builtin_deploy (int            argc,
     }
   else
     {
-      rpmostree_monitor_default_deployment_change (os_proxy, &default_deployment);
+      rpmostree_monitor_default_deployment_change (os_proxy, &new_default_deployment);
 
       g_autoptr(GVariant) options =
         rpmostree_get_options_variant (opt_reboot,
@@ -174,9 +174,10 @@ rpmostree_builtin_deploy (int            argc,
     }
   else if (!opt_reboot)
     {
-      if (default_deployment == NULL)
+      if (new_default_deployment == NULL)
         return RPM_OSTREE_EXIT_UNCHANGED;
 
+      /* do diff without dbus: https://github.com/projectatomic/rpm-ostree/pull/116 */
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,

--- a/src/app/rpmostree-builtin-deploy.c
+++ b/src/app/rpmostree-builtin-deploy.c
@@ -42,14 +42,6 @@ static GOptionEntry option_entries[] = {
   { NULL }
 };
 
-static void
-default_deployment_changed_cb (GObject *object,
-                               GParamSpec *pspec,
-                               GVariant **value)
-{
-  g_object_get (object, pspec->name, value, NULL);
-}
-
 int
 rpmostree_builtin_deploy (int            argc,
                           char         **argv,
@@ -113,6 +105,8 @@ rpmostree_builtin_deploy (int            argc,
     }
   else
     {
+      rpmostree_monitor_default_deployment_change (os_proxy, &default_deployment);
+
       g_autoptr(GVariant) options =
         rpmostree_get_options_variant (opt_reboot,
                                        TRUE,   /* allow-downgrade */
@@ -121,12 +115,8 @@ rpmostree_builtin_deploy (int            argc,
                                        FALSE,  /* dry-run */
                                        FALSE); /* no-overrides */
 
-      /* This will set the GVariant if the default deployment changes. */
-      g_signal_connect (os_proxy, "notify::default-deployment",
-                        G_CALLBACK (default_deployment_changed_cb),
-                        &default_deployment);
 
-      /* Use newer D-Bus API only if we have to. */
+      /* Use newer D-Bus API only if we have to so we maintain coverage. */
       if (install_pkgs || uninstall_pkgs)
         {
           if (!rpmostree_update_deployment (os_proxy,
@@ -184,13 +174,10 @@ rpmostree_builtin_deploy (int            argc,
     }
   else if (!opt_reboot)
     {
-      const char *sysroot_path;
-
       if (default_deployment == NULL)
         return RPM_OSTREE_EXIT_UNCHANGED;
 
-      sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-
+      const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,
                                                            error))

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -169,7 +169,6 @@ rpmostree_builtin_rebase (int             argc,
     {
       /* rebase operations always result in a new default deployment since we
        * error if the refspec doesn't change */
-
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -167,11 +167,10 @@ rpmostree_builtin_rebase (int             argc,
 
   if (!opt_reboot)
     {
-      const char *sysroot_path;
+      /* rebase operations always result in a new default deployment since we
+       * error if the refspec doesn't change */
 
-      sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-
-      /* By request, doing this without dbus */
+      const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,
                                                            error))

--- a/src/app/rpmostree-builtin-rollback.c
+++ b/src/app/rpmostree-builtin-rollback.c
@@ -90,6 +90,7 @@ rpmostree_builtin_rollback (int             argc,
 
   if (!opt_reboot)
     {
+      /* do diff without dbus: https://github.com/projectatomic/rpm-ostree/pull/116 */
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,

--- a/src/app/rpmostree-builtin-rollback.c
+++ b/src/app/rpmostree-builtin-rollback.c
@@ -90,11 +90,7 @@ rpmostree_builtin_rollback (int             argc,
 
   if (!opt_reboot)
     {
-      const char *sysroot_path;
-
-      sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-
-      /* By request, doing this without dbus */
+      const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,
                                                            error))

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -60,7 +60,7 @@ rpmostree_builtin_upgrade (int             argc,
   g_autoptr(GOptionContext) context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  g_autoptr(GVariant) default_deployment = NULL;
+  g_autoptr(GVariant) new_default_deployment = NULL;
   g_autofree char *transaction_address = NULL;
   _cleanup_peer_ GPid peer_pid = 0;
   const char *const *install_pkgs = NULL;
@@ -117,7 +117,7 @@ rpmostree_builtin_upgrade (int             argc,
     }
   else
     {
-      rpmostree_monitor_default_deployment_change (os_proxy, &default_deployment);
+      rpmostree_monitor_default_deployment_change (os_proxy, &new_default_deployment);
 
       g_autoptr(GVariant) options =
         rpmostree_get_options_variant (opt_reboot,
@@ -184,13 +184,14 @@ rpmostree_builtin_upgrade (int             argc,
     }
   else if (!opt_reboot)
     {
-      if (default_deployment == NULL)
+      if (new_default_deployment == NULL)
         {
           if (opt_upgrade_unchanged_exit_77)
             return RPM_OSTREE_EXIT_UNCHANGED;
           return EXIT_SUCCESS;
         }
 
+      /* do diff without dbus: https://github.com/projectatomic/rpm-ostree/pull/116 */
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -60,8 +60,7 @@ rpmostree_builtin_upgrade (int             argc,
   g_autoptr(GOptionContext) context = g_option_context_new ("");
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
-  g_autoptr(GVariant) previous_default_deployment = NULL;
-  g_autoptr(GVariant) new_default_deployment = NULL;
+  g_autoptr(GVariant) default_deployment = NULL;
   g_autofree char *transaction_address = NULL;
   _cleanup_peer_ GPid peer_pid = 0;
   const char *const *install_pkgs = NULL;
@@ -108,8 +107,6 @@ rpmostree_builtin_upgrade (int             argc,
                                 cancellable, &os_proxy, error))
     return EXIT_FAILURE;
 
-  previous_default_deployment = rpmostree_os_dup_default_deployment (os_proxy);
-
   if (opt_preview || opt_check)
     {
       if (!rpmostree_os_call_download_update_rpm_diff_sync (os_proxy,
@@ -120,6 +117,8 @@ rpmostree_builtin_upgrade (int             argc,
     }
   else
     {
+      rpmostree_monitor_default_deployment_change (os_proxy, &default_deployment);
+
       g_autoptr(GVariant) options =
         rpmostree_get_options_variant (opt_reboot,
                                        opt_allow_downgrade,
@@ -164,8 +163,6 @@ rpmostree_builtin_upgrade (int             argc,
                                                 error))
     return EXIT_FAILURE;
 
-  new_default_deployment = rpmostree_os_dup_default_deployment (os_proxy);
-
   if (opt_preview || opt_check)
     {
       g_autoptr(GVariant) result = NULL;
@@ -187,23 +184,14 @@ rpmostree_builtin_upgrade (int             argc,
     }
   else if (!opt_reboot)
     {
-      const char *sysroot_path;
-      gboolean changed;
-
-      sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-
-      if (previous_default_deployment == new_default_deployment)
-        changed = FALSE;
-      else
-        changed = !g_variant_equal (previous_default_deployment, new_default_deployment);
-
-      if (!changed)
+      if (default_deployment == NULL)
         {
-          if (opt_upgrade_unchanged_exit_77 && !changed)
+          if (opt_upgrade_unchanged_exit_77)
             return RPM_OSTREE_EXIT_UNCHANGED;
           return EXIT_SUCCESS;
         }
 
+      const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,
                                                            error))

--- a/src/app/rpmostree-libbuiltin.c
+++ b/src/app/rpmostree-libbuiltin.c
@@ -33,15 +33,13 @@ rpmostree_usage_error (GOptionContext  *context,
                        const char      *message,
                        GError         **error)
 {
-  g_autofree char *help = NULL;
-
   g_return_if_fail (context != NULL);
   g_return_if_fail (message != NULL);
 
-  help = g_option_context_get_help (context, TRUE, NULL);
+  g_autofree char *help = g_option_context_get_help (context, TRUE, NULL);
   g_printerr ("%s\n", help);
 
-  g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED, message);
+  (void) glnx_throw (error, "usage error: %s", message);
 }
 
 /* Print the diff between the booted and pending deployments */
@@ -50,20 +48,12 @@ rpmostree_print_treepkg_diff_from_sysroot_path (const gchar *sysroot_path,
                                                 GCancellable *cancellable,
                                                 GError **error)
 {
-  glnx_unref_object OstreeSysroot *sysroot = NULL;
-  glnx_unref_object GFile *sysroot_file = NULL;
-  gboolean ret = FALSE;
-
-  sysroot_file = g_file_new_for_path (sysroot_path);
-  sysroot = ostree_sysroot_new (sysroot_file);
-
+  g_autoptr(GFile) sysroot_file = g_file_new_for_path (sysroot_path);
+  g_autoptr(OstreeSysroot) sysroot = ostree_sysroot_new (sysroot_file);
   if (!ostree_sysroot_load (sysroot, cancellable, error))
-    goto out;
+    return FALSE;
 
-  ret = rpmostree_print_treepkg_diff (sysroot, cancellable, error);
-
-out:
-  return ret;
+  return rpmostree_print_treepkg_diff (sysroot, cancellable, error);
 }
 
 /* Print the diff between the booted and pending deployments */
@@ -72,39 +62,32 @@ rpmostree_print_treepkg_diff (OstreeSysroot    *sysroot,
                               GCancellable     *cancellable,
                               GError          **error)
 {
-  gboolean ret = FALSE;
-  OstreeDeployment *booted_deployment;
-  OstreeDeployment *new_deployment;
-  g_autoptr(GPtrArray) deployments =
-    ostree_sysroot_get_deployments (sysroot);
-
-  booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);
-
+  g_autoptr(GPtrArray) deployments = ostree_sysroot_get_deployments (sysroot);
   g_assert (deployments->len > 1);
-  new_deployment = deployments->pdata[0];
+
+  OstreeDeployment *new_deployment = deployments->pdata[0];
+  OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);
 
   if (booted_deployment && new_deployment != booted_deployment)
     {
-      glnx_unref_object OstreeRepo *repo = NULL;
+      g_autoptr(OstreeRepo) repo = NULL;
+      if (!ostree_sysroot_get_repo (sysroot, &repo, cancellable, error))
+        return FALSE;
+
       const char *from_rev = ostree_deployment_get_csum (booted_deployment);
       const char *to_rev = ostree_deployment_get_csum (new_deployment);
+
       g_autoptr(GPtrArray) removed = NULL;
       g_autoptr(GPtrArray) added = NULL;
       g_autoptr(GPtrArray) modified_old = NULL;
       g_autoptr(GPtrArray) modified_new = NULL;
-
-      if (!ostree_sysroot_get_repo (sysroot, &repo, cancellable, error))
-        goto out;
-
       if (!rpm_ostree_db_diff (repo, from_rev, to_rev,
                                &removed, &added, &modified_old, &modified_new,
                                cancellable, error))
-        goto out;
+        return FALSE;
 
       rpmostree_diff_print (repo, removed, added, modified_old, modified_new);
     }
 
-  ret = TRUE;
- out:
-  return ret;
+  return TRUE;
 }

--- a/src/app/rpmostree-libbuiltin.c
+++ b/src/app/rpmostree-libbuiltin.c
@@ -42,6 +42,23 @@ rpmostree_usage_error (GOptionContext  *context,
   (void) glnx_throw (error, "usage error: %s", message);
 }
 
+static void
+default_deployment_change_cb (GObject *object,
+                              GParamSpec *pspec,
+                              GVariant **value)
+{
+  g_object_get (object, pspec->name, value, NULL);
+}
+
+void
+rpmostree_monitor_default_deployment_change (RPMOSTreeOS *os_proxy,
+                                             GVariant   **deployment)
+{
+  /* This will set the GVariant if the default deployment changes. */
+  g_signal_connect (os_proxy, "notify::default-deployment",
+                    G_CALLBACK (default_deployment_change_cb), deployment);
+}
+
 /* Print the diff between the booted and pending deployments */
 gboolean
 rpmostree_print_treepkg_diff_from_sysroot_path (const gchar *sysroot_path,

--- a/src/app/rpmostree-libbuiltin.h
+++ b/src/app/rpmostree-libbuiltin.h
@@ -22,6 +22,8 @@
 
 #include <ostree.h>
 
+#include "rpm-ostreed-generated.h"
+
 G_BEGIN_DECLS
 
 void
@@ -38,4 +40,9 @@ gboolean
 rpmostree_print_treepkg_diff_from_sysroot_path (const gchar *sysroot_path,
                                                 GCancellable *cancellable,
                                                 GError **error);
+
+void
+rpmostree_monitor_default_deployment_change (RPMOSTreeOS *os_proxy,
+                                             GVariant   **deployment);
+
 G_END_DECLS

--- a/src/app/rpmostree-override-builtins.c
+++ b/src/app/rpmostree-override-builtins.c
@@ -93,7 +93,6 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
   else if (!opt_reboot)
     {
       /* override ops currently always result in a new deployment */
-
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,

--- a/src/app/rpmostree-override-builtins.c
+++ b/src/app/rpmostree-override-builtins.c
@@ -92,6 +92,8 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
     }
   else if (!opt_reboot)
     {
+      /* override ops currently always result in a new deployment */
+
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -127,11 +127,9 @@ pkg_change (RPMOSTreeSysroot *sysroot_proxy,
     }
   else if (!opt_reboot)
     {
-      const char *sysroot_path;
+      /* install/uninstall currently always results in a new deployment */
 
-
-      sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
-
+      const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,
                                                            error))

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -128,7 +128,6 @@ pkg_change (RPMOSTreeSysroot *sysroot_proxy,
   else if (!opt_reboot)
     {
       /* install/uninstall currently always results in a new deployment */
-
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,


### PR DESCRIPTION
Make `upgrade` use the same trick as `deploy` to determine if a new
deployment was laid down. Apart from those two, all other operations
that can lay down a new deployment always do so in the happy path.

Prep for further work.