### PR TITLE
lib/postprocess: Use O_TMPFILE, not O_APPEND for tmpfiles.d writing

### DIFF
--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -53,3 +53,9 @@ assert_not_file_has_content ls.txt '__db' 'lock'
 ostree --repo=${repobuild} ls -R ${treeref} /usr/etc/selinux > ls.txt
 assert_not_file_has_content ls.txt 'LOCK'
 echo "ok no leftover files"
+
+ostree --repo=${repobuild} cat ${treeref} /usr/lib/tmpfiles.d/rpm-ostree-1-autovar.conf > autovar.txt
+# Picked this one at random as an example of something that won't likely be
+# converted to tmpfiles.d upstream.  But if it is, we can change this test.
+assert_file_has_content_literal autovar.txt 'd /var/empty/sshd 0711 0 0 - -'
+echo "ok autovar'

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -57,5 +57,5 @@ echo "ok no leftover files"
 ostree --repo=${repobuild} cat ${treeref} /usr/lib/tmpfiles.d/rpm-ostree-1-autovar.conf > autovar.txt
 # Picked this one at random as an example of something that won't likely be
 # converted to tmpfiles.d upstream.  But if it is, we can change this test.
-assert_file_has_content_literal autovar.txt 'd /var/empty/sshd 0711 0 0 - -'
+assert_file_has_content_literal autovar.txt 'd /var/cache 0755 0 0 - -'
 echo "ok autovar'

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -58,4 +58,4 @@ ostree --repo=${repobuild} cat ${treeref} /usr/lib/tmpfiles.d/rpm-ostree-1-autov
 # Picked this one at random as an example of something that won't likely be
 # converted to tmpfiles.d upstream.  But if it is, we can change this test.
 assert_file_has_content_literal autovar.txt 'd /var/cache 0755 0 0 - -'
-echo "ok autovar'
+echo "ok autovar"


### PR DESCRIPTION
The comment here was wrong; we don't rely on `O_APPEND` here for package
layering since we convert on import.  I noticed this while I was doing
a grep for `O_APPEND` in the codebase as part of unified core work.

Fix this by converting to `O_TMPFILE`+`GLNX_LINK_TMPFILE_NOREPLACE`.

Prep for unified core.
