### PR TITLE
tree-wide: Use a #define for /usr/share/rpm location

### DIFF
--- a/src/daemon/rpmostreed-transaction-livefs.c
+++ b/src/daemon/rpmostreed-transaction-livefs.c
@@ -124,7 +124,7 @@ path_is_usretc (const char *path)
 static gboolean
 path_is_rpmdb (const char *path)
 {
-  return g_str_has_prefix (path, "/usr/share/rpm/");
+  return g_str_has_prefix (path, "/" RPMOSTREE_RPMDB_LOCATION "/");
 }
 
 static gboolean
@@ -808,7 +808,7 @@ livefs_transaction_execute_inner (LiveFsTransaction *self,
        * make a tmpdir just for this since it's a more convenient place to put
        * temporary files/dirs without generating tempnames.
        */
-      const char *replace_paths[] = { "/usr/share/rpm", "/usr/lib/passwd", "/usr/lib/group" };
+      const char *replace_paths[] = { "/" RPMOSTREE_RPMDB_LOCATION, "/usr/lib/passwd", "/usr/lib/group" };
       for (guint i = 0; i < G_N_ELEMENTS(replace_paths); i++)
         {
           const char *replace_path = replace_paths[i];

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -595,7 +595,7 @@ rpmostree_context_setup (RpmOstreeContext    *self,
     }
 
   /* This is what we use as default. */
-  dnf_context_set_rpm_macro (self->hifctx, "_dbpath", "/usr/share/rpm");
+  dnf_context_set_rpm_macro (self->hifctx, "_dbpath", "/" RPMOSTREE_RPMDB_LOCATION);
 
   if (!dnf_context_setup (self->hifctx, cancellable, error))
     return FALSE;
@@ -2741,7 +2741,7 @@ run_all_transfiletriggers (RpmOstreeContext *self,
    * otherwise librpm will whine on our stderr.
    */
   struct stat stbuf;
-  if (!glnx_fstatat_allow_noent (rootfs_dfd, "usr/share/rpm", &stbuf, AT_SYMLINK_NOFOLLOW, error))
+  if (!glnx_fstatat_allow_noent (rootfs_dfd, RPMOSTREE_RPMDB_LOCATION, &stbuf, AT_SYMLINK_NOFOLLOW, error))
     return FALSE;
   if (errno == 0)
     {
@@ -2794,7 +2794,7 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
   /* First for the ordering TS, set the dbpath to relative, which will also gain
    * the root dir.
    */
-  set_rpm_macro_define ("_dbpath", "/usr/share/rpm");
+  set_rpm_macro_define ("_dbpath", "/" RPMOSTREE_RPMDB_LOCATION);
 
   /* Don't verify checksums here (we should have done this on ostree
    * import).  Also, avoid updating the database or anything by
@@ -3116,7 +3116,7 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
 
   rpmostree_output_task_begin ("Writing rpmdb");
 
-  if (!glnx_shutil_mkdir_p_at (tmprootfs_dfd, "usr/share/rpm", 0755, cancellable, error))
+  if (!glnx_shutil_mkdir_p_at (tmprootfs_dfd, RPMOSTREE_RPMDB_LOCATION, 0755, cancellable, error))
     return FALSE;
 
   /* Now, we use the separate rpmdb ts which *doesn't* have a rootdir set,
@@ -3127,12 +3127,12 @@ rpmostree_context_assemble_tmprootfs (RpmOstreeContext      *self,
    * Instead, this rpmts has the dbpath as absolute.
    */
   { g_autofree char *rpmdb_abspath = glnx_fdrel_abspath (tmprootfs_dfd,
-                                                         "usr/share/rpm");
+                                                         RPMOSTREE_RPMDB_LOCATION);
 
     /* if we were passed an existing tmprootfs, and that tmprootfs already has
      * an rpmdb, we have to make sure to break its hardlinks as librpm mutates
      * the db in place */
-    if (!break_hardlinks_at (tmprootfs_dfd, "usr/share/rpm", cancellable, error))
+    if (!break_hardlinks_at (tmprootfs_dfd, RPMOSTREE_RPMDB_LOCATION, cancellable, error))
       return FALSE;
 
     set_rpm_macro_define ("_dbpath", rpmdb_abspath);

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -27,6 +27,8 @@
 #include "libglnx.h"
 
 #define RPMOSTREE_CORE_CACHEDIR "/var/cache/rpm-ostree/"
+/* See http://lists.rpm.org/pipermail/rpm-maint/2017-October/006681.html */
+#define RPMOSTREE_RPMDB_LOCATION "usr/share/rpm"
 
 #define RPMOSTREE_TYPE_CONTEXT (rpmostree_context_get_type ())
 G_DECLARE_FINAL_TYPE (RpmOstreeContext, rpmostree_context, RPMOSTREE, CONTEXT, GObject)

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -42,6 +42,7 @@
 #include "rpmostree-bwrap.h"
 #include "rpmostree-passwd-util.h"
 #include "rpmostree-rpm-util.h"
+#include "rpmostree-core.h"
 #include "rpmostree-json-parsing.h"
 #include "rpmostree-util.h"
 
@@ -1195,7 +1196,7 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
   if (!rename_if_exists (rootfs_fd, "etc", rootfs_fd, "usr/etc", error))
     return FALSE;
 
-  if (!cleanup_leftover_files (rootfs_fd, "usr/share/rpm", rpmdb_leftover_files,
+  if (!cleanup_leftover_files (rootfs_fd, RPMOSTREE_RPMDB_LOCATION, rpmdb_leftover_files,
                                rpmdb_leftover_prefixes, cancellable, error))
     return FALSE;
 
@@ -1472,7 +1473,7 @@ rpmostree_treefile_postprocessing (int            rootfs_fd,
    * */
   if (!glnx_shutil_rm_rf_at (rootfs_fd, "var/lib/rpm", cancellable, error))
     return FALSE;
-  if (symlinkat ("../../usr/share/rpm", rootfs_fd, "var/lib/rpm") < 0)
+  if (symlinkat ("../../" RPMOSTREE_RPMDB_LOCATION, rootfs_fd, "var/lib/rpm") < 0)
     return glnx_throw_errno_prefix (error, "symlinkat(%s)", "var/lib/rpm");
 
   if (json_object_has_member (treefile, "remove-from-packages"))

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -22,6 +22,7 @@
 
 #include "rpmostree-rpm-util.h"
 #include "rpmostree-output.h"
+#include "rpmostree-core.h"
 
 #include <inttypes.h>
 #include <fnmatch.h>
@@ -777,16 +778,16 @@ checkout_only_rpmdb (OstreeRepo       *repo,
   /* Check out the database (via copy) */
   OstreeRepoCheckoutAtOptions checkout_options = { 0, };
   checkout_options.mode = OSTREE_REPO_CHECKOUT_MODE_USER;
-  checkout_options.subpath = "usr/share/rpm";
+  checkout_options.subpath = RPMOSTREE_RPMDB_LOCATION;
   if (!ostree_repo_checkout_at (repo, &checkout_options, tmpdir->fd,
-                                "usr/share/rpm", commit,
+                                RPMOSTREE_RPMDB_LOCATION, commit,
                                 cancellable, error))
     return FALSE;
 
   /* And make a compat symlink to keep rpm happy */
   if (!glnx_shutil_mkdir_p_at (tmpdir->fd, "var/lib", 0777, cancellable, error))
     return FALSE;
-  if (symlinkat ("../../usr/share/rpm", tmpdir->fd, "var/lib/rpm") == -1)
+  if (symlinkat ("../../" RPMOSTREE_RPMDB_LOCATION, tmpdir->fd, "var/lib/rpm") == -1)
     return glnx_throw_errno_prefix (error, "symlinkat");
 
   return TRUE;


### PR DESCRIPTION
In prep for potentially changing it:
http://lists.rpm.org/pipermail/rpm-maint/2017-October/006681.html

Of course actually doing a transition would be harder than this, as we'd need to
add a compat symlink, and even that wouldn't quite be enough as e.g. the
"preview" code would need to learn how to follow the symlink (or just try both
locations).

In practice I think we'd need to land the code to handle both locations, let
that trickle out for e.g. 3 months, then make the switch in our treecomposes.

But, might as well make this change now; using a `#define` makes it slightly
easier to find places that need changing later.
