### PR TITLE
bin/compose: Fix use of EXIT_FAILURE for error paths

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1092,7 +1092,7 @@ rpmostree_compose_builtin_install (int             argc,
 
   g_autoptr(RpmOstreeTreeComposeContext) self = NULL;
   if (!rpm_ostree_compose_context_new (treefile_path, &self, cancellable, error))
-    return FALSE;
+    return EXIT_FAILURE;
   gboolean changed;
   if (!impl_install_tree (self, &changed, cancellable, error))
     return EXIT_FAILURE;
@@ -1246,7 +1246,7 @@ rpmostree_compose_builtin_tree (int             argc,
         return EXIT_FAILURE;
       /* Finally process the --touch-if-changed option  */
       if (!process_touch_if_changed (error))
-        return FALSE;
+        return EXIT_FAILURE;
     }
 
 


### PR DESCRIPTION
I got a critical from an nonexistent `DESTDIR` in `rpm-ostree compose install`.

(I'm probably going to do a patch to add `rpmostree_command_invocation_set_exit_code()`
 so the "exit 77" case can use that and everything else can `s/return EXIT_FAILURE/return FALSE/`
 and we'll be free of these bugs)
