### PR TITLE
 jigdo: Add Provides: rpmostree-jigdo(v1), require it on  client

### DIFF
--- a/src/app/rpmostree-ex-builtin-commit2jigdo.c
+++ b/src/app/rpmostree-ex-builtin-commit2jigdo.c
@@ -926,6 +926,10 @@ write_commit2jigdo (RpmOstreeCommit2JigdoContext *self,
           g_ptr_array_add (rpmbuild_argv, g_strdup ("-D"));
           g_ptr_array_add (rpmbuild_argv, g_strconcat ("ostree_version ", commit_version, NULL));
         }
+
+      g_ptr_array_add (rpmbuild_argv, g_strdup ("-D"));
+      g_ptr_array_add (rpmbuild_argv, g_strconcat ("rpmostree_jigdo_meta ", "Provides: " RPMOSTREE_JIGDO_PROVIDE_V1 "\n", NULL));
+
       g_ptr_array_add (rpmbuild_argv, g_strdup (oirpm_spec));
       g_ptr_array_add (rpmbuild_argv, NULL);
       int estatus;

--- a/src/app/rpmostree-ex-builtin-commit2jigdo.c
+++ b/src/app/rpmostree-ex-builtin-commit2jigdo.c
@@ -500,6 +500,8 @@ build_objid_map_for_package (RpmOstreeCommit2JigdoContext *self,
                              GCancellable                 *cancellable,
                              GError                      **error)
 {
+  const char *errmsg = glnx_strjoina ("build objidmap for ", dnf_package_get_nevra (pkg));
+  GLNX_AUTO_PREFIX_ERROR (errmsg, error);
   g_autofree char *cachebranch = rpmostree_get_cache_branch_pkg (pkg);
   g_autofree char *pkg_commit = NULL;
   g_autoptr(GFile) commit_root = NULL;

--- a/src/app/rpmostree-ex-builtin-commit2jigdo.c
+++ b/src/app/rpmostree-ex-builtin-commit2jigdo.c
@@ -540,7 +540,7 @@ build_objid_map_for_package (RpmOstreeCommit2JigdoContext *self,
        * "content-identical objects" i.e. they differ only in metadata.
        */
       guint32 objsize;
-      if (!query_objsize_assert_32bit (self->repo, checksum, &objsize, error))
+      if (!query_objsize_assert_32bit (self->pkgcache_repo, checksum, &objsize, error))
         return FALSE;
       if (objsize >= BIG_OBJ_SIZE)
         {

--- a/src/libpriv/rpmostree-jigdo-core.h
+++ b/src/libpriv/rpmostree-jigdo-core.h
@@ -75,3 +75,5 @@
 #define RPMOSTREE_JIGDO_XATTRS_TABLE_VARIANT_FORMAT (G_VARIANT_TYPE ("aa(ayay)"))
 /* NEVRA + xattr table */
 #define RPMOSTREE_JIGDO_XATTRS_PKG_VARIANT_FORMAT (G_VARIANT_TYPE ("a(su)"))
+
+#define RPMOSTREE_JIGDO_PROVIDE_V1 "rpmostree-jigdo(v1)"

--- a/tests/composedata/fedora-atomic-host-oirpm.spec
+++ b/tests/composedata/fedora-atomic-host-oirpm.spec
@@ -7,6 +7,7 @@ Version:	%{ostree_version}
 Release:	1%{?dist}
 Summary:	Image (rpm-ostree jigdo) for Fedora Atomic Host
 License:	MIT
+%{rpmostree_jigdo_meta}
 
 %description
 %{summary}


### PR DESCRIPTION
We are going to want versioning on the jigdo RPMs, since it's
highly likely things change.

This is done via new magic `-D rpmostree_jigdo_meta` macro, which we can also
use for other things down the line.