### PR TITLE
status: Prefix ostree refspecs with ostree://

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -299,7 +299,7 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
       g_print ("%s ", is_booted ? libsd_special_glyph (BLACK_CIRCLE) : " ");
 
       if (origin_refspec)
-        g_print ("%s", origin_refspec);
+        g_print ("ostree://%s", origin_refspec);
       else
         g_print ("%s", checksum);
       g_print ("\n");

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -50,6 +50,7 @@ assert_status_jq '.deployments[0].version == "1.0.10"'
 echo "ok status shows right version"
 
 rpm-ostree status > status.txt
+assert_file_has_content status.txt '  ostree://testos:testos/buildmaster/x86_64-runtime'
 assert_file_has_content status.txt 'Version: 1.0.10'
 assert_not_file_has_content status.txt StateRoot:
 rpm-ostree status -v > status.txt


### PR DESCRIPTION
In preparation for jigdo, which would be like `jigdo://`.
