### PR TITLE
scripts: Ignore nfs-utils.post

### DIFF
--- a/src/libpriv/rpmostree-script-gperf.gperf
+++ b/src/libpriv/rpmostree-script-gperf.gperf
@@ -36,3 +36,5 @@ gdb.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE
 systemd.transfiletriggerin, RPMOSTREE_SCRIPT_ACTION_IGNORE
 # https://bugzilla.redhat.com/show_bug.cgi?id=1473402
 man-db.transfiletriggerin, RPMOSTREE_SCRIPT_ACTION_IGNORE
+# https://src.fedoraproject.org/rpms/nfs-utils/pull-request/1
+nfs-utils.post, RPMOSTREE_SCRIPT_ACTION_IGNORE


### PR DESCRIPTION
The maintainer can't apparently be bothered to review my patch,
and we don't need the `%post` anyways - and this is now blocking
my jigdo work.
