### PR TITLE
libpriv/core: squash a -Wmaybe-uninitialized

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1705,7 +1705,7 @@ import_one_package (RpmOstreeContext *self,
   OstreeRepo *ostreerepo = get_pkgcache_repo (self);
   g_autofree char *ostree_commit = NULL;
   glnx_unref_object RpmOstreeUnpacker *unpacker = NULL;
-  g_autofree char *pkg_path;
+  g_autofree char *pkg_path = NULL;
   DnfRepo *pkg_repo;
 
   int flags = 0;


### PR DESCRIPTION
Noticed this pass by while doing a `fedpkg local`. It doesn't actually
matter much since there are no exits possible between the point it's
declared and when it's actually assigned, which I will assume is why our
clang suite didn't pick it up, maybe? Not gonna look into that right
now.