### PR TITLE
tests/livefs: Make sure /usr/bin/ls is executable

### DIFF
--- a/tests/vmcheck/test-livefs.sh
+++ b/tests/vmcheck/test-livefs.sh
@@ -128,6 +128,7 @@ cd /ostree/repo/tmp
 rm vmcheck -rf
 ostree checkout vmcheck vmcheck --fsync=0
 (cat vmcheck/usr/bin/ls; echo more stuff) > vmcheck/usr/bin/ls.new
+chmod a+x vmcheck/usr/bin/ls.new
 mv vmcheck/usr/bin/ls{.new,}
 ostree commit -b vmcheck --tree=dir=vmcheck --link-checkout-speedup
 rm vmcheck -rf


### PR DESCRIPTION
Oh man was I confused how this happened; thought it was a bug in some livefs
changes I was working on.
