### PR TITLE
unpacker: Error out when trying to install RPM in /usr/local

### DIFF
--- a/src/libpriv/rpmostree-unpacker.c
+++ b/src/libpriv/rpmostree-unpacker.c
@@ -608,7 +608,8 @@ path_is_ostree_compliant (const char *path)
   g_assert (*path == '/');
   path++;
   return (*path == '\0' ||
-          g_str_equal (path, "usr")   || g_str_has_prefix (path, "usr/")  ||
+          g_str_equal (path, "usr")   || (g_str_has_prefix (path, "usr/")
+                                          && !g_str_has_prefix (path, "usr/local/")) ||
           g_str_equal (path, "bin")   || g_str_has_prefix (path, "bin/")  ||
           g_str_equal (path, "sbin")  || g_str_has_prefix (path, "sbin/") ||
           g_str_equal (path, "lib")   || g_str_has_prefix (path, "lib/")  ||


### PR DESCRIPTION
This came up with `https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-license-9-0-9.0.176-1.x86_64.rpm`.
Reported by @dustymabe on IRC.
