### PR TITLE
daemon: Unify pkgcache with system repo

### DIFF
--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -727,11 +727,6 @@ rpmostreed_sysroot_populate (RpmostreedSysroot *self,
   if (!ostree_sysroot_get_repo (self->ot_sysroot, &self->repo, cancellable, error))
     return FALSE;
 
-  /* Migrate legacy pkgcache repo into system repo. After the first time, this boils down to
-   * one stat() call. */
-  if (!rpmostree_migrate_pkgcache_repo (self->repo, cancellable, error))
-    return FALSE;
-
   if (!sysroot_populate_deployments_unlocked (self, NULL, error))
     return FALSE;
 

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -727,6 +727,11 @@ rpmostreed_sysroot_populate (RpmostreedSysroot *self,
   if (!ostree_sysroot_get_repo (self->ot_sysroot, &self->repo, cancellable, error))
     return FALSE;
 
+  /* Migrate legacy pkgcache repo into system repo. After the first time, this boils down to
+   * one stat() call. */
+  if (!rpmostree_migrate_pkgcache_repo (self->repo, cancellable, error))
+    return FALSE;
+
   if (!sysroot_populate_deployments_unlocked (self, NULL, error))
     return FALSE;
 

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -591,6 +591,11 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
       upgrader_flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED;
     }
 
+  /* before doing any real work, let's make sure the pkgcache is migrated */
+  OstreeRepo *repo = ostree_sysroot_repo (sysroot);
+  if (!rpmostree_migrate_pkgcache_repo (repo, cancellable, error))
+    return FALSE;
+
   g_autoptr(RpmOstreeSysrootUpgrader) upgrader =
     rpmostree_sysroot_upgrader_new (sysroot, self->osname, upgrader_flags,
                                     cancellable, error);
@@ -608,10 +613,6 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
                                   &old_refspec, &new_refspec, error))
         return FALSE;
     }
-
-  g_autoptr(OstreeRepo) repo = NULL;
-  if (!ostree_sysroot_get_repo (sysroot, &repo, cancellable, error))
-    return FALSE;
 
   g_autoptr(OstreeAsyncProgress) progress =
     ostree_async_progress_new ();

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -36,8 +36,9 @@ G_DECLARE_FINAL_TYPE (RpmOstreeContext, rpmostree_context, RPMOSTREE, CONTEXT, G
 #define RPMOSTREE_TYPE_TREESPEC (rpmostree_treespec_get_type ())
 G_DECLARE_FINAL_TYPE (RpmOstreeTreespec, rpmostree_treespec, RPMOSTREE, TREESPEC, GObject)
 
-RpmOstreeContext *rpmostree_context_new_system (GCancellable *cancellable,
-                                                GError **error);
+RpmOstreeContext *rpmostree_context_new_system (OstreeRepo   *repo,
+                                                GCancellable *cancellable,
+                                                GError      **error);
 
 RpmOstreeContext *rpmostree_context_new_tree (int basedir_dfd,
                                               OstreeRepo  *repo,

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -595,6 +595,12 @@ rpmostree_migrate_pkgcache_repo (OstreeRepo   *repo,
       if (!glnx_shutil_rm_rf_at (repo_dfd, RPMOSTREE_OLD_PKGCACHE_DIR, cancellable, error))
         return FALSE;
     }
+  else
+    {
+      if (!glnx_shutil_mkdir_p_at (repo_dfd, dirname (strdupa (RPMOSTREE_OLD_PKGCACHE_DIR)),
+                                   0755, cancellable, error))
+        return FALSE;
+    }
 
   /* leave a symlink for compatibility with older rpm-ostree versions */
   if (symlinkat ("../..", repo_dfd, RPMOSTREE_OLD_PKGCACHE_DIR) < 0)

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -116,6 +116,11 @@ rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
                                        GError           **error);
 
 gboolean
+rpmostree_migrate_pkgcache_repo (OstreeRepo   *repo,
+                                 GCancellable *cancellable,
+                                 GError      **error);
+
+gboolean
 rpmostree_decompose_sha256_nevra (const char **nevra,
                                   char       **sha256,
                                   GError     **error);

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -84,7 +84,7 @@ vm_cmdfile() {
 
 # Delete anything which we might change between runs
 vm_clean_caches() {
-    vm_cmd rm /ostree/repo/extensions/rpmostree/pkgcache/refs/heads/* -rf
+    vm_cmd rm /ostree/repo/refs/heads/rpmostree/pkg/* -rf
 }
 
 # run rpm-ostree in vm
@@ -363,6 +363,8 @@ vm_get_journal_cursor() {
 }
 
 # Wait for a message logged after $cursor matching a regexp to appear
+# $1 - cursor
+# $2 - regex to wait for
 vm_wait_content_after_cursor() {
     from_cursor=$1; shift
     regex=$1; shift

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -61,10 +61,10 @@ echo "ok failed to install in /opt and /usr/local"
 
 vm_build_rpm foo
 vm_rpmostree pkg-add foo-1.0
-vm_cmd ostree --repo=/sysroot/ostree/repo/extensions/rpmostree/pkgcache refs |grep /foo/> refs.txt
+vm_cmd ostree refs |grep /foo/> refs.txt
 pkgref=$(head -1 refs.txt)
 # Verify we have a mapping from pkg-in-ostree → rpmmd-repo info
-vm_cmd ostree --repo=/sysroot/ostree/repo/extensions/rpmostree/pkgcache show --print-metadata-key rpmostree.repo ${pkgref} >refdata.txt
+vm_cmd ostree show --print-metadata-key rpmostree.repo ${pkgref} >refdata.txt
 assert_file_has_content refdata.txt 'id.*test-repo'
 assert_file_has_content refdata.txt 'timestamp'
 rm -f refs.txt refdata.txt
@@ -166,3 +166,25 @@ vm_cmd cat /usr/lib/ostree-boot/EFI/efi/fedora/fonts/unicode.pf2 > unicode.txt
 assert_file_has_content unicode.txt unicode
 echo "ok failed installed in /boot"
 
+# there should be a couple of pkgs already installed from the tests up above,
+# though let's add our own to be self-contained
+vm_build_rpm test-pkgcache-migrate-pkg1
+vm_build_rpm test-pkgcache-migrate-pkg2
+vm_rpmostree install test-pkgcache-migrate-pkg{1,2}
+
+# jury-rig a pkgcache of the olden days
+OLD_PKGCACHE_DIR=/ostree/repo/extensions/rpmostree/pkgcache
+vm_cmd systemctl stop rpm-ostreed
+vm_cmd test ! -d ${OLD_PKGCACHE_DIR}
+vm_cmd mkdir -p ${OLD_PKGCACHE_DIR}
+vm_cmd ostree init --repo ${OLD_PKGCACHE_DIR} --mode=bare
+vm_cmd ostree pull-local --repo ${OLD_PKGCACHE_DIR} /ostree/repo \
+  rpmostree/pkg/test-pkgcache-migrate-pkg{1,2}/1.0-1.x86__64
+cursor=$(vm_get_journal_cursor)
+vm_cmd systemctl start rpm-ostreed
+vm_wait_content_after_cursor $cursor 'migrated 2 cached packages'
+for ref in rpmostree/pkg/test-pkgcache-migrate-pkg{1,2}/1.0-1.x86__64; do
+  vm_cmd ostree show $ref
+done
+vm_cmd test ! -d ${OLD_PKGCACHE_DIR}
+echo "ok migrate pkgcache"


### PR DESCRIPTION
We originally needed the pkgcache to be a separate repo due to ostree's
overzealous pruning policies. The idea was to maintain multiple commits
in each pkg branch for different SELinux policies. In practice, there's
not much use in maintaining old copies and it's just easier to always
relabel on the fly. So then, the need for a separate repo completely
melts away.

This helps simplify the core a bunch and just generally makes it more
pleasant to work with. It also allows us to avoid subtle issues like
https://github.com/projectatomic/rpm-ostree/issues/1047.

The tricky bit is migrating the cache. In theory, we only really need to
migrate local RPM overrides/overlays, but if we're going to build
support for that, we might as well migrate it all. We do this by
checking at key points where the cache will be used whether a migration
is necessary. After migrating once, it boils down to one `fstatat()` on
subsequent runs to check that the repo no longer exists.