### PR TITLE
Lift 'override' out of experimental

### DIFF
--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -266,6 +266,27 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
+        <term><command>override</command></term>
+
+        <listitem>
+          <para>
+            <command>remove</command> Remove a package from the base
+            tree.  Note that this is similar to layering in that
+            the original base is retained.
+          </para>
+
+          <para>
+            <command>replace</command> Replace a package in the base tree.
+          </para>
+
+          <para>
+            <command>reset</command> Undo a <literal>remove</literal> or
+            <literal>replace</literal> operation.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><command>rebase</command></term>
 
         <listitem>

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -74,6 +74,8 @@ static RpmOstreeCommand commands[] = {
   { "uninstall", 0,
     "Remove one or more overlay packages",
     rpmostree_builtin_uninstall },
+  { "override", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
+    "Manage base overrides", rpmostree_builtin_override },
   { "refresh-md", 0,
     "Generate rpm repo metadata",
     rpmostree_builtin_refresh_md },

--- a/src/app/rpmostree-builtin-ex.c
+++ b/src/app/rpmostree-builtin-ex.c
@@ -26,8 +26,6 @@ static RpmOstreeCommand ex_subcommands[] = {
   { "livefs", RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
     "Apply pending deployment changes to booted deployment",
     rpmostree_ex_builtin_livefs },
-  { "override", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
-    "Manage base overrides", rpmostree_ex_builtin_override },
   { "unpack", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "unpack RPM into local OSTree repo", rpmostree_ex_builtin_unpack },
   { "container", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,

--- a/src/app/rpmostree-builtin-override.c
+++ b/src/app/rpmostree-builtin-override.c
@@ -37,9 +37,9 @@ static RpmOstreeCommand override_subcommands[] = {
 };
 
 int
-rpmostree_ex_builtin_override (int argc, char **argv,
-                               RpmOstreeCommandInvocation *invocation,
-                               GCancellable *cancellable, GError **error)
+rpmostree_builtin_override (int argc, char **argv,
+                            RpmOstreeCommandInvocation *invocation,
+                            GCancellable *cancellable, GError **error)
 {
   return rpmostree_handle_subcommand (argc, argv, override_subcommands,
                                       invocation, cancellable, error);

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -74,6 +74,7 @@ BUILTINPROTO(internals);
 BUILTINPROTO(container);
 BUILTINPROTO(install);
 BUILTINPROTO(uninstall);
+BUILTINPROTO(override);
 BUILTINPROTO(start_daemon);
 BUILTINPROTO(ex);
 

--- a/tests/vmcheck/test-download-only.sh
+++ b/tests/vmcheck/test-download-only.sh
@@ -140,7 +140,7 @@ $REMOTE_OSTREE commit -b vmcheck --tree=ref=$pending
 vm_rpmostree cleanup -prmb
 vm_rpmostree rebase --remote vmcheck_remote
 vm_build_rpm_repo_mode skip foobar version 2.0
-vm_rpmostree ex override replace $YUMREPO/foobar-2.0-1.x86_64.rpm
+vm_rpmostree override replace $YUMREPO/foobar-2.0-1.x86_64.rpm
 csum=$($REMOTE_OSTREE commit -b vmcheck --tree=ref=vmcheck)
 vm_rpmostree upgrade --download-only
 vm_assert_status_jq \

--- a/tests/vmcheck/test-override-local-replace.sh
+++ b/tests/vmcheck/test-override-local-replace.sh
@@ -83,14 +83,14 @@ assert_replaced_local_pkg() {
 
 # try to replace foo without replacing the extension
 vm_build_rpm foo version 2.0
-if vm_rpmostree ex override replace $YUMREPO/foo-2.0-1.x86_64.rpm 2>err.txt; then
+if vm_rpmostree override replace $YUMREPO/foo-2.0-1.x86_64.rpm 2>err.txt; then
   assert_not_reached "successfully replaced foo without fooext?"
 fi
 assert_file_has_content err.txt "fooext"
 echo "ok failed to replace foo without fooext"
 
 vm_build_rpm fooext version 2.0 requires "foo = 2.0-1"
-vm_rpmostree ex override replace $YUMREPO/foo{,ext}-2.0-1.x86_64.rpm
+vm_rpmostree override replace $YUMREPO/foo{,ext}-2.0-1.x86_64.rpm
 vm_assert_status_jq \
   '.deployments[0]["base-local-replacements"]|length == 2' \
   '.deployments[0]["requested-base-local-replacements"]|length == 2'
@@ -102,7 +102,7 @@ echo "ok override replace foo and fooext"
 
 # replace bar with older version
 vm_build_rpm bar version 0.9
-vm_rpmostree ex override replace $YUMREPO/bar-0.9-1.x86_64.rpm
+vm_rpmostree override replace $YUMREPO/bar-0.9-1.x86_64.rpm
 vm_assert_status_jq \
   '.deployments[0]["base-local-replacements"]|length == 3' \
   '.deployments[0]["requested-base-local-replacements"]|length == 3'
@@ -125,14 +125,14 @@ assert_replaced_local_pkg bar-1.0-1.x86_64 bar-0.9-1.x86_64
 echo "ok override replacements carried through upgrade"
 
 # try to reset pkgs using both name and nevra
-vm_rpmostree ex override reset foo fooext-2.0-1.x86_64
+vm_rpmostree override reset foo fooext-2.0-1.x86_64
 vm_assert_status_jq \
   '.deployments[0]["base-local-replacements"]|length == 1' \
   '.deployments[0]["requested-base-local-replacements"]|length == 1'
 assert_replaced_local_pkg bar-1.0-1.x86_64 bar-0.9-1.x86_64
 echo "ok override reset foo and fooext using name and nevra"
 
-vm_rpmostree ex override reset --all
+vm_rpmostree override reset --all
 vm_assert_status_jq \
   '.deployments[0]["base-removals"]|length == 0' \
   '.deployments[0]["requested-base-removals"]|length == 0'
@@ -143,7 +143,7 @@ vm_rpmostree cleanup -p
 # test inactive replacements
 vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo_and_bar
 vm_rpmostree upgrade
-vm_rpmostree ex override replace $YUMREPO/bar-0.9-1.x86_64.rpm
+vm_rpmostree override replace $YUMREPO/bar-0.9-1.x86_64.rpm
 vm_assert_status_jq \
   '.deployments[0]["base-local-replacements"]|length == 1' \
   '.deployments[0]["requested-base-local-replacements"]|length == 1'
@@ -169,7 +169,7 @@ vm_rpmostree cleanup -p
 vm_build_rpm baz
 vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo_and_bar
 vm_rpmostree upgrade
-vm_rpmostree ex override replace $YUMREPO/bar-0.9-1.x86_64.rpm \
+vm_rpmostree override replace $YUMREPO/bar-0.9-1.x86_64.rpm \
                        --install $YUMREPO/baz-1.0-1.x86_64.rpm
 vm_assert_status_jq \
   '.deployments[0]["base-local-replacements"]|length == 1' \

--- a/tests/vmcheck/test-override-remove.sh
+++ b/tests/vmcheck/test-override-remove.sh
@@ -66,7 +66,7 @@ vm_cmd mv /tmp/vmcheck/yumrepo{,.bak}
 # this works. the only difference here is the [.0] which we use to access the
 # nevra of each gv_nevra element.
 
-vm_rpmostree ex override remove foo bar
+vm_rpmostree override remove foo bar
 vm_assert_status_jq \
   '.deployments[0]["base-removals"]|length == 2' \
   '[.deployments[0]["base-removals"][][.0]]|index("foo-1.0-1.x86_64") >= 0' \
@@ -87,7 +87,7 @@ vm_assert_status_jq \
   '.deployments[0]["requested-base-removals"]|index("bar") >= 0'
 echo "ok override remove carried through upgrade"
 
-vm_rpmostree ex override reset foo
+vm_rpmostree override reset foo
 vm_assert_status_jq \
   '.deployments[0]["base-removals"]|length == 1' \
   '[.deployments[0]["base-removals"][][.0]]|index("bar-1.0-1.x86_64") >= 0' \
@@ -95,14 +95,14 @@ vm_assert_status_jq \
   '.deployments[0]["requested-base-removals"]|index("bar") >= 0'
 echo "ok override reset foo"
 
-vm_rpmostree ex override reset --all
+vm_rpmostree override reset --all
 vm_assert_status_jq \
   '.deployments[0]["base-removals"]|length == 0' \
   '.deployments[0]["requested-base-removals"]|length == 0'
 echo "ok override reset --all"
 
 # check that upgrading to a base without foo works
-vm_rpmostree ex override remove foo
+vm_rpmostree override remove foo
 vm_assert_status_jq \
   '.deployments[0]["base-removals"]|length == 1' \
   '[.deployments[0]["base-removals"][][.0]]|index("foo-1.0-1.x86_64") >= 0' \
@@ -133,13 +133,13 @@ echo "ok override remove/reset operate offline"
 
 # a few error checks
 
-if vm_rpmostree ex override remove non-existent-package; then
+if vm_rpmostree override remove non-existent-package; then
   assert_not_reached "override remove non-existent-package succeeded?"
 fi
 echo "ok override remove non-existent-package fails"
 
 vm_rpmostree install foo
-if vm_rpmostree ex override remove foo; then
+if vm_rpmostree override remove foo; then
   assert_not_reached "override remove layered pkg foo succeeded?"
 fi
 vm_rpmostree cleanup -p
@@ -149,7 +149,7 @@ echo "ok override remove layered pkg foo fails"
 vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo_and_bar
 
 vm_rpmostree upgrade
-vm_rpmostree ex override remove foo
+vm_rpmostree override remove foo
 if vm_rpmostree install foo; then
   assert_not_reached "tried to layer pkg removed by override"
 fi
@@ -163,7 +163,7 @@ echo "ok can't layer pkg removed by override"
 
 vm_build_rpm foo-ext requires "foo = 1.0-1"
 vm_rpmostree upgrade --install foo-ext
-if vm_rpmostree ex override remove foo; then
+if vm_rpmostree override remove foo; then
   assert_not_reached "override remove base pkg needed by layered pkg succeeded?"
 fi
 vm_rpmostree cleanup -p


### PR DESCRIPTION
We have a *lot* of experimental functionality.  I think the
`override` bits are fleshed out enough now that we can lift
the `ex` designation.  For example, jlebon fixed SELinux
labeling in the presence of override-replace.
