### PR TITLE
tests: Use --parent=none rather than deleting the ref

### DIFF
--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -59,7 +59,6 @@ fi
 rm -vrf vmcheck/usr/etc/selinux/targeted/semanage.*.LOCK
 # ✀✀✀ END tmp hack
 
-ostree refs --delete vmcheck || true
-ostree commit -b vmcheck --link-checkout-speedup \
+ostree commit --parent=none -b vmcheck --link-checkout-speedup \
   --selinux-policy=vmcheck --tree=dir=vmcheck
 ostree admin deploy vmcheck


### PR DESCRIPTION
This is atomic. Not that it matters for this test, but let's have our tests use
ostree well.
