### PR TITLE
libpriv/scripts: prefix scriptlet outputs in journal

### DIFF
--- a/src/libpriv/rpmostree-bwrap.c
+++ b/src/libpriv/rpmostree-bwrap.c
@@ -300,7 +300,7 @@ rpmostree_bwrap_set_child_setup (RpmOstreeBwrap *bwrap,
 
 gboolean
 rpmostree_bwrap_run (RpmOstreeBwrap *bwrap,
-                     GError **error)
+                     GError        **error)
 {
   int estatus;
   const char *current_lang = getenv ("LANG");
@@ -328,10 +328,11 @@ rpmostree_bwrap_run (RpmOstreeBwrap *bwrap,
     const char *errmsg = glnx_strjoina ("Executing bwrap(", bwrap->child_argv0, ")");
     GLNX_AUTO_PREFIX_ERROR (errmsg, error);
 
-    if (!g_spawn_sync (NULL, (char**)bwrap->argv->pdata, (char**) bwrap_env, G_SPAWN_SEARCH_PATH,
-                       bwrap_child_setup, bwrap,
-                       NULL, NULL, &estatus, error))
+    if (!g_spawn_sync (NULL, (char**)bwrap->argv->pdata, (char**) bwrap_env,
+                       G_SPAWN_SEARCH_PATH, bwrap_child_setup, bwrap, NULL, NULL,
+                       &estatus, error))
       return FALSE;
+
     if (!g_spawn_check_exit_status (estatus, error))
       return FALSE;
   }

--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -50,6 +50,7 @@ void rpmostree_bwrap_set_child_setup (RpmOstreeBwrap *bwrap,
                                       GSpawnChildSetupFunc func,
                                       gpointer             data);
 
-gboolean rpmostree_bwrap_run (RpmOstreeBwrap *bwrap, GError **error);
+gboolean rpmostree_bwrap_run (RpmOstreeBwrap *bwrap,
+                              GError        **error);
 
 gboolean rpmostree_bwrap_selftest (GError **error);

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -349,4 +349,5 @@ vm_assert_journal_has_content() {
   # add an extra helping of quotes for hungry ssh
   vm_cmd journalctl --after-cursor "'$from_cursor'" > tmp-journal.txt
   assert_file_has_content tmp-journal.txt "$@"
+  rm -f tmp-journal.txt
 }

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -339,3 +339,14 @@ vm_build_rpm() {
     build_rpm "$@"
     vm_send_test_repo 0 # XXX use rsync
 }
+
+vm_get_journal_cursor() {
+  vm_cmd journalctl -o json -n 1 | jq -r '.["__CURSOR"]'
+}
+
+vm_assert_journal_has_content() {
+  from_cursor=$1; shift
+  # add an extra helping of quotes for hungry ssh
+  vm_cmd journalctl --after-cursor "'$from_cursor'" > tmp-journal.txt
+  assert_file_has_content tmp-journal.txt "$@"
+}

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -150,6 +150,6 @@ cursor=$(vm_get_journal_cursor)
 if vm_rpmostree install bad-post &> err.txt; then
   assert_not_reached "installing pkg with failing post unexpectedly succeeded"
 fi
-assert_file_has_content err.txt "Run.*journalctl.*for more information"
+assert_file_has_content err.txt "run.*journalctl.*for more information"
 vm_assert_journal_has_content $cursor 'rpm-ostree(bad-post.post).*a bad post'
 echo "ok script output prefixed in journal"


### PR DESCRIPTION
It's annoying to just get a "`Child process exited with code $x`" when
something goes wrong during script execution. Let's try to be a bit more
helpful to make debugging easier by appending the `stderr` output of the
script if any.