### PR TITLE
compose: Add rpmostree.rpmmd-repo metadata to commits by default

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -934,6 +934,13 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
       }
   }
 
+  /* Bind metadata from the libdnf context */
+  if (!g_hash_table_contains (self->metadata, "rpmostree.rpmmd-repos"))
+    {
+      g_hash_table_insert (self->metadata, g_strdup ("rpmostree.rpmmd-repos"),
+                           rpmostree_context_get_rpmmd_repo_commit_metadata (self->corectx));
+    }
+
   /* Destroy this now so the libdnf stack won't have any references
    * into the filesystem before we manipulate it.
    */

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -55,6 +55,8 @@ RpmOstreeTreespec *rpmostree_treespec_new (GVariant   *variant);
 
 GHashTable *rpmostree_dnfcontext_get_varsubsts (DnfContext *context);
 
+GVariant *rpmostree_context_get_rpmmd_repo_commit_metadata (RpmOstreeContext  *self);
+
 GVariant *rpmostree_treespec_to_variant (RpmOstreeTreespec *spec);
 const char *rpmostree_treespec_get_ref (RpmOstreeTreespec *spec);
 

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -28,6 +28,8 @@ assert_file_has_content meta.txt 'rev.*97ec21c614689e533d294cdae464df607b526ab9'
 assert_file_has_content meta.txt 'src.*https://gitlab.com/exampleos/custom-atomic-host'
 ostree --repo=${repobuild} show --print-metadata-key exampleos.tests ${treeref} > meta.txt
 assert_file_has_content meta.txt 'smoketested.*e2e'
+ostree --repo=${repobuild} show --print-metadata-key rpmostree.rpmmd-repos ${treeref} > meta.txt
+assert_file_has_content meta.txt 'id.*fedora.*timestamp'
 echo "ok metadata"
 
 for path in /boot /usr/lib/ostree-boot; do


### PR DESCRIPTION
This is a revisit of a PR for client-side layering: https://github.com/projectatomic/rpm-ostree/pull/1072
Here though we're doing this by default for server-side composes.
There are a few reasons to do this; first, I'm seeing an issue
in some of our Jenkins jobs for Fedora that hit "mirror roulette"
and end up creating commits that "revert" to older versions temporarily.

While I've [certainly pitched](https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/IMPE6KCRBHCEJH5VBE6ZFIRLPAD743JT/) this as a feature, I think
we really want something like `--force-older-timestamp` - basically
error out if the timestamps on one or more input repos were older.
Not doing that in this patch, but it paves the way to do so.

Second, I'd like to use this data in the `ostree.source-title`
metadata key down the line.  Something like:

`└ rpmmd: fedora-26 (20170310), fedora-26-updates (20171101)`

(This could be a lot nicer if we drive versioning in to the rpm-md repo info,
 and e.g. there's some friendly "week number" style versioning for the updates
 repo now that it's batched...for now we have timestamps)

For CentOS/RHELAH this gets interesting and potentially more verbose,
to the point where we may want to render it more explicitly.

But anyways, let's do this now, as it will be useful even without
an explicit rendering, since users can do e.g. `ostree show` on
a base commit hash to dump the data.

I had a concern that some users may not want to emit this metadata;
they can currently do `--add-metadata-string rpmostree.rpmmd-repos ''`
and that will "win".
