### PR TITLE
tree-wide: Use glnx_close_fd()

### DIFF
--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -116,13 +116,10 @@ roc_context_prepare_for_root (ROContainerContext *rocctx,
 static void
 roc_context_deinit (ROContainerContext *rocctx)
 {
-  if (rocctx->userroot_dfd != -1)
-    (void) close (rocctx->userroot_dfd);
+  glnx_close_fd (&rocctx->userroot_dfd);
   g_clear_object (&rocctx->repo);
-  if (rocctx->roots_dfd != -1)
-    (void) close (rocctx->roots_dfd);
-  if (rocctx->rpmmd_dfd != -1)
-    (void) close (rocctx->rpmmd_dfd);
+  glnx_close_fd (&rocctx->roots_dfd);
+  glnx_close_fd (&rocctx->rpmmd_dfd);
   g_clear_object (&rocctx->ctx);
 }
 

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -200,8 +200,7 @@ rpmostree_sysroot_upgrader_finalize (GObject *object)
 
   g_clear_pointer (&self->rsack, rpmostree_refsack_unref);
   g_clear_object (&self->ctx);
-  if (self->tmprootfs_dfd != -1)
-    (void)close (self->tmprootfs_dfd);
+  glnx_close_fd (&self->tmprootfs_dfd);
 
   (void)glnx_tmpdir_delete (&self->metatmpdir, NULL, NULL);
 
@@ -960,8 +959,7 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
    * bits in the compose and container path.
    */
   g_clear_object (&self->ctx);
-  (void) close (self->tmprootfs_dfd);
-  self->tmprootfs_dfd = -1;
+  glnx_close_fd (&self->tmprootfs_dfd);
 
   return TRUE;
 }

--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -86,8 +86,8 @@ rpmostree_unpacker_finalize (GObject *object)
     archive_read_free (self->archive); 
   if (self->fi)
     (void) rpmfiFree (self->fi);
-  if (self->owns_fd && self->fd != -1)
-    (void) close (self->fd);
+  if (self->owns_fd)
+    glnx_close_fd (&self->fd);
   g_string_free (self->tmpfiles_d, TRUE);
   g_free (self->ostree_branch);
 


### PR DESCRIPTION
It's cleaner, and we get `EBADF` checks, etc.
