### PR TITLE
ex-container: Make /etc/shadow 0400 on import, not  post-checkout

### DIFF
--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -224,9 +224,6 @@ download_rpms_and_assemble_commit (ROContainerContext *rocctx,
                                           &ret_commit, cancellable, error))
     return FALSE;
 
-  if (!rpmostree_rootfs_postprocess_container (tmpdir.fd, cancellable, error))
-    return FALSE;
-
   *out_commit = g_steal_pointer (&ret_commit);
   return TRUE;
 }

--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -198,6 +198,39 @@ symlink_at_replace (const char    *oldpath,
   return TRUE;
 }
 
+/* Download and import rpms, then generate a rootfs, and commit it */
+static gboolean
+download_rpms_and_assemble_commit (ROContainerContext *rocctx,
+                                   char              **out_commit,
+                                   GCancellable       *cancellable,
+                                   GError            **error)
+{
+  /* --- Download as necessary --- */
+  if (!rpmostree_context_download (rocctx->ctx, cancellable, error))
+    return FALSE;
+
+  /* --- Import as necessary --- */
+  if (!rpmostree_context_import (rocctx->ctx, cancellable, error))
+    return FALSE;
+
+  g_auto(GLnxTmpDir) tmpdir = { 0, };
+  if (!glnx_mkdtempat (rocctx->userroot_dfd, "tmp/rpmostree-commit-XXXXXX", 0755,
+                       &tmpdir, error))
+    return FALSE;
+
+  g_autofree char *ret_commit = NULL;
+  if (!rpmostree_context_assemble_commit (rocctx->ctx, tmpdir.fd, NULL,
+                                          NULL, RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE,
+                                          &ret_commit, cancellable, error))
+    return FALSE;
+
+  if (!rpmostree_rootfs_postprocess_container (tmpdir.fd, cancellable, error))
+    return FALSE;
+
+  *out_commit = g_steal_pointer (&ret_commit);
+  return TRUE;
+}
+
 int
 rpmostree_container_builtin_assemble (int             argc,
                                       char          **argv,
@@ -269,30 +302,9 @@ rpmostree_container_builtin_assemble (int             argc,
 
   rpmostree_print_transaction (rpmostree_context_get_hif (rocctx->ctx));
 
-  /* --- Download as necessary --- */
-  if (!rpmostree_context_download (rocctx->ctx, cancellable, error))
-    return EXIT_FAILURE;
-
-  /* --- Import as necessary --- */
-  if (!rpmostree_context_import (rocctx->ctx, cancellable, error))
-    return EXIT_FAILURE;
-
   g_autofree char *commit = NULL;
-  { g_auto(GLnxTmpDir) tmpdir = { 0, };
-
-    if (!glnx_mkdtempat (rocctx->userroot_dfd, "tmp/rpmostree-commit-XXXXXX", 0755,
-                         &tmpdir, error))
-      return EXIT_FAILURE;
-
-    if (!rpmostree_context_assemble_commit (rocctx->ctx, tmpdir.fd, NULL,
-                                            NULL, RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE,
-                                            &commit, cancellable, error))
-      return EXIT_FAILURE;
-
-    if (!rpmostree_rootfs_postprocess_container (tmpdir.fd, cancellable, error))
-      return EXIT_FAILURE;
-  }
-
+  if (!download_rpms_and_assemble_commit (rocctx, &commit, cancellable, error))
+    return EXIT_FAILURE;
   g_print ("Checking out %s @ %s...\n", name, commit);
 
   { OstreeRepoCheckoutAtOptions opts = { OSTREE_REPO_CHECKOUT_MODE_USER,
@@ -463,30 +475,9 @@ rpmostree_container_builtin_upgrade (int argc, char **argv,
       }
   }
 
-  /* --- Download as necessary --- */
-  if (!rpmostree_context_download (rocctx->ctx, cancellable, error))
-    return EXIT_FAILURE;
-
-  /* --- Import as necessary --- */
-  if (!rpmostree_context_import (rocctx->ctx, cancellable, error))
-    return EXIT_FAILURE;
-
   g_autofree char *new_commit_checksum = NULL;
-  { g_auto(GLnxTmpDir) tmpdir = { 0, };
-
-    if (!glnx_mkdtempat (rocctx->userroot_dfd, "tmp/rpmostree-commit-XXXXXX", 0755,
-                         &tmpdir, error))
-      return EXIT_FAILURE;
-
-    if (!rpmostree_context_assemble_commit (rocctx->ctx, tmpdir.fd, NULL,
-                                            NULL, RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE,
-                                            &new_commit_checksum,
-                                            cancellable, error))
-      return EXIT_FAILURE;
-
-    if (!rpmostree_rootfs_postprocess_container (tmpdir.fd, cancellable, error))
-      return EXIT_FAILURE;
-  }
+  if (!download_rpms_and_assemble_commit (rocctx, &new_commit_checksum, cancellable, error))
+    return EXIT_FAILURE;
 
   g_print ("Checking out %s @ %s...\n", name, new_commit_checksum);
 

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -53,11 +53,6 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
                                      GError       **error);
 
 gboolean
-rpmostree_rootfs_postprocess_container (int           rootfs_fd,
-                                        GCancellable *cancellable,
-                                        GError       **error);
-
-gboolean
 rpmostree_prepare_rootfs_get_sepolicy (int            dfd,
                                        OstreeSePolicy **out_sepolicy,
                                        GCancellable  *cancellable,

--- a/tests/ex-container-tests/test-bash.sh
+++ b/tests/ex-container-tests/test-bash.sh
@@ -14,5 +14,6 @@ repos=fedora;
 EOF
 
 rpm-ostree ex container assemble bash.conf
+ostree --repo=repo fsck -q
 ostree --repo=repo ls bash /usr/etc/shadow > shadowls.txt
 assert_file_has_content shadowls.txt '^-00400 .*/usr/etc/shadow'


### PR DESCRIPTION
Switching to the `_CONSUME` flag revealed an "oh god how did I write that"
bug in the previous patch in https://github.com/projectatomic/rpm-ostree/pull/1046
AKA commit: 334f0b89be271cbe2b9973ebc7eab50f955517e8

The way that actually fixed the bug before was because we were using
hardlink checkouts, and we were operating outside an `rofiles-fuse`
context, we simply directly changed the on-disk object mode.

But with the `_CONSUME` flag we started deleting the files as we write,
meaning that stopped working.

I *initially* wrote a patch to do the same split "prepare/processing/commit"
flow that treecompose and package layering do, but that can't really fix this
bug - we need to do it on import.

So do the chmod on import and drop the postprocessing bits.
