### PR TITLE
vmcheck: use systemd-run for running post-that-hangs

### DIFF
--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -163,27 +163,18 @@ fi
 cursor=$(vm_get_journal_cursor)
 vm_build_rpm post-that-hangs \
              post "echo entering post-that-hangs-infloop 1>&2; while true; do sleep 1h; done"
-# Enable job control so we can do a background job, then foreground.
-set -m
-nohup $SSH -t -t rpm-ostree install post-that-hangs &
+# use a systemd transient service as an easy way to run in the background
+vm_cmd systemd-run --unit vmcheck-install-hang rpm-ostree install post-that-hangs
 if ! vm_wait_content_after_cursor "${cursor}" "entering post-that-hangs-infloop"; then
-    kill -s INT %1
-    fg %1 || true
-    exit 1
+    vm_cmd systemctl stop vmcheck-install-hang
+    assert_not_reached "failed to wait for post-that-hangs"
 fi
-# Explicitly kill the client process in the VM; I originally tried to kill the
-# ssh binary and have it propagate the signal, on our side but couldn't figure
-# out how to make that work.
 vm_cmd pkill --signal INT -f "'rpm-ostree install post-that-hangs'"
-# But do also kill the ssh binary on our side
-kill -s INT %1
-# And wait for that to complete so it doesn't hang the shell
-fg %1 || true
-set +m
 # Wait for our expected result
 vm_wait_content_after_cursor "${cursor}" "Txn.*failed.*Running %post for post-that-hangs"
 # Forcibly restart now to avoid any races with the txn finally exiting
 vm_cmd systemctl restart rpm-ostreed
+echo "ok cancel infinite post"
 
 # Test rm -rf /!
 vm_cmd 'useradd testuser || true'
@@ -195,6 +186,7 @@ fi
 vm_cmd test -f /home/testuser/somedata -a -f /etc/fstab -a -f /tmp/sometmpfile -a -f /var/tmp/sometmpfile
 # This is the error today, we may improve it later
 assert_file_has_content err.txt 'error: sanitycheck: Executing bwrap(/usr/bin/true)'
+echo "ok impervious to rm -rf post"
 
 vm_build_rpm etc-mutate post "truncate -s 0 /etc/selinux/config"
 if vm_rpmostree install etc-mutate; then


### PR DESCRIPTION
Just taking what I learned from #1035 and applying it here. What's nice
about this is that there's no cleanup needed. Once the process is killed
(or worst case, we reboot the VM), there's no traces left at all.

Also added a few extra "ok" outputs.