### PR TITLE
tree: pass NULL to glnx_fstatat_allow_noent when needed

### DIFF
--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -242,8 +242,7 @@ rpmostree_container_builtin_assemble (int             argc,
 
   const char *target_rootdir = glnx_strjoina (name, ".0");
 
-  struct stat stbuf;
-  if (!glnx_fstatat_allow_noent (rocctx->roots_dfd, target_rootdir, &stbuf,
+  if (!glnx_fstatat_allow_noent (rocctx->roots_dfd, target_rootdir, NULL,
                                  AT_SYMLINK_NOFOLLOW, error))
     {
       glnx_set_error_from_errno (error);

--- a/src/daemon/rpmostreed-transaction-livefs.c
+++ b/src/daemon/rpmostreed-transaction-livefs.c
@@ -587,8 +587,7 @@ replace_usr (OstreeRepo *repo,
       const char *name = dent->d_name;
       /* Keep track of what entries are in the new /usr */
       g_hash_table_add (seen_new_children, g_strdup (name));
-      struct stat stbuf;
-      if (!glnx_fstatat_allow_noent (deployment_usr_dfd, name, &stbuf, AT_SYMLINK_NOFOLLOW, error))
+      if (!glnx_fstatat_allow_noent (deployment_usr_dfd, name, NULL, AT_SYMLINK_NOFOLLOW, error))
         return FALSE;
       if (errno == ENOENT)
         {

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -744,8 +744,7 @@ checkout_pkg_metadata (RpmOstreeContext *self,
   /* give it a .rpm extension so we can fool the libdnf stack */
   g_autofree char *path = get_nevra_relpath (nevra);
 
-  struct stat stbuf;
-  if (!glnx_fstatat_allow_noent (self->tmpdir.fd, path, &stbuf, 0, error))
+  if (!glnx_fstatat_allow_noent (self->tmpdir.fd, path, NULL, 0, error))
     return FALSE;
   /* we may have already written the header out for this one */
   if (errno == 0)
@@ -2158,8 +2157,7 @@ delete_package_from_root (RpmOstreeContext *self,
       if (rpmostree_str_has_prefix_in_ptrarray (fn, deleted_dirs))
         continue;
 
-      struct stat stbuf;
-      if (!glnx_fstatat_allow_noent (rootfs_dfd, fn, &stbuf, AT_SYMLINK_NOFOLLOW, error))
+      if (!glnx_fstatat_allow_noent (rootfs_dfd, fn, NULL, AT_SYMLINK_NOFOLLOW, error))
         return FALSE;
       if (errno == ENOENT)
         continue; /* a job well done */
@@ -2916,8 +2914,7 @@ run_all_transfiletriggers (RpmOstreeContext *self,
   /* Triggers from base packages, but only if we already have an rpmdb,
    * otherwise librpm will whine on our stderr.
    */
-  struct stat stbuf;
-  if (!glnx_fstatat_allow_noent (rootfs_dfd, RPMOSTREE_RPMDB_LOCATION, &stbuf, AT_SYMLINK_NOFOLLOW, error))
+  if (!glnx_fstatat_allow_noent (rootfs_dfd, RPMOSTREE_RPMDB_LOCATION, NULL, AT_SYMLINK_NOFOLLOW, error))
     return FALSE;
   if (errno == 0)
     {

--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -1008,12 +1008,10 @@ rootfs_has_usrlib_passwd (int rootfs_dfd,
                        gboolean *out_have_passwd,
                        GError **error)
 {
-  struct stat stbuf;
-
   /* Does this rootfs have a usr/lib/passwd?  We might be doing a
    * container or something else.
    */
-  if (!glnx_fstatat_allow_noent (rootfs_dfd, "usr/lib/passwd", &stbuf, 0, error))
+  if (!glnx_fstatat_allow_noent (rootfs_dfd, "usr/lib/passwd", NULL, 0, error))
     return FALSE;
   *out_have_passwd = (errno == 0);
   return TRUE;
@@ -1099,12 +1097,11 @@ rpmostree_passwd_prepare_rpm_layering (int                rootfs_dfd,
    */
   for (guint i = 0; i < G_N_ELEMENTS (pwgrp_shadow_files); i++)
     {
-      struct stat stbuf;
       const char *file = pwgrp_shadow_files[i];
       const char *src = glnx_strjoina ("usr/etc/", file);
       const char *tmp = glnx_strjoina ("usr/etc/", file, ".tmp");
 
-      if (!glnx_fstatat_allow_noent (rootfs_dfd, src, &stbuf, AT_SYMLINK_NOFOLLOW, error))
+      if (!glnx_fstatat_allow_noent (rootfs_dfd, src, NULL, AT_SYMLINK_NOFOLLOW, error))
         return FALSE;
       if (errno == ENOENT)
         continue;


### PR DESCRIPTION
Now that libglnx allows it, we can skip declaring a `struct stat` we
don't actually need just to check if a file exists.