### PR TITLE
lib/scripts: Only log to journal if stdout is already the journal

### DIFF
--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -605,6 +605,34 @@ rpmostree_cache_branch_to_nevra (const char *cachebranch)
   return g_string_free (r, FALSE);
 }
 
+/* Implementation taken from https://git.gnome.org/browse/libgsystem/tree/src/gsystem-log.c */
+gboolean
+rpmostree_stdout_is_journal (void)
+{
+  static gsize initialized;
+  static gboolean stdout_is_socket;
+
+  if (g_once_init_enter (&initialized))
+    {
+      guint64 pid = (guint64) getpid ();
+      g_autofree char *fdpath = g_strdup_printf ("/proc/%" G_GUINT64_FORMAT "/fd/1", pid);
+      char buf[1024];
+      ssize_t bytes_read;
+
+      if ((bytes_read = readlink (fdpath, buf, sizeof(buf) - 1)) != -1)
+        {
+          buf[bytes_read] = '\0';
+          stdout_is_socket = g_str_has_prefix (buf, "socket:");
+        }
+      else
+        stdout_is_socket = FALSE;
+
+      g_once_init_leave (&initialized, TRUE);
+    }
+
+  return stdout_is_socket;
+}
+
 /* Given the result of rpm_ostree_db_diff(), print it. */
 void
 rpmostree_diff_print (OstreeRepo *repo,

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -83,6 +83,8 @@ gs_file_get_path_cached (GFile *file)
   return rpmostree_file_get_path_cached (file);
 }
 
+gboolean rpmostree_stdout_is_journal (void);
+
 void rpmostree_diff_print (OstreeRepo *repo,
                            GPtrArray *removed,
                            GPtrArray *added,


### PR DESCRIPTION
The jigdo work is turning into "partial unified core 🌐" (mostly due to SELinux,
but that's an aside); we made a change here previously to avoid using
the journal if `uid != 0`, but it's more correct to check whether or
not we're already using the journal.

Concretely this fixes calling `rpmostree_context_assemble_tmprootfs()` as uid 0
inside my dev container, running `rpm-ostree compose commit2jigdo`.
