### PR TITLE
(refactor) Move pkgcache helper function to sysroot-core

### DIFF
--- a/src/daemon/rpmostree-sysroot-core.h
+++ b/src/daemon/rpmostree-sysroot-core.h
@@ -41,7 +41,11 @@ OstreeDeployment *rpmostree_syscore_get_origin_merge_deployment (OstreeSysroot *
 
 gboolean rpmostree_syscore_bump_mtime (OstreeSysroot *self, GError **error);
 
-
+gboolean
+rpmostree_syscore_get_pkgcache_repo (OstreeRepo   *parent,
+                                     OstreeRepo  **out_pkgcache,
+                                     GCancellable *cancellable,
+                                     GError      **error);
 
 #define RPMOSTREE_LIVE_INPROGRESS_XATTR "user.rpmostree-live-inprogress"
 #define RPMOSTREE_LIVE_REPLACED_XATTR "user.rpmostree-live-replaced"

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -615,7 +615,7 @@ finalize_replacement_overrides (RpmOstreeSysrootUpgrader *self,
 
   g_autoptr(GPtrArray) inactive_replacements = g_ptr_array_new ();
   g_autoptr(OstreeRepo) pkgcache_repo = NULL;
-  if (!rpmostree_get_pkgcache_repo (self->repo, &pkgcache_repo, cancellable, error))
+  if (!rpmostree_syscore_get_pkgcache_repo (self->repo, &pkgcache_repo, cancellable, error))
     return FALSE;
 
   GLNX_HASH_TABLE_FOREACH_KV (local_replacements, const char*, nevra, const char*, sha256)
@@ -690,7 +690,7 @@ finalize_overlays (RpmOstreeSysrootUpgrader *self,
         return FALSE;
 
       g_autoptr(OstreeRepo) pkgcache_repo = NULL;
-      if (!rpmostree_get_pkgcache_repo (self->repo, &pkgcache_repo, cancellable, error))
+      if (!rpmostree_syscore_get_pkgcache_repo (self->repo, &pkgcache_repo, cancellable, error))
         return FALSE;
 
       GLNX_HASH_TABLE_FOREACH_KV (local_pkgs, const char*, nevra, const char*, sha256)
@@ -824,7 +824,7 @@ prep_local_assembly (RpmOstreeSysrootUpgrader *self,
     return FALSE;
 
   g_autoptr(OstreeRepo) pkgcache_repo = NULL;
-  if (!rpmostree_get_pkgcache_repo (self->repo, &pkgcache_repo, cancellable, error))
+  if (!rpmostree_syscore_get_pkgcache_repo (self->repo, &pkgcache_repo, cancellable, error))
     return FALSE;
 
   rpmostree_context_set_repos (self->ctx, self->repo, pkgcache_repo);

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -482,7 +482,7 @@ import_local_rpm (OstreeRepo    *parent,
    * need relabeling and that's OK.
    * */
 
-  if (!rpmostree_get_pkgcache_repo (parent, &pkgcache_repo, cancellable, error))
+  if (!rpmostree_syscore_get_pkgcache_repo (parent, &pkgcache_repo, cancellable, error))
     return FALSE;
 
   /* let's just use the current sepolicy -- we'll just relabel it if the new

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -518,28 +518,6 @@ rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
 }
 
 gboolean
-rpmostree_get_pkgcache_repo (OstreeRepo   *parent,
-                             OstreeRepo  **out_pkgcache,
-                             GCancellable *cancellable,
-                             GError      **error)
-{
-  if (!glnx_shutil_mkdir_p_at (ostree_repo_get_dfd (parent),
-                               "extensions/rpmostree", 0755,
-                               cancellable, error))
-    return FALSE;
-  g_autoptr(OstreeRepo) pkgcache =
-    ostree_repo_create_at (ostree_repo_get_dfd (parent),
-                           "extensions/rpmostree/pkgcache",
-                           OSTREE_REPO_MODE_BARE, NULL,
-                           cancellable, error);
-  if (!pkgcache)
-    return FALSE;
-
-  *out_pkgcache = g_steal_pointer (&pkgcache);
-  return TRUE;
-}
-
-gboolean
 rpmostree_decompose_sha256_nevra (const char **nevra, /* gets incremented */
                                   char       **out_sha256,
                                   GError     **error)

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -113,12 +113,6 @@ rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
                                        GError           **error);
 
 gboolean
-rpmostree_get_pkgcache_repo (OstreeRepo   *parent,
-                             OstreeRepo  **out_pkgcache,
-                             GCancellable *cancellable,
-                             GError      **error);
-
-gboolean
 rpmostree_decompose_sha256_nevra (const char **nevra,
                                   char       **sha256,
                                   GError     **error);


### PR DESCRIPTION
Trying to drain the `util.c` file; this one lives more logically
there.
