### PR TITLE
 core: Add rpmmd-repos metadata to final commit

### DIFF
--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -500,10 +500,10 @@ build_metadata_variant (RpmOstreeUnpacker *self,
                          g_variant_new_uint32 (1));
 
   /* Originally we just had unpack_version = 1, let's add a minor version for
-   * compatible increments.
+   * compatible increments.  Bumped 4 → 5 for timestamp.
    */
   g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.unpack_minor_version",
-                         g_variant_new_uint32 (4));
+                         g_variant_new_uint32 (5));
 
   if (self->pkg)
     {

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -52,8 +52,10 @@ vm_build_rpm foo
 vm_rpmostree pkg-add foo-1.0
 vm_cmd ostree --repo=/sysroot/ostree/repo/extensions/rpmostree/pkgcache refs |grep /foo/> refs.txt
 pkgref=$(head -1 refs.txt)
+# Verify we have a mapping from pkg-in-ostree → rpmmd-repo info
 vm_cmd ostree --repo=/sysroot/ostree/repo/extensions/rpmostree/pkgcache show --print-metadata-key rpmostree.repo ${pkgref} >refdata.txt
 assert_file_has_content refdata.txt 'id.*test-repo'
+assert_file_has_content refdata.txt 'timestamp'
 rm -f refs.txt refdata.txt
 # This will cover things like us failing to break hardlinks for the rpmdb,
 # as well as rofiles-fuse


### PR DESCRIPTION
Related to:
#774

I'd like to have `rpm-ostree status -v` show the state of the rpm-md repos that
were used as input; a while ago we added the data to the journal which is
useful, but we can't rely on that (journal might not be persistent, etc.).

This is is really for client-side layering right now; we do also add the key for
`SERVER_BASE` but that path is only for `ex container`.

Down the line though I can definitely see adding this data to `compose tree`;
but we might want to have it be opt-in as I can see some organizations not
wanting their repo data to "leak".