### PR TITLE
compose: Fix --ex-unified-core devino cache (suid bits lost)

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -431,6 +431,7 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
         return FALSE;
       rpmostree_context_set_repos (self->corectx, self->repo, self->pkgcache_repo);
       self->devino_cache = ostree_repo_devino_cache_new ();
+      rpmostree_context_set_devino_cache (self->corectx, self->devino_cache);
 
       /* Ensure that the imported packages are labeled with *a* policy if
        * possible, even if it's not the final one. This helps avoid duplicating
@@ -1146,7 +1147,7 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
   /* The penultimate step, just basically `ostree commit` */
   g_autofree char *new_revision = NULL;
   if (!rpmostree_commit (self->rootfs_dfd, self->repo, self->ref, opt_write_commitid_to,
-                         metadata, gpgkey, selinux, NULL,
+                         metadata, gpgkey, selinux, self->devino_cache,
                          &new_revision,
                          cancellable, error))
     return FALSE;

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -29,6 +29,10 @@ ostree --repo=${repobuild} ls -R ${treeref} /usr/share/man > manpages.txt
 assert_file_has_content manpages.txt man5/ostree.repo.5
 echo "ok manpages"
 
+ostree --repo=${repobuild} ls ${treeref} /usr/bin/su > su.txt
+assert_file_has_content su.txt '^-04[71][0-7][0-7]'
+echo "ok setuid"
+
 # https://github.com/projectatomic/rpm-ostree/issues/669
 ostree --repo=${repobuild} ls  ${treeref} /tmp > ls.txt
 assert_file_has_content ls.txt 'l00777 0 0      0 /tmp -> sysroot/tmp'


### PR DESCRIPTION
With unified core 🌐 we are *relying* on the devino cache
for correctness when using `bare-user` repos.  Otherwise lots
of bad things will happen as we won't hit the happy path from
[this libostree PR](https://github.com/ostreedev/ostree/pull/1297)
(I should probably add an assertion there that we aren't trying to commit
 `user.ostreemeta`).

It looks like I had this working in some of the old unified core WIP patches,
but it was lost when rebasing 🏄.

We noticed this when I was trying to deploy jigdo in FAHC and the system
wouldn't boot as various things rely on those suid transitions.
