### PR TITLE
postprocess: Add envvar option, and detect NFS, skip ostree txn

### DIFF
--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1909,8 +1909,8 @@ rpmostree_commit (int            rootfs_fd,
     }
 
   /* See comment above */
-  const gboolean use_txn = getenv ("RPMOSTREE_COMMIT_NO_TXN") == NULL &&
-    !repo_is_on_netfs (repo);
+  const gboolean use_txn = (getenv ("RPMOSTREE_COMMIT_NO_TXN") == NULL &&
+                            !repo_is_on_netfs (repo));
 
   if (use_txn)
     {


### PR DESCRIPTION
This is for: https://pagure.io/atomic-wg/issue/387

Right now the way libostree stages objects into `${repo}/tmp` is basically an
anti-pattern for (possibly concurrent) operations on NFS. Having multiple
processes try to clean the tmpdir invites races, and there's really no reason to
"stage" all of the content.

(Unfortunately unless NFS supports `O_TMPFILE` we still need temp files,
 but that's a separate issue)

In this patch we auto-detect NFS which should make the Fedora pungi runs "just
work", but I also added an environment variable to opt-in.
