### PR TITLE
app/compose: include rpmdb pkglist in compose

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1124,10 +1124,10 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
   }
 
   if (!rpmostree_rootfs_postprocess_common (self->rootfs_dfd, cancellable, error))
-    return EXIT_FAILURE;
+    return FALSE;
   if (!rpmostree_postprocess_final (self->rootfs_dfd, self->treefile, opt_ex_unified_core,
                                     cancellable, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (self->treefile)
     {

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1091,6 +1091,37 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
 }
 
 static gboolean
+create_rpmdb_pkglist_variant (int              rootfs_dfd,
+                              GVariant       **out_variant,
+                              GCancellable    *cancellable,
+                              GError         **error)
+{
+  g_autoptr(GPtrArray) pkglist = NULL;
+  g_autoptr(RpmOstreeRefSack) refsack = NULL;
+  if (!rpmostree_get_pkglist_for_root (rootfs_dfd, ".", &refsack,
+                                       &pkglist, cancellable, error))
+    return FALSE;
+
+  GVariantBuilder pkglist_v_builder;
+  g_variant_builder_init (&pkglist_v_builder, (GVariantType*)"a(stsss)");
+
+  const guint n = pkglist->len;
+  for (guint i = 0; i < n; i++)
+    {
+      DnfPackage *pkg = pkglist->pdata[i];
+      g_variant_builder_add (&pkglist_v_builder, "(stsss)",
+                             dnf_package_get_name (pkg),
+                             dnf_package_get_epoch (pkg),
+                             dnf_package_get_version (pkg),
+                             dnf_package_get_release (pkg),
+                             dnf_package_get_arch (pkg));
+    }
+
+  *out_variant = g_variant_builder_end (&pkglist_v_builder);
+  return TRUE;
+}
+
+static gboolean
 impl_commit_tree (RpmOstreeTreeComposeContext *self,
                   GCancellable    *cancellable,
                   GError         **error)
@@ -1108,6 +1139,15 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
   { g_autoptr(GVariantBuilder) metadata_builder = g_variant_builder_new (G_VARIANT_TYPE ("a{sv}"));
     GLNX_HASH_TABLE_FOREACH_KV (self->metadata, const char*, strkey, GVariant*, v)
       g_variant_builder_add (metadata_builder, "{sv}", strkey, v);
+
+    /* include list of packages in rpmdb; this is used client-side for easily previewing
+     * pending updates. once we only support unified core composes, this can easily be much
+     * more readily injected during assembly */
+    g_autoptr(GVariant) rpmdb_v = NULL;
+    if (!create_rpmdb_pkglist_variant (self->rootfs_dfd, &rpmdb_v, cancellable, error))
+      return FALSE;
+    g_variant_builder_add (metadata_builder, "{sv}", "rpmostree.rpmdb.pkglist",
+                           g_steal_pointer (&rpmdb_v));
 
     metadata = g_variant_ref_sink (g_variant_builder_end (metadata_builder));
     /* Canonicalize to big endian, like OSTree does. Without this, any numbers

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -890,6 +890,10 @@ rpmostree_get_pkglist_for_root (int               dfd,
                                 GCancellable     *cancellable,
                                 GError          **error)
 {
+  /* the DnfPackage objects don't have a ref on their DnfSack; make sure callers don't fall
+   * in that trap */
+  g_return_val_if_fail (out_pkglist == NULL || out_refsack != NULL, FALSE);
+
   g_autoptr(RpmOstreeRefSack) refsack =
     rpmostree_get_refsack_for_root (dfd, path, cancellable, error);
   if (!refsack)

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -39,4 +39,9 @@ assert_not_file_has_content ls.txt '__db' 'lock'
 ostree --repo=${repobuild} ls -R ${treeref} /usr/etc/selinux > ls.txt
 assert_not_file_has_content ls.txt 'LOCK'
 echo "ok no leftover files"
+
+ostree --repo=${repobuild} show ${treeref} \
+  --print-metadata-key rpmostree.rpmdb.pkglist > pkglist.txt
+assert_file_has_content pkglist.txt 'systemd'
+echo "ok pkglist"
 }


### PR DESCRIPTION
We don't want to have to download all of `/usr/share/rpm` just to get
the list of packages used to compose the tree. This is fundamental
information that needs to be easier to discover. So let's stick it right
in the commit metadata. There's various use cases for this information,
including easily checking for and displaying updates and a pkglist-aware
version of `ostree log`.