### PR TITLE
core: Use DEVINO_CANONICAL for pkglayer if policy unchanged

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -9,7 +9,7 @@ dn=$(dirname $0)
 # Use the latest ostree by default
 id=$(. /etc/os-release && echo $ID)
 version_id=$(. /etc/os-release && echo $VERSION_ID)
-if [ "$id" == fedora ] && [ "$version_id" == 26 ]; then
+if [ "$id" == fedora ] && [ "$version_id" == 27 ]; then
     echo -e '[fahc]\nmetadata_expire=1m\nbaseurl=https://ci.centos.org/artifacts/sig-atomic/fahc/rdgo/build/\ngpgcheck=0\n' > /etc/yum.repos.d/fahc.repo
     # Until we fix https://github.com/rpm-software-management/libdnf/pull/149
     sed -i -e 's,metadata_expire=6h,exclude=ostree ostree-devel ostree-libs ostree-grub2\nmetadata_expire=6h,' /etc/yum.repos.d/fedora-updates.repo

--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,7 @@ LIBS="$save_LIBS"
 # Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 >= 2.40.0 json-glib-1.0
-				     ostree-1 >= 2017.10
+				     ostree-1 >= 2017.14
 				     libsystemd
 				     polkit-gobject-1
 				     rpm librepo


### PR DESCRIPTION
There's a lot more details in the libostree PR:
https://github.com/ostreedev/ostree/pull/1357

Basically loading the xattrs is slow; let's only do it if we need to, and "need
to" is defined by "SELinux policy changed". On my test F27AH VM, the difference
between a stat() + hash table lookup versus the full xattr load on my test case
of rpm-ostree install ./tree-1.7.0-10.fc27.x86_64.rpm is absolutely dramatic;
consistently on the order of 10s without this support, and <1s with (800ms).
