### PR TITLE
app: Add a more reliable helper for finding active transaction

### DIFF
--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -57,8 +57,11 @@ rpmostree_load_os_proxies                    (RPMOSTreeSysroot *sysroot_proxy,
                                               RPMOSTreeOS **out_os_proxy,
                                               RPMOSTreeOSExperimental **out_osexperimental_proxy,
                                               GError **error);
-RPMOSTreeTransaction *
-rpmostree_transaction_connect                (const char *transaction_address,
+
+gboolean
+rpmostree_transaction_connect_active         (RPMOSTreeSysroot *sysroot_proxy,
+                                              char                 **out_path,
+                                              RPMOSTreeTransaction **out_txn,
                                               GCancellable *cancellable,
                                               GError      **error);
 


### PR DESCRIPTION
There are (somewhat hard to avoid) race conditions for the client
to find the active transaction and connect to it.  This approach
adds a retry loop, and teaches the status builtin to use it.

The status code becomes a lot less ugly.  Prep for:
[rpm-ostree cancel](https://github.com/projectatomic/rpm-ostree/pull/1019)
