### PR TITLE
daemon/upgrader: Clear core ctx after committing

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -962,6 +962,12 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
                                            cancellable, error))
     return FALSE;
 
+  /* Ensure we aren't holding any references to the tmpdir now that we're
+   * done. */
+  g_clear_object (&self->ctx);
+  (void) close (self->tmprootfs_dfd);
+  self->tmprootfs_dfd = -1;
+
   return TRUE;
 }
 

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -962,8 +962,11 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
                                            cancellable, error))
     return FALSE;
 
-  /* Ensure we aren't holding any references to the tmpdir now that we're
-   * done. */
+  /* Ensure we aren't holding any references to the tmpdir now that we're done;
+   * rpmostree_sysroot_upgrader_deploy() eventually calls
+   * rpmostree_syscore_cleanup() which deletes 🗑 the tmpdir.  See also similar
+   * bits in the compose and container path.
+   */
   g_clear_object (&self->ctx);
   (void) close (self->tmprootfs_dfd);
   self->tmprootfs_dfd = -1;


### PR DESCRIPTION
Amazingly we had 3 variations of this bug in the different
layers above using the `RpmOstreeContext` API (in compose, container,
and layering).

We fixed the first two already, this fixes the last one.  We
get a warning if librpm holds a ref to a deleted rpmdb.

Closes: https://github.com/projectatomic/rpm-ostree/issues/987
