### PR TITLE
postprocess: Use names (not ids) in synthesized tmpfiles.d files

### DIFF
--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -63,6 +63,16 @@ rpmostree_generate_passwd_from_previous (OstreeRepo      *repo,
                                          GCancellable    *cancellable,
                                          GError         **error);
 
+typedef struct RpmOstreePasswdDB RpmOstreePasswdDB;
+RpmOstreePasswdDB *
+rpmostree_passwddb_open (int rootfs, GCancellable *cancellable, GError **error);
+const char *
+rpmostree_passwddb_lookup_user (RpmOstreePasswdDB *db, uid_t uid);
+const char *
+rpmostree_passwddb_lookup_group (RpmOstreePasswdDB *db, gid_t gid);
+void
+rpmostree_passwddb_free (RpmOstreePasswdDB *db);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreePasswdDB, rpmostree_passwddb_free)
 
 gboolean
 rpmostree_passwd_cleanup (int rootfs_dfd, GCancellable *cancellable, GError **error);

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -57,5 +57,7 @@ echo "ok no leftover files"
 ostree --repo=${repobuild} cat ${treeref} /usr/lib/tmpfiles.d/rpm-ostree-1-autovar.conf > autovar.txt
 # Picked this one at random as an example of something that won't likely be
 # converted to tmpfiles.d upstream.  But if it is, we can change this test.
-assert_file_has_content_literal autovar.txt 'd /var/cache 0755 0 0 - -'
+assert_file_has_content_literal autovar.txt 'd /var/cache 0755 root root - -'
+# And this one has a non-root uid
+assert_file_has_content_literal autovar.txt 'd /var/log/chrony 0755 chrony chrony - -'
 echo "ok autovar"

--- a/tests/composedata/fedora-base.json
+++ b/tests/composedata/fedora-base.json
@@ -3,7 +3,7 @@
 
     "repos": ["fedora"],
 
-    "packages": ["kernel", "nss-altfiles", "systemd", "ostree", "selinux-policy-targeted"],
+    "packages": ["kernel", "nss-altfiles", "systemd", "ostree", "selinux-policy-targeted", "chrony"],
 
     "packages-aarch64": ["grub2-efi", "ostree-grub2",
                          "efibootmgr", "shim"],


### PR DESCRIPTION
Related to: https://github.com/projectatomic/rpm-ostree/issues/49

We want to support "name binding" per client system, rather than
having a hardcoded mapping in our tree.  Currently if e.g. a new
daemon is added as a dependency (or as part of e.g. systemd) it's
easy to silently miss it.

This is prep for doing that binding client side consistently, which is what we
do with package layering.
