### PR TITLE
livefs: add warning that /etc won't be preserved

### DIFF
--- a/src/daemon/rpmostreed-transaction-livefs.c
+++ b/src/daemon/rpmostreed-transaction-livefs.c
@@ -659,6 +659,9 @@ livefs_transaction_execute_inner (LiveFsTransaction *self,
         return FALSE;
     }
 
+  /* XXX: right now we don't have a good solution for this */
+  rpmostree_output_message ("WARNING: changes to /etc are not currently preserved!");
+
   /* Write out the origin as having completed this */
   if (!write_livefs_state (sysroot, booted_deployment, NULL, target_csum, error))
     return FALSE;


### PR DESCRIPTION
Since the whole premise of livefs is that you stay in your deployment
just a little longer, it becomes much more likely for people to run into
https://github.com/projectatomic/rpm-ostree/issues/40 (myself included).

Printing such a notice was discussed in the initial livefs design
discussions: https://github.com/projectatomic/rpm-ostree/issues/639.