### PR TITLE
ci: don't use CentOS Alpha anymore

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -49,11 +49,11 @@ required: true
 cluster:
   hosts:
     - name: vmcheck1
-      distro: centos/7/atomic/alpha
+      distro: centos/7/atomic
     - name: vmcheck2
-      distro: centos/7/atomic/alpha
+      distro: centos/7/atomic
     - name: vmcheck3
-      distro: centos/7/atomic/alpha
+      distro: centos/7/atomic
   container:
     # FIXME remove this version binding when rpm-md repos are updated
     image: registry.centos.org/centos/centos:7.3.1611

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -34,4 +34,8 @@ fi
 adduser testuser
 
 export LSAN_OPTIONS=verbosity=1:log_threads=1
-build --enable-installed-tests --enable-gtk-doc
+BWRAP=/usr/bin/bwrap
+if [ "$id" == centos ]; then
+  BWRAP=/usr/lib64/rpm-ostree/bwrap
+fi
+build --enable-installed-tests --enable-gtk-doc --with-bubblewrap=$BWRAP


### PR DESCRIPTION
It's no longer being built and is now older than the latest CentOS AH
release. This should help us no longer see messages like:

```
(rpm-ostree pkg-add:5662): GLib-CRITICAL **: g_variant_dict_lookup:
assertion 'is_valid_dict (dict)' failed
```

which happen because in #1034, we started using `G_VARIANT_DICT_INIT`,
whose special magic values only make sense in `glib2 >= 2.50`. (The alpha
image stopped at 2.46).

Saw this while debugging #1035.