### PR TITLE
build: allow `git describe` versioning in worktrees

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,7 +30,7 @@ if ENABLE_GTK_DOC
 SUBDIRS += api-doc
 endif
 
-RPM_OSTREE_GITREV=$(shell if command -v git >/dev/null 2>&1 && test -d $(srcdir)/.git; then git describe --abbrev=42 --tags --always HEAD; fi)
+RPM_OSTREE_GITREV=$(shell if command -v git >/dev/null 2>&1 && test -e $(srcdir)/.git; then git describe --abbrev=42 --tags --always HEAD; fi)
 
 ACLOCAL_AMFLAGS += -I m4 ${ACLOCAL_FLAGS}
 AM_CPPFLAGS += -DDATADIR='"$(datadir)"' \


### PR DESCRIPTION
In git worktrees, `.git` is not a directory but a regular file
containing the path to the real git directory. This was causing us to
not use `git describe` in the versioning info, which is really useful to
sanity check that you're running the code you think you're running. Fix
this by just checking that a `.git` entry exists.