### PR TITLE
compose: Write rpmdb to /usr/lib/sysimage/rpm-ostree-base-db

### DIFF
--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -29,6 +29,8 @@
 #define RPMOSTREE_CORE_CACHEDIR "/var/cache/rpm-ostree/"
 /* See http://lists.rpm.org/pipermail/rpm-maint/2017-October/006681.html */
 #define RPMOSTREE_RPMDB_LOCATION "usr/share/rpm"
+#define RPMOSTREE_SYSIMAGE_DIR "usr/lib/sysimage"
+#define RPMOSTREE_BASE_RPMDB RPMOSTREE_SYSIMAGE_DIR "/rpm-ostree-base-db"
 
 #define RPMOSTREE_TYPE_CONTEXT (rpmostree_context_get_type ())
 G_DECLARE_FINAL_TYPE (RpmOstreeContext, rpmostree_context, RPMOSTREE, CONTEXT, GObject)

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -193,9 +193,9 @@ init_rootfs (int            dfd,
   return TRUE;
 }
 
-/* Given a directory referenced by @src_dfd+@src_path,
- * Create @dest_dfd+@dest_path as a directory, hardlinking
- * all content - recursively.
+/* Given a directory referenced by @src_dfd+@src_path, as well as a target
+ * directory @dest_dfd+@dest_path (which must already exist), hardlink all
+ * content recursively.
  */
 static gboolean
 hardlink_recurse (int                src_dfd,
@@ -1231,10 +1231,13 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
   if (!rename_if_exists (rootfs_fd, "etc", rootfs_fd, "usr/etc", error))
     return FALSE;
 
+  gboolean have_rpmdb;
   if (!glnx_fstatat_allow_noent (rootfs_fd, RPMOSTREE_RPMDB_LOCATION, NULL, AT_SYMLINK_NOFOLLOW, error))
     return FALSE;
-  if (errno == ENOENT)
+  have_rpmdb = (errno == 0);
+  if (!have_rpmdb)
     {
+      /* Try looking in var/lib/rpm */
       struct stat stbuf;
       if (!glnx_fstatat_allow_noent (rootfs_fd, "var/lib/rpm", &stbuf, AT_SYMLINK_NOFOLLOW, error))
         return FALSE;
@@ -1244,12 +1247,30 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
             return FALSE;
           if (symlinkat ("../../" RPMOSTREE_RPMDB_LOCATION, rootfs_fd, "var/lib/rpm") < 0)
             return glnx_throw_errno_prefix (error, "symlinkat(%s)", "var/lib/rpm");
+          have_rpmdb = TRUE;
         }
     }
 
   if (!cleanup_leftover_files (rootfs_fd, RPMOSTREE_RPMDB_LOCATION, rpmdb_leftover_files,
                                rpmdb_leftover_prefixes, cancellable, error))
     return FALSE;
+
+  /* If we do have an rpmdb, hardlink it into the base path */
+  if (have_rpmdb)
+    {
+      /* We need idempotence, so check if it already exists */
+      if (!glnx_fstatat_allow_noent (rootfs_fd, RPMOSTREE_BASE_RPMDB, NULL, AT_SYMLINK_NOFOLLOW, error))
+        return FALSE;
+      if (errno == ENOENT)
+        {
+          if (!glnx_shutil_mkdir_p_at (rootfs_fd, RPMOSTREE_BASE_RPMDB, 0755, cancellable, error))
+            return FALSE;
+          if (!hardlink_recurse (rootfs_fd, RPMOSTREE_RPMDB_LOCATION,
+                                 rootfs_fd, RPMOSTREE_BASE_RPMDB,
+                                 cancellable, error))
+            return glnx_prefix_error (error, "Hardlinking %s", RPMOSTREE_BASE_RPMDB);
+        }
+    }
 
   if (!cleanup_selinux_lockfiles (rootfs_fd, cancellable, error))
     return FALSE;

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -1,10 +1,15 @@
 # This used to live in test-basic.sh, but it's now shared with test-basic-unified.sh
 basic_test() {
-ostree --repo=${repobuild} ls -R ${treeref} /usr/lib/ostree-boot > bootls.txt
 if ostree --repo=${repobuild} ls -R ${treeref} /usr/etc/passwd-; then
     assert_not_reached "Found /usr/etc/passwd- backup file in tree"
 fi
-echo "ok compose"
+echo "ok passwd"
+
+for path in /usr/share/rpm /usr/lib/sysimage/rpm-ostree-base-db; do
+    ostree --repo=${repobuild} ls -R ${treeref} ${path} > db.txt
+    assert_file_has_content_literal db.txt /Packages
+done
+echo "ok db"
 
 ostree --repo=${repobuild} show --print-metadata-key exampleos.gitrepo ${treeref} > meta.txt
 assert_file_has_content meta.txt 'rev.*97ec21c614689e533d294cdae464df607b526ab9'


### PR DESCRIPTION
This is prep for a rework of
https://github.com/projectatomic/rpm-ostree/pull/621

For a no-op `rpm-ostree upgrade` (i.e. no updates available), as long as
layering is enabled, we pay the cost of checking out the base tree, *mostly*
only to get the base rpmdb.

This is prep for fixing that down the line by knowing we always have the "base"
tree's rpmdb checked out. Then in the layering case we only modify
`/usr/share/rpm` (eventually that will point to `/usr/lib/sysimage/rpm`).

Teaching `rpmostree-core.c` about this can follow on later.
