### PR TITLE
Improve progress output

### DIFF
--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -130,12 +130,25 @@ sysroot_output_cb (RpmOstreeOutputType type, void *data, void *opaque)
     rpmostree_transaction_emit_task_end (RPMOSTREE_TRANSACTION (transaction),
                                          ((RpmOstreeOutputTaskEnd*)data)->text);
     break;
-  case RPMOSTREE_OUTPUT_PERCENT_PROGRESS:
+  case RPMOSTREE_OUTPUT_PROGRESS_PERCENT:
     rpmostree_transaction_emit_percent_progress (RPMOSTREE_TRANSACTION (transaction),
-                                                 ((RpmOstreeOutputPercentProgress*)data)->text,
-                                                 ((RpmOstreeOutputPercentProgress*)data)->percentage);
+                                                 ((RpmOstreeOutputProgressPercent*)data)->text,
+                                                 ((RpmOstreeOutputProgressPercent*)data)->percentage);
     break;
-  case RPMOSTREE_OUTPUT_PERCENT_PROGRESS_END:
+  case RPMOSTREE_OUTPUT_PROGRESS_N_ITEMS:
+    {
+      RpmOstreeOutputProgressNItems *nitems = data;
+      /* We still emit PercentProgress for compatibility with older clients as
+       * well as Cockpit. It's not worth trying to deal with version skew just
+       * for this yet.
+       */
+      int percentage = (nitems->current == nitems->total) ? 100 :
+        (((double)(nitems->current)) / (nitems->total) * 100);
+      g_autofree char *newtext = g_strdup_printf ("%s (%u/%u)", nitems->text, nitems->current, nitems->total);
+      rpmostree_transaction_emit_percent_progress (RPMOSTREE_TRANSACTION (transaction), newtext, percentage);
+    }
+    break;
+  case RPMOSTREE_OUTPUT_PROGRESS_END:
     rpmostree_transaction_emit_progress_end (RPMOSTREE_TRANSACTION (transaction));
     break;
   }

--- a/src/libpriv/rpmostree-output.c
+++ b/src/libpriv/rpmostree-output.c
@@ -47,14 +47,23 @@ rpmostree_output_default_handler (RpmOstreeOutputType type,
   case RPMOSTREE_OUTPUT_TASK_END:
     g_print ("%s\n", ((RpmOstreeOutputTaskEnd*)data)->text);
     break;
-  case RPMOSTREE_OUTPUT_PERCENT_PROGRESS:
+  case RPMOSTREE_OUTPUT_PROGRESS_PERCENT:
     if (!console.locked)
       glnx_console_lock (&console);
     glnx_console_progress_text_percent (
-      ((RpmOstreeOutputPercentProgress*)data)->text,
-      ((RpmOstreeOutputPercentProgress*)data)->percentage);
+      ((RpmOstreeOutputProgressPercent*)data)->text,
+      ((RpmOstreeOutputProgressPercent*)data)->percentage);
     break;
-  case RPMOSTREE_OUTPUT_PERCENT_PROGRESS_END:
+  case RPMOSTREE_OUTPUT_PROGRESS_N_ITEMS:
+    {
+      RpmOstreeOutputProgressNItems *nitems = data;
+      if (!console.locked)
+        glnx_console_lock (&console);
+
+      glnx_console_progress_n_items (nitems->text, nitems->current, nitems->total);
+    }
+    break;
+  case RPMOSTREE_OUTPUT_PROGRESS_END:
     if (console.locked)
       glnx_console_unlock (&console);
     break;
@@ -104,14 +113,21 @@ rpmostree_output_task_end (const char *format, ...)
 }
 
 void
-rpmostree_output_percent_progress (const char *text, int percentage)
+rpmostree_output_progress_percent (const char *text, int percentage)
 {
-  RpmOstreeOutputPercentProgress progress = { text, percentage };
-  active_cb (RPMOSTREE_OUTPUT_PERCENT_PROGRESS, &progress, active_cb_opaque);
+  RpmOstreeOutputProgressPercent progress = { text, percentage };
+  active_cb (RPMOSTREE_OUTPUT_PROGRESS_PERCENT, &progress, active_cb_opaque);
 }
 
 void
-rpmostree_output_percent_progress_end (void)
+rpmostree_output_progress_n_items (const char *text, guint current, guint total)
 {
-  active_cb (RPMOSTREE_OUTPUT_PERCENT_PROGRESS_END, NULL, active_cb_opaque);
+  RpmOstreeOutputProgressNItems progress = { text, current, total };
+  active_cb (RPMOSTREE_OUTPUT_PROGRESS_N_ITEMS, &progress, active_cb_opaque);
+}
+
+void
+rpmostree_output_progress_end (void)
+{
+  active_cb (RPMOSTREE_OUTPUT_PROGRESS_END, NULL, active_cb_opaque);
 }

--- a/src/libpriv/rpmostree-output.h
+++ b/src/libpriv/rpmostree-output.h
@@ -22,8 +22,9 @@ typedef enum {
   RPMOSTREE_OUTPUT_MESSAGE,
   RPMOSTREE_OUTPUT_TASK_BEGIN,
   RPMOSTREE_OUTPUT_TASK_END,
-  RPMOSTREE_OUTPUT_PERCENT_PROGRESS,
-  RPMOSTREE_OUTPUT_PERCENT_PROGRESS_END,
+  RPMOSTREE_OUTPUT_PROGRESS_N_ITEMS,
+  RPMOSTREE_OUTPUT_PROGRESS_PERCENT,
+  RPMOSTREE_OUTPUT_PROGRESS_END,
 } RpmOstreeOutputType;
 
 void
@@ -52,10 +53,19 @@ rpmostree_output_task_end (const char *format, ...) G_GNUC_PRINTF (1,2);
 typedef struct {
   const char *text;
   guint32 percentage;
-} RpmOstreeOutputPercentProgress;
+} RpmOstreeOutputProgressPercent;
+
+typedef struct {
+  const char *text;
+  guint current;
+  guint total;
+} RpmOstreeOutputProgressNItems;
 
 void
-rpmostree_output_percent_progress (const char *text, int percentage);
+rpmostree_output_progress_n_items (const char *text, guint current, guint total);
 
 void
-rpmostree_output_percent_progress_end (void);
+rpmostree_output_progress_percent (const char *text, int percentage);
+
+void
+rpmostree_output_progress_end (void);

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -135,12 +135,12 @@ echo "ok cleanup"
 
 # install foo and make sure it was imported
 vm_rpmostree install foo | tee output.txt
-assert_file_has_content output.txt '^Importing:'
+assert_file_has_content output.txt '^Importing (1/1)'
 
 # upgrade with same foo in repos --> shouldn't re-import
 vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
 vm_rpmostree upgrade | tee output.txt
-assert_not_file_has_content output.txt '^Importing:'
+assert_not_file_has_content output.txt '^Importing ('
 
 # upgrade with different foo in repos --> should re-import
 c1=$(sha256sum ${test_tmpdir}/yumrepo/packages/x86_64/foo-1.0-1.x86_64.rpm)
@@ -150,7 +150,7 @@ if cmp -s c1 c2; then
   assert_not_reached "RPM rebuild yielded same SHA256"
 fi
 vm_rpmostree upgrade | tee output.txt
-assert_file_has_content output.txt '^Importing:'
+assert_file_has_content output.txt '^Importing (1/1)'
 echo "ok invalidate pkgcache from RPM chksum"
 
 # make sure installing in /boot translates to /usr/lib/ostree-boot


### PR DESCRIPTION
This rolls up several libglnx changes: https://github.com/GNOME/libglnx/pull/101

Now of course things are trickier here because we have an internal
abstraction over directly emitting to a console versus sending the
result over DBus.  Further complicating things is that some things
call into libdnf and thus *require* use of `DnfState` which does
not give us the "n items" information, versus other parts which
we implement and can do what we want.

Even *further* complicating things is that we have to take care around non-CLI
callers like Cockpit; so I didn't try to pass the "n items" over DBus, rather
just reimplemented the "insert into text" that libglnx is doing.

Anyways overall this looks better IMO for all cases.
