### PR TITLE
ci: run clang build with -Werror

### DIFF
--- a/ci/build-check.sh
+++ b/ci/build-check.sh
@@ -10,3 +10,17 @@ ${dn}/build.sh
 # support parallel runs right now
 /usr/bin/make check
 make install
+
+# And now a clang build with -Werror turned on. We can't do this with gcc (in
+# build.sh) because it doesn't support -Wno-error=macro-redefined, (and neither
+# does clang on CentOS). Anyway, all we want is at least one clang run.
+if test -x /usr/bin/clang; then
+  # Except unused-command-line-argument:
+  #   error: argument unused during compilation: '-specs=/usr/lib/rpm/redhat/redhat-hardened    -cc1' [-Werror,-Wunused-command-line-argument]
+  # Except for macro-redefined:
+  #   /usr/include/python2.7/pyconfig-64.h:1199:9: error: '_POSIX_C_SOURCE' macro redefined
+  export CFLAGS="-Wall -Werror -Wno-error=macro-redefined -Wno-error=unused-command-line-argument ${CFLAGS:-}"
+  export CC=clang
+  git clean -dfx && git submodule foreach git clean -dfx
+  build
+fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -20,11 +20,11 @@ fi
 pkg_upgrade
 pkg_install_builddeps rpm-ostree
 # Mostly dependencies for tests
-pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML clang \
+pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML \
     libubsan libasan libtsan elfutils fuse sudo python-gobject-base \
     selinux-policy-devel
-# For ex-container tests
-pkg_install_if_os fedora parallel
+# For ex-container tests and clang build
+pkg_install_if_os fedora parallel clang
 
 if [ -n "${CI_PKGS:-}" ]; then
   pkg_install ${CI_PKGS}

--- a/src/daemon/rpmostreed-daemon.c
+++ b/src/daemon/rpmostreed-daemon.c
@@ -451,7 +451,7 @@ update_status (RpmostreedDaemon *self)
       guint64 readytime = g_source_get_ready_time (self->idle_exit_source);
       guint64 curtime = g_source_get_time (self->idle_exit_source);
       guint64 timeout_micros = readytime - curtime;
-      if (timeout_micros < 0)
+      if (readytime < curtime)
         timeout_micros = 0;
 
       g_assert (currently_idle && self->idle_exit_source);


### PR DESCRIPTION
Start running `clang` with `-Werror` like ostree. We can only run this
on Fedora right now because the CentOS `clang` doesn't support
`-Wno-error=macro-redefined`, though that's fine.