### PR TITLE
ci: don't run clang on CentOS

### DIFF
--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -12,9 +12,14 @@ ${dn}/build.sh
 make install
 git clean -dfx
 
-# And now a clang build to find unused variables
-export CC=clang
-export CFLAGS='-Werror=unused-variable -Werror=maybe-uninitialized'
-build_default
-# don't actually run the tests, just compile them
-/usr/bin/make check TESTS=
+# And now a clang build to find unused variables, but only run on Fedora because
+# the CentOS version is ancient anyway and doesn't support all the flags that
+# might get passed to it.
+id=$(. /etc/os-release && echo $ID)
+if [ "$id" == fedora ]; then
+    export CC=clang
+    export CFLAGS='-Werror=unused-variable -Werror=maybe-uninitialized'
+    build_default
+    # don't actually run the tests, just compile them
+    /usr/bin/make check TESTS=
+fi

--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -10,13 +10,13 @@ ${dn}/build.sh
 # support parallel runs right now
 /usr/bin/make check
 make install
-git clean -dfx
 
 # And now a clang build to find unused variables, but only run on Fedora because
 # the CentOS version is ancient anyway and doesn't support all the flags that
 # might get passed to it.
 id=$(. /etc/os-release && echo $ID)
 if [ "$id" == fedora ]; then
+    git clean -dfx
     export CC=clang
     export CFLAGS='-Werror=unused-variable -Werror=maybe-uninitialized'
     build_default


### PR DESCRIPTION
The CentOS tester is currently failing because clang is being passed an
argument it doesn't know about:

    clang: error: unknown argument: '-fstack-protector-strong'

We get our version of clang from EPEL, which currently has 3.4.2. The
Fedora clang does have support for the flag (4.0.1).

Anyway, the point of this check is just to find unused/uninitialized
vars and other gotchas. In that sense, we're more interested in what the
latest version of clang has to say.