### PR TITLE
add support for layering packages with SELinux packages

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -21,7 +21,8 @@ pkg_upgrade
 pkg_install_builddeps rpm-ostree
 # Mostly dependencies for tests
 pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML clang \
-    libubsan libasan libtsan elfutils fuse sudo python-gobject-base
+    libubsan libasan libtsan elfutils fuse sudo python-gobject-base \
+    selinux-policy-devel
 # For ex-container tests
 pkg_install_if_os fedora parallel
 

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -3289,6 +3289,20 @@ rpmostree_context_commit_tmprootfs (RpmOstreeContext      *self,
 
     ostree_repo_commit_modifier_set_devino_cache (commit_modifier, devino_cache);
 
+    /* if we're SELinux aware, then reload the final policy from the tmprootfs in case it
+     * was changed by a scriptlet; this covers the foobar/foobar-selinux path */
+    if (self->sepolicy)
+      {
+        g_autoptr(OstreeSePolicy) final_sepolicy = NULL;
+        if (!rpmostree_prepare_rootfs_get_sepolicy (tmprootfs_dfd, &final_sepolicy,
+                                                    cancellable, error))
+          return FALSE;
+
+        /* takes a ref */
+        ostree_repo_commit_modifier_set_sepolicy (commit_modifier, final_sepolicy);
+      }
+
+
     mtree = ostree_mutable_tree_new ();
 
     if (!ostree_repo_write_dfd_to_mtree (self->ostreerepo, tmprootfs_dfd, ".",

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2346,7 +2346,8 @@ rpmostree_context_relabel (RpmOstreeContext *self,
   rpmostree_output_percent_progress_end ();
 
   sd_journal_send ("MESSAGE_ID=" SD_ID128_FORMAT_STR, SD_ID128_FORMAT_VAL(RPMOSTREE_MESSAGE_SELINUX_RELABEL),
-                   "MESSAGE=Relabeled %u/%u pkgs, %u files changed", n_changed_pkgs, n_to_relabel, n_changed_files,
+                   "MESSAGE=Relabeled %u/%u pkgs, %u file%s changed", n_changed_pkgs,
+                   n_to_relabel, n_changed_files, _NS(n_changed_files),
                    "RELABELED_PKGS=%u/%u", n_changed_pkgs, n_to_relabel,
                    "RELABELED_N_CHANGED_FILES=%u", n_changed_files,
                    NULL);

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -340,6 +340,11 @@ vm_build_rpm() {
     vm_send_test_repo 0 # XXX use rsync
 }
 
+vm_build_selinux_rpm() {
+    build_selinux_rpm "$@"
+    vm_send_test_repo 0 # XXX use rsync
+}
+
 vm_get_journal_cursor() {
   vm_cmd journalctl -o json -n 1 | jq -r '.["__CURSOR"]'
 }

--- a/tests/vmcheck/test-layering-relabel.sh
+++ b/tests/vmcheck/test-layering-relabel.sh
@@ -89,7 +89,7 @@ root=$(vm_get_deployment_root 0)
 assert_actual_label $root/usr/bin/baz bin_t
 cursor=$(vm_get_journal_cursor)
 vm_rpmostree upgrade
-vm_assert_journal_has_content $cursor 'Relabeled 1/1 pkg, 1 file changed'
+vm_assert_journal_has_content $cursor 'Relabeled 1/1 pkgs, 1 file changed'
 root=$(vm_get_deployment_root 0)
 assert_actual_label $root/usr/bin/baz install_exec_t
 echo "ok relabel"

--- a/tests/vmcheck/test-layering-relabel.sh
+++ b/tests/vmcheck/test-layering-relabel.sh
@@ -87,8 +87,9 @@ vm_build_rpm baz
 vm_rpmostree install baz
 root=$(vm_get_deployment_root 0)
 assert_actual_label $root/usr/bin/baz bin_t
-vm_rpmostree upgrade > out.txt
-assert_file_has_content out.txt 'Relabeling 1 package'
+cursor=$(vm_get_journal_cursor)
+vm_rpmostree upgrade
+vm_assert_journal_has_content $cursor 'Relabeled 1/1 pkg, 1 file changed'
 root=$(vm_get_deployment_root 0)
 assert_actual_label $root/usr/bin/baz install_exec_t
 echo "ok relabel"

--- a/tests/vmcheck/test-layering-relabel.sh
+++ b/tests/vmcheck/test-layering-relabel.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# Copyright (C) 2017 Red Hat Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# make sure there's nothing yet
+vm_assert_status_jq \
+  '.deployments[0]["base-checksum"]|not'
+
+# check that pkgs that install sepolicies have their changes take effect
+vm_build_selinux_rpm foobar-selinux /usr/bin/foobar install_exec_t
+vm_build_rpm foobar requires foobar-selinux
+vm_rpmostree install foobar
+vm_assert_status_jq \
+  '.deployments[0]["base-checksum"]' \
+  '.deployments[0]["packages"]|length == 1' \
+  '.deployments[0]["packages"]|index("foobar") >= 0'
+
+assert_expected_label() {
+    local path=$1; shift
+    local expected=system_u:object_r:$1:s0; shift
+    local l=$(vm_cmd matchpathcon -n $path)
+    assert_streq "$l" "$expected"
+}
+
+assert_actual_label() {
+    local path=$1; shift
+    local expected=system_u:object_r:$1:s0; shift
+    local l=$(vm_cmd getfattr -n security.selinux --absolute-names --only-values $path)
+    assert_streq "$l" "$expected"
+}
+
+# shouldn't have affected our current policy
+assert_expected_label /usr/bin/foobar bin_t
+
+# but should have affected the new root
+root=$(vm_get_deployment_root 0)
+assert_actual_label $root/usr/bin/foobar install_exec_t
+echo "ok layer selinux pkg"
+
+# now let's change the policy
+vm_build_selinux_rpm foobar-selinux /usr/bin/foobar shell_exec_t
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
+vm_rpmostree upgrade
+root=$(vm_get_deployment_root 0)
+assert_actual_label $root/usr/bin/foobar shell_exec_t
+echo "ok upgrade selinux pkg"
+
+# check that a change in the base layer binary policy causes a relabel
+# we do this by just baking in a layered RPM that recompiles the policy
+vm_rpmostree cleanup -p
+vm_build_selinux_rpm baz-selinux /usr/bin/baz install_exec_t
+vm_rpmostree install baz-selinux
+se_csum=$(vm_cmd ostree checksum /usr/etc/selinux/targeted/policy/policy.*)
+root=$(vm_get_deployment_root 0)
+se_new_csum=$(vm_cmd ostree checksum $root/usr/etc/selinux/targeted/policy/policy.*)
+assert_not_streq "$se_csum" "$se_new_csum"
+csum=$(vm_get_deployment_info 0 checksum)
+vm_cmd ostree commit -b vmcheck --tree=ref=$csum
+vm_rpmostree cleanup -p
+echo "ok setup relabel"
+
+# now we have a pending upgrade with a different sepolicy
+# let's install some packages before upgrading
+vm_build_rpm baz
+vm_rpmostree install baz
+root=$(vm_get_deployment_root 0)
+assert_actual_label $root/usr/bin/baz bin_t
+vm_rpmostree upgrade > out.txt
+assert_file_has_content out.txt 'Relabeling 1 package'
+root=$(vm_get_deployment_root 0)
+assert_actual_label $root/usr/bin/baz install_exec_t
+echo "ok relabel"


### PR DESCRIPTION
There's a lot of paths in the core related to SELinux policy changes and
relabeling packages. We currently have no test coverage for them. We add
support in the test libraries here to build such packages. Tests will
then be able to do e.g.:

    vm_build_selinux_rpm foobar-selinux /usr/bin/foobar install_exec_t
    vm_build_rpm foobar requires foobar-selinux
    ...