### PR TITLE
Make use of new _CONSUME flag to ostree commit

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -2434,7 +2434,7 @@ relabel_one_package (RpmOstreeContext *self,
     glnx_unref_object OstreeMutableTree *mtree = ostree_mutable_tree_new ();
 
     g_autoptr(OstreeRepoCommitModifier) modifier =
-      ostree_repo_commit_modifier_new (OSTREE_REPO_COMMIT_MODIFIER_FLAGS_NONE,
+      ostree_repo_commit_modifier_new (OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CONSUME,
                                        NULL, NULL, NULL);
 
     ostree_repo_commit_modifier_set_devino_cache (modifier, cache);

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1856,8 +1856,12 @@ rpmostree_commit (int            rootfs_fd,
   /* We may make this configurable if someone complains about including some
    * unlabeled content, but I think the fix for that is to ensure that policy is
    * labeling it.
+   *
+   * Also right now we unconditionally use the CONSUME flag, but this will need
+   * to change for the split compose/commit root patches.
    */
-  OstreeRepoCommitModifierFlags modifier_flags = OSTREE_REPO_COMMIT_MODIFIER_FLAGS_ERROR_ON_UNLABELED;
+  OstreeRepoCommitModifierFlags modifier_flags = OSTREE_REPO_COMMIT_MODIFIER_FLAGS_ERROR_ON_UNLABELED |
+    OSTREE_REPO_COMMIT_MODIFIER_FLAGS_CONSUME;
   /* If changing this, also look at changing rpmostree-unpacker.c */
   g_autoptr(OstreeRepoCommitModifier) commit_modifier =
     ostree_repo_commit_modifier_new (modifier_flags, NULL, NULL, NULL);


### PR DESCRIPTION
This is used for both `ex container` and client-side operations, but not most
uses of `compose tree` (which should go into `bare-user` or `archive`).
We'll circle back and do `bare-user` for `_CONSUME` in libostree though
soon.
