### PR TITLE
 Change ex-container to use BARE_USER_ONLY, update core creation API

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -749,7 +749,7 @@ impl_compose_tree (const char      *treefile_pathstr,
   if (fchdir (self->workdir_dfd) != 0)
     return glnx_throw_errno_prefix (error, "fchdir");
 
-  self->corectx = rpmostree_context_new_compose (self->cachedir_dfd, cancellable, error);
+  self->corectx = rpmostree_context_new_tree (self->cachedir_dfd, self->repo, cancellable, error);
   if (!self->corectx)
     return FALSE;
 

--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -42,7 +42,10 @@ static GOptionEntry init_option_entries[] = {
   { NULL }
 };
 
+static gboolean opt_cache_only;
+
 static GOptionEntry assemble_option_entries[] = {
+  { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Assume cache is present, do not attempt to update it", NULL },
   { NULL }
 };
 
@@ -249,6 +252,10 @@ rpmostree_container_builtin_assemble (int             argc,
 
   if (!roc_context_prepare_for_root (rocctx, treespec, cancellable, error))
     return EXIT_FAILURE;
+
+  DnfContext *dnfctx = rpmostree_context_get_hif (rocctx->ctx);
+  if (opt_cache_only)
+    dnf_context_set_cache_age (dnfctx, G_MAXUINT);
 
   /* --- Resolving dependencies --- */
   if (!rpmostree_context_prepare (rocctx->ctx, cancellable, error))

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -37,13 +37,10 @@ G_DECLARE_FINAL_TYPE (RpmOstreeTreespec, rpmostree_treespec, RPMOSTREE, TREESPEC
 RpmOstreeContext *rpmostree_context_new_system (GCancellable *cancellable,
                                                 GError **error);
 
-RpmOstreeContext *rpmostree_context_new_compose (int basedir_dfd,
-                                                 GCancellable *cancellable,
-                                                 GError **error);
-
-RpmOstreeContext *rpmostree_context_new_unprivileged (int basedir_dfd,
-                                                      GCancellable *cancellable,
-                                                      GError **error);
+RpmOstreeContext *rpmostree_context_new_tree (int basedir_dfd,
+                                              OstreeRepo  *repo,
+                                              GCancellable *cancellable,
+                                              GError **error);
 
 DnfContext * rpmostree_context_get_hif (RpmOstreeContext *self);
 

--- a/src/libpriv/rpmostree-unpacker.h
+++ b/src/libpriv/rpmostree-unpacker.h
@@ -38,12 +38,10 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeUnpacker, g_object_unref)
 
 /**
  * RpmOstreeUnpackerFlags:
- * @RPMOSTREE_UNPACKER_FLAGS_UNPRIVILEGED: Ignore file ownership and setuid modes
  * @RPMOSTREE_UNPACKER_FLAGS_SKIP_EXTRANEOUS: Skip files/directories outside of supported ostree-compliant paths rather than erroring out
  */
 typedef enum {
-  RPMOSTREE_UNPACKER_FLAGS_UNPRIVILEGED =  (1 << 0),
-  RPMOSTREE_UNPACKER_FLAGS_SKIP_EXTRANEOUS =  (1 << 1),
+  RPMOSTREE_UNPACKER_FLAGS_SKIP_EXTRANEOUS =  (1 << 0),
 } RpmOstreeUnpackerFlags;
 
 RpmOstreeUnpacker*


### PR DESCRIPTION

Switch `ex container` to `OSTREE_REPO_MODE_BARE_USER_ONLY`; this is a good
match, for the same reasons as flatpak. We don't want suid binaries, we don't
want to chown anything, no SELinux labeling, etc.  There's no reason to write the
metadata to the `BARE_USER` xattrs.

The "unprivileged" context as used for `ex container` was a flag that was passed
down, but I think it's a lot easier if things just infer this state by looking
at whether the target repo is `bare-user-only`. Now we just have an
`rpmostree_context_new_tree()` API that handles both container and compose.