### PR TITLE
Split `compose tree` into `compose install` and `compose commit`

### DIFF
--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -106,10 +106,12 @@ Boston, MA 02111-1307, USA.
 
         <listitem>
           <para>
-            Entrypoint for tree composition; most typically used on
-            servers to prepare trees for replication by client systems.
-            Currently has two subcommands, <literal>tree</literal> and
-            <literal>sign</literal>.
+            Entrypoint for tree composition; most typically used on servers to
+            prepare trees for replication by client systems. The
+            <literal>tree</literal> subcommand processes a treefile, installs
+            packages, and commits the result to an OSTree repository. There are
+            also split commands <literal>install</literal>,
+            <literal>postprocess</literal>, and <literal>commit</literal>.
           </para>
         </listitem>
       </varlistentry>

--- a/src/app/rpmostree-builtin-compose.c
+++ b/src/app/rpmostree-builtin-compose.c
@@ -30,8 +30,17 @@
 
 static RpmOstreeCommand compose_subcommands[] = {
   { "tree", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
-    "Install packages and commit the result to an OSTree repository",
+    "Process a \"treefile\"; install packages and commit the result to an OSTree repository",
     rpmostree_compose_builtin_tree },
+  { "install", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
+    "Install packages into a target path",
+    rpmostree_compose_builtin_install },
+  { "postprocess", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
+    "Perform final postprocessing on an installation root",
+    rpmostree_compose_builtin_postprocess },
+  { "commit", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD | RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
+    "Commit a target path to an OSTree repository",
+    rpmostree_compose_builtin_commit },
   { NULL, 0, NULL, NULL }
 };
 

--- a/src/app/rpmostree-compose-builtins.h
+++ b/src/app/rpmostree-compose-builtins.h
@@ -27,6 +27,9 @@
 G_BEGIN_DECLS
 
 gboolean rpmostree_compose_builtin_tree (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
+gboolean rpmostree_compose_builtin_install (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
+gboolean rpmostree_compose_builtin_postprocess (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
+gboolean rpmostree_compose_builtin_commit (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
 
 G_END_DECLS
 

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -66,6 +66,12 @@ rpmostree_prepare_rootfs_for_commit (int            src_rootfs_dfd,
                                      GError       **error);
 
 gboolean
+rpmostree_postprocess_final (int            rootfs_dfd,
+                             JsonObject    *treefile,
+                             GCancellable  *cancellable,
+                             GError       **error);
+
+gboolean
 rpmostree_commit (int            rootfs_dfd,
                   OstreeRepo    *repo,
                   const char    *refname,

--- a/tests/compose-tests/libcomposetest.sh
+++ b/tests/compose-tests/libcomposetest.sh
@@ -33,8 +33,9 @@ prepare_compose_test() {
     export treeref=fedora/stable/x86_64/${name}
 }
 
+compose_base_argv="--repo=${repobuild} --cache-only --cachedir=${test_compose_datadir}/cache"
 runcompose() {
-    rpm-ostree compose --repo=${repobuild} tree --cache-only --cachedir=${test_compose_datadir}/cache ${treefile} "$@"
+    rpm-ostree compose tree ${compose_base_argv} ${treefile} "$@"
     ostree --repo=${repo} pull-local ${repobuild}
 }
 

--- a/tests/compose-tests/test-installroot.sh
+++ b/tests/compose-tests/test-installroot.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+dn=$(cd $(dirname $0) && pwd)
+. ${dn}/libcomposetest.sh
+
+prepare_compose_test "installroot"
+compose_base_argv="--repo=${repobuild} --cache-only --cachedir=${test_compose_datadir}/cache"
+instroot_tmp=$(mktemp -d /var/tmp/rpm-ostree-instroot.XXXXXX)
+rpm-ostree compose install ${compose_base_argv} ${treefile} ${instroot_tmp}
+instroot=${instroot_tmp}/rootfs
+assert_not_has_dir ${instroot}/usr/lib/ostree-boot
+assert_not_has_dir ${instroot}/etc
+test -L ${instroot}/home
+assert_has_dir ${instroot}/usr/etc
+
+# Clone the root - we'll test direct commit, as well as postprocess with
+# and without treefile.
+mv ${instroot}{,-postprocess}
+cp -al ${instroot}{-postprocess,-directcommit}
+cp -al ${instroot}{-postprocess,-postprocess-treefile}
+
+integrationconf=usr/lib/tmpfiles.d/rpm-ostree-0-integration.conf
+
+assert_not_has_file ${instroot}-postprocess/${integrationconf}
+rpm-ostree compose postprocess  ${instroot}-postprocess
+rpm-ostree compose postprocess ${instroot}-postprocess-treefile
+assert_has_file ${instroot}-postprocess/${integrationconf}
+ostree --repo=${repobuild} commit -b test-directcommit --selinux-policy ${instroot}-postprocess --tree=dir=${instroot}-postprocess
+echo "ok postprocess + direct commit"
+
+testdate=$(date)
+echo "${testdate}" > ${instroot}-directcommit/usr/share/rpm-ostree-composetest-split.txt
+assert_not_has_file ${instroot}-directcommit/${integrationconf}
+rpm-ostree compose commit --repo=${repobuild} ${treefile} ${instroot}-directcommit
+ostree --repo=${repobuild} ls ${treeref} /usr/bin/bash
+ostree --repo=${repobuild} cat ${treeref} /usr/share/rpm-ostree-composetest-split.txt >out.txt
+assert_file_has_content_literal out.txt "${testdate}"
+ostree --repo=${repobuild} cat ${treeref} /${integrationconf}
+echo "ok installroot"

--- a/tests/compose-tests/test-installroot.sh
+++ b/tests/compose-tests/test-installroot.sh
@@ -6,7 +6,8 @@ dn=$(cd $(dirname $0) && pwd)
 . ${dn}/libcomposetest.sh
 
 prepare_compose_test "installroot"
-compose_base_argv="--repo=${repobuild} --cache-only --cachedir=${test_compose_datadir}/cache"
+# This is used to test postprocessing with treefile vs not
+pysetjsonmember "boot_location" '"new"'
 instroot_tmp=$(mktemp -d /var/tmp/rpm-ostree-instroot.XXXXXX)
 rpm-ostree compose install ${compose_base_argv} ${treefile} ${instroot_tmp}
 instroot=${instroot_tmp}/rootfs
@@ -24,11 +25,22 @@ cp -al ${instroot}{-postprocess,-postprocess-treefile}
 integrationconf=usr/lib/tmpfiles.d/rpm-ostree-0-integration.conf
 
 assert_not_has_file ${instroot}-postprocess/${integrationconf}
-rpm-ostree compose postprocess  ${instroot}-postprocess
-rpm-ostree compose postprocess ${instroot}-postprocess-treefile
+rpm-ostree compose postprocess ${instroot}-postprocess
 assert_has_file ${instroot}-postprocess/${integrationconf}
+# Without treefile, kernels end up in "both" mode
+ls ${instroot}-postprocess/boot > ls.txt
+assert_file_has_content ls.txt '^vmlinuz-'
+rm -f ls.txt
 ostree --repo=${repobuild} commit -b test-directcommit --selinux-policy ${instroot}-postprocess --tree=dir=${instroot}-postprocess
 echo "ok postprocess + direct commit"
+
+rpm-ostree compose postprocess ${instroot}-postprocess-treefile ${treefile}
+assert_has_file ${instroot}-postprocess-treefile/${integrationconf}
+# with treefile, no kernels in /boot
+ls ${instroot}-postprocess-treefile/boot > ls.txt
+assert_not_file_has_content ls.txt '^vmlinuz-'
+rm -f ls.txt
+echo "ok postprocess with treefile"
 
 testdate=$(date)
 echo "${testdate}" > ${instroot}-directcommit/usr/share/rpm-ostree-composetest-split.txt


### PR DESCRIPTION
Right now `rpm-ostree compose tree` is very prescriptive about how
things work.  Trying to add anything that isn't an RPM is absolutely
fighting the system.  Our postprocessing system *enforces* no
network access (good for reproducibilty, but still prescriptive).

There's really a logical split between three phases:

 - "build a rootfs that installs packages"
 - "run postprocessing"
 - "commit result"

Our primary job is the 1st and the 3rd - and we can do *either*. If for example
someone wants to use `rpm-ostree compose install`, and then tar up the result as
a Docker/OCI image, that becomes a bit easier. Or on the flip side, if someone
wants to do a `Dockerfile` style build system, we can make it easier to extract
the result of that and commit it into ostree.

Related issues/PRs:

 - https://github.com/projectatomic/rpm-ostree/pull/96
 - https://github.com/projectatomic/rpm-ostree/issues/471
