### PR TITLE
Add test infra for `ex container`, and one test for bash

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -126,10 +126,12 @@ required: false
 host:
   distro: fedora/26/atomic
 
+# We're not doing this bit yet since it breaks unless we use metalinks
+# because f27 isn't released yet and released content is in a separate path.
+# -e RPMOSTREE_COMPOSE_TEST_USE_REPOS=/etc/yum.repos.d.host
+# -v /etc/yum.repos.d:/etc/yum.repos.d.host:ro
 tests:
   - docker run --privileged --rm
-    -e RPMOSTREE_COMPOSE_TEST_USE_REPOS=/etc/yum.repos.d.host
-    -v /etc/yum.repos.d:/etc/yum.repos.d.host:ro
     -v $(pwd):/srv/code -w /srv/code
     registry.fedoraproject.org/fedora:26 /bin/sh -c
     "./ci/build.sh && make install && adduser unpriv && setfacl -m u:unpriv:rwX . && runuser -u unpriv ./tests/ex-container"

--- a/.papr.yml
+++ b/.papr.yml
@@ -101,16 +101,41 @@ host:
 # since https://github.com/projectatomic/rpm-ostree/pull/875
 tests:
   - docker run --privileged --rm
-    -e RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO=1
+    -e RPMOSTREE_COMPOSE_TEST_USE_REPOS=/etc/yum.repos.d.host
     -v /etc/yum.repos.d:/etc/yum.repos.d.host:ro
     -v $(pwd):/srv/code -w /srv/code
     registry.fedoraproject.org/fedora:26 /bin/sh -c
-    "cp -fv /etc/yum.repos.d{.host/*.repo,} &&
-     for x in /etc/yum.repos.d/*.repo; do sed -i -e 's,\$releasever,26,' \$x; done &&
-     ./ci/build.sh && make install && ./tests/compose"
+    "./ci/build.sh && make install && ./tests/compose"
 
 artifacts:
   - compose.log
+
+---
+
+branches:
+  - master
+  - auto
+  - try
+
+context: f26-to-27-ex-container
+build: false
+timeout: 30m
+required: false
+
+# See the f26-compose context for why we do things this way.
+host:
+  distro: fedora/26/atomic
+
+tests:
+  - docker run --privileged --rm
+    -e RPMOSTREE_COMPOSE_TEST_USE_REPOS=/etc/yum.repos.d.host
+    -v /etc/yum.repos.d:/etc/yum.repos.d.host:ro
+    -v $(pwd):/srv/code -w /srv/code
+    registry.fedoraproject.org/fedora:26 /bin/sh -c
+    "./ci/build.sh && make install && adduser unpriv && setfacl -m u:unpriv:rwX . && runuser -u unpriv ./tests/ex-container"
+
+artifacts:
+  - ex-container-logs
 
 ---
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -22,6 +22,8 @@ pkg_install_builddeps rpm-ostree
 # Mostly dependencies for tests
 pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML clang \
     libubsan libasan libtsan elfutils fuse sudo python-gobject-base
+# For ex-container tests
+pkg_install_if_os fedora parallel
 
 if [ -n "${CI_PKGS:-}" ]; then
   pkg_install ${CI_PKGS}

--- a/tests/common/libcomposetest.sh
+++ b/tests/common/libcomposetest.sh
@@ -1,0 +1,31 @@
+# Shared functions for compose/ex-container tests
+#
+# Copyright (C) 2017 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+setup_rpmmd_repos() {
+    dest=$1
+    shift
+    releasever=${1:-26}
+    repos=${RPMOSTREE_COMPOSE_TEST_USE_REPOS:-/etc/yum.repos.d}
+    # When bumping 26 here, also bump fedora.repo, .papr.yml
+    for x in ${repos}/fedora{,-updates}.repo; do
+        bn=$(basename ${x})
+        sed -e "s,\$releasever,$releasever," < $x > ${dest}/${bn}
+    done
+}
+

--- a/tests/compose
+++ b/tests/compose
@@ -4,6 +4,7 @@ set -euo pipefail
 dn=$(cd $(dirname $0) && pwd)
 
 export topsrcdir=$(cd $dn/.. && pwd)
+. ${dn}/common/libcomposetest.sh
 
 # avoid refetching yum metadata everytime
 export RPMOSTREE_USE_CACHED_METADATA=1
@@ -48,16 +49,7 @@ ostree --repo=${repobuild} init --mode=bare-user
 mkdir -p ${test_compose_datadir}/cache
 
 echo "Preparing compose tests..." | tee -a ${LOG}
-
-# take the host repo if it matches our target tree
-if [ -n "${RPMOSTREE_COMPOSE_TEST_USE_HOST_REPO:-}" ]; then
-  # NB: when bumping 26 here, also bump fedora.repo, .papr.yml
-  (source /etc/os-release;
-   if [ "$ID" == "fedora" ] && [ "$VERSION_ID" == "26" ]; then
-     echo "Taking stable Fedora repo file from test env."
-     cp -fv /etc/yum.repos.d/fedora.repo ${dn}/composedata
-   fi) &>> ${LOG}
-fi
+setup_rpmmd_repos ${dn}/composedata
 
 # Delete the default ref, since we want to use subrefs of it
 compose_prepargs=

--- a/tests/composedata/fedora.repo
+++ b/tests/composedata/fedora.repo
@@ -1,9 +1,0 @@
-[fedora]
-#when bumping 26 here, also bump compose script, and .papr.yml
-name=Fedora 26 (devel) - $basearch
-failovermethod=priority
-baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/26/Everything/$basearch/os/
-enabled=1
-gpgcheck=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-26-$basearch
-skip_if_unavailable=False

--- a/tests/ex-container
+++ b/tests/ex-container
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Tests for `rpm-ostree ex container`.
+set -xeuo pipefail
+
+dn=$(cd $(dirname $0) && pwd)
+export topsrcdir=$(cd $dn/.. && pwd)
+. ${dn}/common/libtest-core.sh
+. ${dn}/common/libcomposetest.sh
+
+if test "$(id -u)" = 0; then
+    fatal "Don't run $0 as root"
+fi
+
+LOGDIR=${LOGDIR:-$(pwd)/ex-compose-logs}
+
+tmpdir=$(mktemp -d /var/tmp/rpm-ostree-container.XXXXXX)
+touch ${tmpdir}/.tmpdir
+cleanup_tmp() {
+    # This sanity check ensures we don't delete something else
+    if test -z "${TEST_SKIP_CLEANUP:-}" && test -f ${tmpdir}/.tmpdir; then
+        rm -rf ${tmpdir}
+    fi
+}
+trap cleanup_tmp EXIT
+
+cd ${tmpdir}
+rpm-ostree ex container init
+# Need 27 due to http://bugzilla.redhat.com/1478172 only built there
+setup_rpmmd_repos ${tmpdir}/rpmmd.repos.d 27
+
+echo "Results in ${LOGDIR}"
+rm ${LOGDIR} -rf
+mkdir -p ${LOGDIR}
+
+# Ideally pass $(cwd) down into parallel somehow
+export test_tmpdir=${tmpdir}
+ls ${dn}/ex-container-tests/test-*.sh | sort |
+    parallel --tag --halt soon,fail=1 --joblog joblog --results ${LOGDIR} --line-buffer {}

--- a/tests/ex-container-tests/test-bash.sh
+++ b/tests/ex-container-tests/test-bash.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+set -xeuo pipefail
+
+cd ${test_tmpdir}
+
+cat >bash.conf <<EOF
+[tree]
+ref=bash
+packages=coreutils;bash;
+repos=fedora;
+EOF
+
+rpm-ostree ex container assemble bash.conf


### PR DESCRIPTION
We have some unit-style tests that run `ex container`, but
they aren't "real"; they don't use scripts for example.  Let's
add tests for this similar to `tests/compose`.

We use a 26 base, but the target repos need to be 27
to pick up the fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1478172

Add some bits to share infra between `tests/compose` and `tests/ex-container`;
basically handling the rpmmd repos. I tweaked things to be more streamlined
there between the `.papr.yml` and the test script.

Right now this is just one test for `bash`, but lays some of the infrastructure
for doing more. One thing that we need to do to improve more here is to better
cache RPMs, a bit like the compose tests do.
