### PR TITLE
tests: Use ostree commit --consume

### DIFF
--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -65,6 +65,9 @@ fi
 rm -vrf vmcheck/usr/etc/selinux/targeted/semanage.*.LOCK
 # ✀✀✀ END tmp hack
 
-ostree commit --parent=none -b vmcheck --add-metadata-string=ostree.source-title="Dev overlay on ${origin}" --add-metadata-string=rpmostree.original-origin=${origin} --link-checkout-speedup \
-  --selinux-policy=vmcheck --tree=dir=vmcheck
+ostree commit --parent=none -b vmcheck \
+       --add-metadata-string=ostree.source-title="Dev overlay on ${origin}" \
+       --add-metadata-string=rpmostree.original-origin=${origin} \
+       --link-checkout-speedup --consume \
+       --selinux-policy=vmcheck --tree=dir=vmcheck
 ostree admin deploy vmcheck

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -65,9 +65,14 @@ fi
 rm -vrf vmcheck/usr/etc/selinux/targeted/semanage.*.LOCK
 # ✀✀✀ END tmp hack
 
+consume_opt=
+if ostree commit --help | grep -q -e --consume; then
+    consume_opt=--consume
+fi
+
 ostree commit --parent=none -b vmcheck \
        --add-metadata-string=ostree.source-title="Dev overlay on ${origin}" \
        --add-metadata-string=rpmostree.original-origin=${origin} \
-       --link-checkout-speedup --consume \
+       --link-checkout-speedup ${consume_opt} \
        --selinux-policy=vmcheck --tree=dir=vmcheck
 ostree admin deploy vmcheck


### PR DESCRIPTION
Just noticed this while working on something else; we should use it where
possible.
