### PR TITLE
libpriv/scripts: Only log to journal if uid == 0

### DIFF
--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -278,7 +278,9 @@ run_script_in_bwrap_container (int rootfs_fd,
     goto out;
 
 
-  struct ChildSetupData data = { .stdin_fd = stdin_fd };
+  struct ChildSetupData data = { .stdin_fd = stdin_fd,
+                                 .stdout_fd = -1,
+                                 .stderr_fd = -1, };
 
   /* Only try to log to the journal if we're running in the system
    * context; for unprivileged container builds we don't want to log


### PR DESCRIPTION
The previous change to log to the journal broke running `ex container` as
non-root with scripts. Yes, I really desperately need to set up real tests for
that, like we have for composes. And obviously checking `getuid() == 0` is a bit
crude but doing better would require plumbing through quite a bit of of
knowledge from the toplevel down into script execution.
