### PR TITLE
status: Render ostree metadata source-title key

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -311,7 +311,7 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
 
       /* Load the commit metadata into a dict */
       { g_autoptr(GVariant) commit_meta_v = NULL;
-        g_assert (g_variant_dict_lookup (dict, "base-commit-meta", "a{sv}", &commit_meta_v));
+        g_assert (g_variant_dict_lookup (dict, "base-commit-meta", "@a{sv}", &commit_meta_v));
         commit_meta_dict = g_variant_dict_new (commit_meta_v);
       }
       if (is_locally_assembled)

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -21,12 +21,18 @@ set -x
 
 # And then this code path in the VM
 
-# get csum of current default deployment
+# get csum and origin of current default deployment
 commit=$(rpm-ostree status --json | \
   python -c '
 import sys, json;
 deployment = json.load(sys.stdin)["deployments"][0]
 print deployment["checksum"]
+exit()')
+origin=$(rpm-ostree status --json | \
+  python -c '
+import sys, json;
+deployment = json.load(sys.stdin)["deployments"][0]
+print deployment["origin"]
 exit()')
 
 if [[ -z $commit ]] || ! ostree rev-parse $commit; then
@@ -59,6 +65,6 @@ fi
 rm -vrf vmcheck/usr/etc/selinux/targeted/semanage.*.LOCK
 # ✀✀✀ END tmp hack
 
-ostree commit --parent=none -b vmcheck --link-checkout-speedup \
+ostree commit --parent=none -b vmcheck --add-metadata-string=ostree.source-title="Dev overlay on ${origin}" --add-metadata-string=rpmostree.original-origin=${origin} --link-checkout-speedup \
   --selinux-policy=vmcheck --tree=dir=vmcheck
 ostree admin deploy vmcheck

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -31,8 +31,10 @@ vm_assert_status_jq \
   '.deployments[0]["requested-packages"]' \
   '.deployments[0]["requested-local-packages"]' \
   '.deployments[0]["base-removals"]' \
-  '.deployments[0]["requested-base-removals"]'
-echo "ok empty pkg arrays in status json"
+  '.deployments[0]["requested-base-removals"]' \
+  '.deployments[0]["base-commit-meta"]' \
+  '.deployments[0]["layered-commit-meta"]|not'
+echo "ok empty pkg arrays, and commit meta correct in status json"
 
 # Be sure an unprivileged user exists and that we can SSH into it. This is a bit
 # underhanded, but we need a bona fide user session to verify non-priv status,

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -32,7 +32,7 @@ vm_assert_status_jq \
   '.deployments[0]["requested-local-packages"]' \
   '.deployments[0]["base-removals"]' \
   '.deployments[0]["requested-base-removals"]' \
-  '.deployments[0]["base-commit-meta"]' \
+  '.deployments[0]["base-commit-meta"]["ostree.source-title"]|contains("overlay")' \
   '.deployments[0]["layered-commit-meta"]|not'
 echo "ok empty pkg arrays, and commit meta correct in status json"
 

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -63,7 +63,9 @@ echo "ok pkg-add foo"
 vm_reboot
 vm_assert_status_jq \
   '.deployments[0]["base-checksum"]' \
-  '.deployments[0]["pending-base-checksum"]|not'
+  '.deployments[0]["pending-base-checksum"]|not' \
+  '.deployments[0]["base-commit-meta"]' \
+  '.deployments[0]["layered-commit-meta"]["rpmostree.clientlayer_version"] == 2'
 
 vm_assert_layered_pkg foo-1.0 present
 echo "ok pkg foo added"


### PR DESCRIPTION
Depends: https://github.com/ostreedev/ostree/pull/1296

As I mention in the commit there, I see two uses for this in rpm-ostree; first
in our test suite, and second for OCI-built image imports.

I also took a step further here and inject an `original-origin` metadata
key, though we aren't actually using that yet.  The problem I'm trying
to solve there is that repeated `make vmoverlay` starts chaining things up,
but that gets very confusing.  I think we should always have `vmoverlay` unwind
back to the base ref.  (Or at least do that by default)
