### PR TITLE
tests: Correctly error out if some part of install.sh fails

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -73,13 +73,13 @@ check-local:
 HOSTS ?= "vmcheck"
 
 vmsync:
-	@if [ -z "$(SKIP_INSTALL)" ]; then \
+	@set -e; if [ -z "$(SKIP_INSTALL)" ]; then \
 		env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/install.sh; \
 	fi; \
 	env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/sync.sh
 
 vmoverlay:
-	@if [ -z "$(SKIP_VMOVERLAY)" ]; then \
+	@set -e; if [ -z "$(SKIP_VMOVERLAY)" ]; then \
 	  if [ -z "$(SKIP_INSTALL)" ]; then \
 	    env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/install.sh; \
 	  fi; \

--- a/tests/vmcheck/install.sh
+++ b/tests/vmcheck/install.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 
 DESTDIR=${topsrcdir}/insttree
 
+# Chown everything to writable, due to
+# https://bugzilla.redhat.com/show_bug.cgi?id=517575
+if test -d ${DESTDIR}; then chmod -R u+w ${DESTDIR}/; fi
 rm -rf ${DESTDIR}
 mkdir -p ${DESTDIR}
 
@@ -20,8 +23,7 @@ for pkg in ostree{,-libs,-grub2}; do
     # container case, manpages are missing. Ignore that.
     rpm -ql $pkg | grep -vE "^/(etc|usr/share/(doc|man))/" >  list.txt
 
-    # Also chown everything to writable, due to
-    # https://bugzilla.redhat.com/show_bug.cgi?id=517575
+    # See above chown https://bugzilla.redhat.com/show_bug.cgi?id=517575
     chmod -R u+w ${DESTDIR}/
 
     # Note we cant use --ignore-missing-args here since it was added in


### PR DESCRIPTION
It took me way, way, way too long to debug that my dev container somehow missing
`ostree-grub2` caused the script to fail early, but we'd still continue trying
to sync, leading to us not actually changing the installed `rpm-ostree` binary,
leading to test suite failures.

Also add the chmod hammer at the top so we can delete even if we fail after
doing an rsync.
