### PR TITLE
bin/compose: Drop workdir variable

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -97,7 +97,6 @@ typedef struct {
   RpmOstreeContext *corectx;
   GFile *treefile;
   GFile *previous_root;
-  GFile *workdir;
   GLnxTmpDir workdir_tmp;
   int workdir_dfd;
   int cachedir_dfd;
@@ -119,7 +118,6 @@ rpm_ostree_tree_compose_context_free (RpmOstreeTreeComposeContext *ctx)
   if (!ctx->workdir_tmp.initialized && ctx->workdir_dfd != -1)
     (void) close (ctx->workdir_dfd);
   glnx_tmpdir_clear (&ctx->workdir_tmp);
-  g_clear_object (&ctx->workdir);
   if (ctx->cachedir_dfd != -1)
     (void) close (ctx->cachedir_dfd);
   g_clear_object (&ctx->repo);
@@ -678,15 +676,12 @@ impl_compose_tree (const char      *treefile_pathstr,
     {
       if (!glnx_mkdtempat (AT_FDCWD, "/var/tmp/rpm-ostree.XXXXXX", 0700, &self->workdir_tmp, error))
         return FALSE;
-      self->workdir = g_file_new_for_path (self->workdir_tmp.path);
       /* Note special handling of this aliasing in _finalize() */
       self->workdir_dfd = self->workdir_tmp.fd;
     }
   else
     {
-      self->workdir = g_file_new_for_path (opt_workdir);
-      if (!glnx_opendirat (AT_FDCWD, gs_file_get_path_cached (self->workdir),
-                           FALSE, &self->workdir_dfd, error))
+      if (!glnx_opendirat (AT_FDCWD, opt_workdir, FALSE, &self->workdir_dfd, error))
         return FALSE;
     }
 


### PR DESCRIPTION
Nothing actually uses it, we've been all fd-relative for a while. Just noticed
this while looking at the compose code for further work.
