### PR TITLE
libpriv: Remove unused OSTREE_GIO_FAST_QUERYINFO

### DIFF
--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -34,10 +34,6 @@
 #include "rpmostree-json-parsing.h"
 #include "rpmostree-passwd-util.h"
 
-/* FIXME: */
-#define OSTREE_GIO_FAST_QUERYINFO ("standard::name,standard::type,standard::size,standard::is-symlink,standard::symlink-target," \
-                                   "unix::device,unix::inode,unix::mode,unix::uid,unix::gid,unix::rdev")
-
 #include "libglnx.h"
 
 /* Recursively search a directory for a subpath

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -31,10 +31,6 @@
 
 #include <rpm/rpmts.h>
 
-/* FIXME: */
-#define OSTREE_GIO_FAST_QUERYINFO ("standard::name,standard::type,standard::size,standard::is-symlink,standard::symlink-target," \
-                                   "unix::device,unix::inode,unix::mode,unix::uid,unix::gid,unix::rdev")
-
 static inline void
 cleanup_rpmtdFreeData (rpmtd *tdp)
 {


### PR DESCRIPTION
Hooray, it's dead (here, but not in ostree). Noticed this while working on
<https://github.com/projectatomic/rpm-ostree/pull/997>
