### PR TITLE
tests/core: allow merging identical files during installation

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1822,7 +1822,7 @@ checkout_package (OstreeRepo   *repo,
                   GError      **error)
 {
   OstreeRepoCheckoutAtOptions opts = { OSTREE_REPO_CHECKOUT_MODE_USER,
-                                       OSTREE_REPO_CHECKOUT_OVERWRITE_DISJOINT_UNION_FILES, };
+                                       OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_IDENTICAL, };
 
   /* We want the checkout to match the repo type so that we get hardlinks. */
   if (ostree_repo_get_mode (repo) == OSTREE_REPO_MODE_BARE)

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -101,13 +101,21 @@ assert_file_has_content err.txt "chronologically older"
 echo "ok failed to upgrade to older commit"
 
 # https://github.com/projectatomic/rpm-ostree/issues/365
-vm_build_rpm test-conflict \
+vm_build_rpm base-package \
     files /usr/app \
     install "mkdir -p %{buildroot}/usr/app
              echo one > %{buildroot}/usr/app/conflict-file"
-vm_rpmostree install test-conflict
+vm_rpmostree install base-package
 
-# build a rpm containing the same file and test for error
+# build a file having exact same content and check for merging
+vm_build_rpm test-merging \
+    files /usr/app \
+    install "mkdir -p %{buildroot}/usr/app
+             echo one > %{buildroot}/usr/app/conflict-file"
+vm_rpmostree install test-merging
+echo "ok identical file merges"
+
+# have a file with same file path but different content, testing for conflicts
 vm_build_rpm conflict-pkg \
     files /usr/app \
     install "mkdir -p %{buildroot}/usr/app


### PR DESCRIPTION
This PR uses https://github.com/ostreedev/ostree/pull/1156
to ensure that when installing packages containing files with
exact same content, the files will be merged.

When installing packages containing conflicting files,
the error will still be detected at the ostree side.

The checkout overwrite option at rpm-ostree side is also
modified to accomodate the changes made in ostree side.

A test is added for regression.