### PR TITLE
Inline assemble_commit() wrapper into ex-container, the only user

### DIFF
--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -218,10 +218,18 @@ download_rpms_and_assemble_commit (ROContainerContext *rocctx,
                        &tmpdir, error))
     return FALSE;
 
+  g_autoptr(OstreeRepoDevInoCache) devino_cache = ostree_repo_devino_cache_new ();
+  if (!rpmostree_context_assemble_tmprootfs (rocctx->ctx, tmpdir.fd, devino_cache,
+                                             cancellable, error))
+    return FALSE;
+
+  if (!rpmostree_rootfs_postprocess_common (tmpdir.fd, cancellable, error))
+    return FALSE;
+
   g_autofree char *ret_commit = NULL;
-  if (!rpmostree_context_assemble_commit (rocctx->ctx, tmpdir.fd, NULL,
-                                          NULL, RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE,
-                                          &ret_commit, cancellable, error))
+  if (!rpmostree_context_commit_tmprootfs (rocctx->ctx, tmpdir.fd, devino_cache,
+                                           NULL, RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE,
+                                           &ret_commit, cancellable, error))
     return FALSE;
 
   *out_commit = g_steal_pointer (&ret_commit);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -3567,38 +3567,3 @@ rpmostree_context_commit_tmprootfs (RpmOstreeContext      *self,
     *out_commit = g_steal_pointer (&ret_commit_checksum);
   return TRUE;
 }
-
-gboolean
-rpmostree_context_assemble_commit (RpmOstreeContext      *self,
-                                   int                    tmprootfs_dfd,
-                                   OstreeRepoDevInoCache *devino_cache,
-                                   const char            *parent,
-                                   RpmOstreeAssembleType  assemble_type,
-                                   char                 **out_commit,
-                                   GCancellable          *cancellable,
-                                   GError               **error)
-{
-  g_autoptr(OstreeRepoDevInoCache) devino_owned = NULL;
-
-  /* Auto-synthesize a cache if not provided */
-  if (devino_cache == NULL)
-    devino_cache = devino_owned = ostree_repo_devino_cache_new ();
-  else
-    devino_cache = devino_owned = ostree_repo_devino_cache_ref (devino_cache);
-
-  if (!rpmostree_context_assemble_tmprootfs (self, tmprootfs_dfd, devino_cache,
-                                             cancellable, error))
-    return FALSE;
-
-
-  if (!rpmostree_rootfs_postprocess_common (tmprootfs_dfd, cancellable, error))
-    return FALSE;
-
-  if (!rpmostree_context_commit_tmprootfs (self, tmprootfs_dfd, devino_cache,
-                                           parent, assemble_type,
-                                           out_commit,
-                                           cancellable, error))
-    return FALSE;
-
-  return TRUE;
-}

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -157,12 +157,3 @@ gboolean rpmostree_context_commit_tmprootfs (RpmOstreeContext      *self,
                                              char                 **out_commit,
                                              GCancellable          *cancellable,
                                              GError               **error);
-/* Wrapper for both of the above */
-gboolean rpmostree_context_assemble_commit (RpmOstreeContext      *self,
-                                            int                    tmprootfs_dfd,
-                                            OstreeRepoDevInoCache *devino_cache,
-                                            const char            *parent,
-                                            RpmOstreeAssembleType  assemble_type,
-                                            char                 **out_commit,
-                                            GCancellable          *cancellable,
-                                            GError               **error);


### PR DESCRIPTION
This is a cleanup I was going to do before, but had dropped. It's a general
followup to the `compose` rework; there's not much point to having a high level
wrapper, given that we generally need to do some postprocessing. Inline it into
the `ex container` code, which makes the core more "core".

