### PR TITLE
libpriv/passwd: Use GLNX_FILE_COPY_NOXATTRS

### DIFF
--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -1081,14 +1081,17 @@ rpmostree_passwd_prepare_rpm_layering (int                rootfs_dfd,
 
       /* Copy /usr/lib/{passwd,group} -> /usr/etc (breaking hardlinks) */
       if (!glnx_file_copy_at (rootfs_dfd, usrlibfile, NULL,
-                              rootfs_dfd, usretcfile, 0, cancellable, error))
+                              rootfs_dfd, usretcfile,
+                              GLNX_FILE_COPY_NOXATTRS,
+                              cancellable, error))
         return FALSE;
 
       /* Copy the merge's passwd/group to usr/lib (breaking hardlinks) */
       if (!glnx_file_copy_at (AT_FDCWD,
                               glnx_strjoina (merge_passwd_dir, "/", file), NULL,
                               rootfs_dfd, usrlibfiletmp,
-                              GLNX_FILE_COPY_OVERWRITE, cancellable, error))
+                              GLNX_FILE_COPY_OVERWRITE | GLNX_FILE_COPY_NOXATTRS,
+                              cancellable, error))
         return FALSE;
 
       if (!glnx_renameat (rootfs_dfd, usrlibfiletmp, rootfs_dfd, usrlibfile, error))
@@ -1113,7 +1116,8 @@ rpmostree_passwd_prepare_rpm_layering (int                rootfs_dfd,
         }
 
       if (!glnx_file_copy_at (rootfs_dfd, src, NULL,
-                              rootfs_dfd, tmp, GLNX_FILE_COPY_OVERWRITE,
+                              rootfs_dfd, tmp,
+                              GLNX_FILE_COPY_OVERWRITE | GLNX_FILE_COPY_NOXATTRS,
                               cancellable, error))
         return FALSE;
       if (!glnx_renameat (rootfs_dfd, tmp, rootfs_dfd, src, error))

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1281,6 +1281,9 @@ rpmostree_copy_additional_files (int            rootfs_dfd,
       if (!glnx_shutil_mkdir_p_at (rootfs_dfd, dn, 0755, cancellable, error))
         return FALSE;
 
+      /* FIXME: Should probably use GLNX_FILE_COPY_NOXATTRS, but someone
+       * may be relying on current semantics?
+       */
       if (!glnx_file_copy_at (context_dfd, src, NULL, rootfs_dfd, dest, 0,
                               cancellable, error))
           return glnx_prefix_error (error, "Copying file '%s' into target", src);


### PR DESCRIPTION
Prep for unified core work. This was failing due to a bug in libglnx
<https://github.com/GNOME/libglnx/pull/80> but I think this change is also
correct. There's no good reason for us to copy xattrs like the SELinux label
here - rather we want the labels to be reset during commit.

I did a tree-wide grep for other users and the only other case that is odd is
the treecompose `add-files`; I'd say we should change this but out of (a likely
excess of) conservatism I just left a "FIXME" for now.
