### PR TITLE
compose: Do relabel before downloading in --ex-unified-core

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -514,6 +514,11 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
     {
       if (!rpmostree_context_import (self->corectx, cancellable, error))
         return FALSE;
+      /* Depending on cache state, we may have some pkgs already
+       * labeled with a final target policy.
+       */
+      if (!rpmostree_context_relabel (self->corectx, cancellable, error))
+        return FALSE;
       rpmostree_context_set_tmprootfs_dfd (self->corectx, rootfs_dfd);
       if (!rpmostree_context_assemble (self->corectx, cancellable, error))
         return FALSE;

--- a/tests/compose-tests/test-basic-unified.sh
+++ b/tests/compose-tests/test-basic-unified.sh
@@ -30,3 +30,11 @@ ostree --repo=${repobuild} cat ${treeref} /usr/lib/tmpfiles.d/pkg-chrony.conf > 
 # And this one has a non-root uid
 assert_file_has_content_literal autovar.txt 'd /var/log/chrony 0755 chrony chrony - -'
 echo "ok autovar"
+
+# And redo it to trigger relabeling
+origrev=$(ostree --repo=${repobuild} rev-parse ${treeref})
+runcompose  --force-nocache --ex-unified-core
+newrev=$(ostree --repo=${repobuild} rev-parse ${treeref})
+assert_not_streq "${origrev}" "${newrev}"
+
+echo "ok rerun"


### PR DESCRIPTION
We removed this in review, but I rediscovered why I added it.  We
fail the `g_assert (sepolicy_matches)` if we already had packages
done with the final label when we go to reuse the cache.

(Basically, if we use the cache multiple times it's hard to avoid
 relabeling all the time which is unfortunate...gets back a bit to
 a way to annotate pkgcache commits as supporting multiple policies)
