### PR TITLE
libpriv/scripts: use rofiles-fuse on /etc too

### DIFF
--- a/src/libpriv/rpmostree-bwrap.c
+++ b/src/libpriv/rpmostree-bwrap.c
@@ -166,6 +166,12 @@ setup_rofiles_usr (RpmOstreeBwrap *bwrap,
 
   rpmostree_bwrap_append_bwrap_argv (bwrap, "--bind", rofiles_mntpath, "/usr", NULL);
 
+  /* also mount /etc from the rofiles mount to allow RPM scripts to change defaults, while
+   * still being protected; note we use bind to ensure symlinks work, see:
+   * https://github.com/projectatomic/rpm-ostree/pull/640 */
+  const char *rofiles_etc_mntpath = glnx_strjoina (rofiles_mntpath, "/etc");
+  rpmostree_bwrap_append_bwrap_argv (bwrap, "--bind", rofiles_etc_mntpath, "/etc", NULL);
+
   return TRUE;
 }
 

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -255,9 +255,6 @@ run_script_in_bwrap_container (int rootfs_fd,
                                /* Scripts can see a /var with compat links like alternatives */
                                "--ro-bind", "./var", "/var",
                                "--tmpfs", "/var/tmp",
-                               /* Allow RPM scripts to change the /etc defaults; note we use bind
-                                * to ensure symlinks work, see https://github.com/projectatomic/rpm-ostree/pull/640 */
-                               "--bind", "./usr/etc", "/etc",
                                NULL);
   if (!bwrap)
     goto out;

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -174,6 +174,13 @@ if vm_rpmostree install etc-mutate; then
   assert_not_reached "successfully installed etc-mutate?"
 fi
 
+# Ensure this is reset; at least in the Vagrant box with
+# fedora-atomic:fedora/26/x86_64/atomic-host
+# Version: 26.131 (2017-09-19 22:29:04)
+# Commit: 98088cb6ed2a4b3f7e4e7bf6d34f9e137c296bc43640b4c1967631f22fe1802f
+# it starts out modified - the modification is just deletion of trailing
+# whitespace.
+vm_cmd cp /{usr/,}etc/selinux/config
 vm_build_rpm etc-copy post "cp /etc/selinux/config{,.new}
                             echo '# etc-copy comment' >> /etc/selinux/config.new
                             mv /etc/selinux/config{.new,}"


### PR DESCRIPTION
We were directly bind mounting the checked out `/usr/etc` onto `/etc`
which was exposing us to corruption from scriptlets. Since we already
have an rofiles-fuse mount for `/usr`, let's just re-use its `etc/`
subdir and bind mount that instead.