### PR TITLE
ci/papr: Update to f27-primary

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -3,20 +3,20 @@ branches:
     - auto
     - try
 
-context: f26-primary
+context: f27-primary
 
 required: true
 
 cluster:
   hosts:
     - name: vmcheck1
-      distro: fedora/26/atomic
+      distro: fedora/27/atomic
     - name: vmcheck2
-      distro: fedora/26/atomic
+      distro: fedora/27/atomic
     - name: vmcheck3
-      distro: fedora/26/atomic
+      distro: fedora/27/atomic
   container:
-    image: registry.fedoraproject.org/fedora:26
+    image: registry.fedoraproject.org/fedora:27
 
 env:
   HOSTS: vmcheck1 vmcheck2 vmcheck3


### PR DESCRIPTION
I didn't try porting some of the other contexts yet...I want to see
if this works.

Note that FAHC was switched to 27, so it's only luck that things
work on 26.
