### PR TITLE
compose/dracut: Use a host tmpdir for dracut

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -920,7 +920,7 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
 
       g_auto(GLnxTmpfile) initramfs_tmpf = { 0, };
       if (!rpmostree_run_dracut (self->tmprootfs_dfd, add_dracut_argv, kver,
-                                 initramfs_path, &initramfs_tmpf,
+                                 initramfs_path, NULL, &initramfs_tmpf,
                                  cancellable, error))
         return FALSE;
 

--- a/src/libpriv/rpmostree-kernel.c
+++ b/src/libpriv/rpmostree-kernel.c
@@ -366,6 +366,7 @@ rpmostree_run_dracut (int     rootfs_dfd,
                       const char *const* argv,
                       const char *kver,
                       const char *rebuild_from_initramfs,
+                      GLnxTmpDir  *dracut_host_tmpdir,
                       GLnxTmpfile *out_initramfs_tmpf,
                       GCancellable  *cancellable,
                       GError **error)
@@ -446,6 +447,9 @@ rpmostree_run_dracut (int     rootfs_dfd,
   if (!bwrap)
     return FALSE;
 
+  if (dracut_host_tmpdir)
+    rpmostree_bwrap_append_bwrap_argv (bwrap, "--bind", dracut_host_tmpdir->path, "/tmp/dracut", NULL);
+
   /* Set up argv and run */
   rpmostree_bwrap_append_child_argv (bwrap, (char*)glnx_basename (rpmostree_dracut_wrapper_path), NULL);
   for (char **iter = (char**)argv; iter && *iter; iter++)
@@ -453,6 +457,9 @@ rpmostree_run_dracut (int     rootfs_dfd,
 
   if (kver)
     rpmostree_bwrap_append_child_argv (bwrap, "--kver", kver, NULL);
+
+  if (dracut_host_tmpdir)
+    rpmostree_bwrap_append_child_argv (bwrap, "--tmpdir", "/tmp/dracut", NULL);
 
   rpmostree_bwrap_set_child_setup (bwrap, dracut_child_setup, GINT_TO_POINTER (tmpf.fd));
 

--- a/src/libpriv/rpmostree-kernel.h
+++ b/src/libpriv/rpmostree-kernel.h
@@ -49,6 +49,7 @@ rpmostree_run_dracut (int     rootfs_dfd,
                       const char *const* argv,
                       const char *kver,
                       const char *rebuild_from_initramfs,
+                      GLnxTmpDir  *dracut_host_tmpdir,
                       GLnxTmpfile *out_initramfs_tmpf,
                       GCancellable  *cancellable,
                       GError **error);


### PR DESCRIPTION

In unified core mode, this avoids an intense spam of errors from `cp`
because `tmpfs` doesn't support the `user.` xattr namespace, and
since [this dracut commit](https://github.com/dracutdevs/dracut/commit/61c761bc2c35fb244d46fbbde97161f5927071dc)
dracut tries to copy all xattrs, which was just done for IMA.
There's no point to having the SELinux labels or other xattrs
in the initramfs.

The real fix here is dracut should learn to *only* copy the IMA
xattrs, or even better disable IMA enforcement for the dracut
run or something.