### PR TITLE
core: c++ build: Use enum-NONE value instead of zero

### DIFF
--- a/src/daemon/rpmostree-sysroot-core.c
+++ b/src/daemon/rpmostree-sysroot-core.c
@@ -251,7 +251,7 @@ clean_pkgcache_orphans (OstreeSysroot            *sysroot,
 
   if (n_freed > 0 || freed_space > 0)
     {
-      char *freed_space_str = g_format_size_full (freed_space, 0);
+      char *freed_space_str = g_format_size_full (freed_space, G_FORMAT_SIZE_DEFAULT);
       rpmostree_output_message ("Freed pkgcache branches: %u size: %s",
                                 n_freed, freed_space_str);
     }


### PR DESCRIPTION
In the whole libdnf/C++ discussion I experimented with trying to build
rpm-ostree as C++. There's a whole ton of stuff there. I'm going to punt for
now, but let's land this one change so some progress was made.
