### PR TITLE
txn: For --download-only, print 'changed' message if changed

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -911,7 +911,10 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
       if (self->flags & RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_ONLY)
         {
           /* XXX: improve msg here; e.g. cache will be blown on next operation? */
-          rpmostreed_transaction_emit_message_printf (transaction, "Downloaded.");
+          if (changed)
+            rpmostreed_transaction_emit_message_printf (transaction, "Update downloaded.");
+          else
+            rpmostreed_transaction_emit_message_printf (transaction, "No changes.");
           return TRUE;
         }
 


### PR DESCRIPTION
I was playing with `--download-only` a bit with an eye to
having something like this be used by Cockpit/gnome-software instead
of what it's doing now, but a problem is that at the moment we
don't have a way to reflect the "changed" state back to clients.

This is a first step towards that by simply printing a different
message.

I think really to make all of this work more nicely though, including
supporting e.g. rpm database diffs, we are going to have to instead
work on the [pending deployment](https://github.com/ostreedev/ostree/issues/545)
path.
