### PR TITLE
🆕⌚️ Initial support for automatic updates 

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -74,15 +74,26 @@ librpmostreed_la_LIBADD = \
 dbusconf_DATA = $(srcdir)/src/daemon/org.projectatomic.rpmostree1.conf
 dbusconfdir = ${sysconfdir}/dbus-1/system.d
 
-systemdunit_in_files = $(srcdir)/src/daemon/rpm-ostreed.service.in
-systemdunit_DATA     = $(systemdunit_in_files:.service.in=.service)
+systemdunit_service_in_files = \
+	$(srcdir)/src/daemon/rpm-ostreed.service.in \
+	$(srcdir)/src/daemon/rpm-ostreed-automatic.service.in \
+	$(NULL)
+
+systemdunit_service_files = $(systemdunit_service_in_files:.service.in=.service)
+systemdunit_timer_files = $(srcdir)/src/daemon/rpm-ostreed-automatic.timer
+
+systemdunit_DATA = \
+	$(systemdunit_service_files) \
+	$(systemdunit_timer_files) \
+	$(NULL)
+
 systemdunitdir       = $(prefix)/lib/systemd/system/
 if BUILDOPT_ASAN
 daemon_asan_options = -e s,@SYSTEMD_ENVIRON\@,Environment=ASAN_OPTIONS=detect_leaks=false,
 else
 daemon_asan_options = -e /@SYSTEMD_ENVIRON\@/d
 endif
-$(systemdunit_DATA): Makefile
+$(systemdunit_service_files): Makefile
 	$(SED_SUBST) $(daemon_asan_options) $@.in > $@
 
 # We keep this stub script around to have SELinux labeling work,
@@ -119,10 +130,11 @@ EXTRA_DIST += \
 	$(polkit_policy_DATA) \
 	$(sysconf_DATA) \
 	$(service_in_files) \
-	$(systemdunit_in_files) \
+	$(systemdunit_service_in_files) \
+	$(systemdunit_timer_files) \
 	$(NULL)
 
 CLEANFILES += \
 	$(service_DATA) \
-	$(systemdunit_DATA) \
+	$(systemdunit_service_files) \
 	$(NULL)

--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -62,6 +62,8 @@ librpmostreepriv_la_SOURCES = \
 	src/libpriv/rpmostree-editor.h \
 	src/libpriv/libsd-locale-util.c \
 	src/libpriv/libsd-locale-util.h \
+	src/libpriv/libsd-time-util.c \
+	src/libpriv/libsd-time-util.h \
 	src/libpriv/rpmostree-libarchive-input-stream.c \
 	src/libpriv/rpmostree-libarchive-input-stream.h \
 	$(NULL)

--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -24,6 +24,7 @@ librpmostreepriv_la_SOURCES = \
 	src/libpriv/rpmostree-json-parsing.h \
 	src/libpriv/rpmostree-util.c \
 	src/libpriv/rpmostree-util.h \
+	src/libpriv/rpmostree-types.h \
 	src/libpriv/rpmostree-passwd-util.c \
 	src/libpriv/rpmostree-passwd-util.h \
 	src/libpriv/rpmostree-refts.h \

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -18,7 +18,7 @@ if BUILDOPT_ASAN
 AM_TESTS_ENVIRONMENT += BUILDOPT_ASAN=yes ASAN_OPTIONS=detect_leaks=false
 endif
 
-testbin_cppflags = $(AM_CPPFLAGS) -I $(srcdir)/src/libpriv -I $(srcdir)/libglnx -I $(srcdir)/tests/common
+testbin_cppflags = $(AM_CPPFLAGS) -I $(srcdir)/src/lib -I $(srcdir)/src/libpriv -I $(srcdir)/libglnx -I $(srcdir)/tests/common
 testbin_cflags = $(AM_CFLAGS) $(PKGDEP_RPMOSTREE_CFLAGS)
 testbin_ldadd = $(PKGDEP_RPMOSTREE_LIBS) librpmostree-1.la librpmostreepriv.la
 
@@ -56,9 +56,17 @@ uninstalled_test_scripts = \
 	tests/check/test-ucontainer.sh \
 	$(NULL)
 
-uninstalled_test_extra_programs = dbus-run-session
+uninstalled_test_extra_programs = \
+	inject-pkglist			\
+	dbus-run-session		\
+	$(NULL)
 
 dbus_run_session_SOURCES = tests/utils/dbus-run-session.c
+
+inject_pkglist_CPPFLAGS = $(testbin_cppflags)
+inject_pkglist_CFLAGS = $(testbin_cflags)
+inject_pkglist_LDADD = $(testbin_ldadd) libtest.la
+inject_pkglist_SOURCES = tests/utils/inject-pkglist.c
 
 check-local:
 	@echo "  *** NOTE ***"
@@ -78,7 +86,7 @@ vmsync:
 	fi; \
 	env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/sync.sh
 
-vmoverlay:
+vmoverlay: inject-pkglist
 	@set -e; if [ -z "$(SKIP_VMOVERLAY)" ]; then \
 	  if [ -z "$(SKIP_INSTALL)" ]; then \
 	    env $(BASE_TESTS_ENVIRONMENT) ./tests/vmcheck/install.sh; \

--- a/man/rpm-ostreed.conf.xml
+++ b/man/rpm-ostreed.conf.xml
@@ -68,11 +68,27 @@ Boston, MA 02111-1307, USA.
 
     <variablelist>
       <varlistentry>
+        <term><varname>AutomaticUpdatePolicy=</varname></term>
+
+        <listitem>
+        <para>Controls the automatic update policy. One of "none", "check", or "reboot".
+        "none" disables automatic updates. "check" downloads just enough metadata to check
+        for updates and display them in <command>rpm-ostree status</command>. "reboot"
+        downloads the update, deploys it, and reboots the machine. Defaults to
+        "none".</para>
+
+        <para>Automatic updates enablement and frequency are controlled by the
+        <command>rpm-ostreed-automatic.timer</command> unit. <!-- XXX: needs man page -->
+        See <citerefentry><refentrytitle>systemd.timer</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+        for more information on how to control systemd timers.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
         <term><varname>IdleExitTimeout=</varname></term>
 
         <listitem>
         <para>Controls the time in seconds of inactivity before the daemon exits. Use 0 to
-        disable auto-exit.</para>
+        disable auto-exit. Defaults to 60.</para>
         </listitem>
       </varlistentry>
     <!--

--- a/man/rpm-ostreed.conf.xml
+++ b/man/rpm-ostreed.conf.xml
@@ -71,10 +71,9 @@ Boston, MA 02111-1307, USA.
         <term><varname>AutomaticUpdatePolicy=</varname></term>
 
         <listitem>
-        <para>Controls the automatic update policy. One of "none", "check", or "reboot".
+        <para>Controls the automatic update policy. Currently "none" or "check".
         "none" disables automatic updates. "check" downloads just enough metadata to check
-        for updates and display them in <command>rpm-ostree status</command>. "reboot"
-        downloads the update, deploys it, and reboots the machine. Defaults to
+        for updates and display them in <command>rpm-ostree status</command>. Defaults to
         "none".</para>
 
         <para>Automatic updates enablement and frequency are controlled by the

--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -27,6 +27,7 @@
 #include <glib-unix.h>
 #include <libglnx.h>
 
+#include "rpmostree-types.h"
 #include "rpmostree-dbus-helpers.h"
 #include "rpmostree-builtins.h"
 #include "rpmostree-libbuiltin.h"
@@ -1236,25 +1237,29 @@ rpmostree_print_cached_update (GVariant         *cached_update,
 
       g_autoptr(GVariant) upgraded =
         _rpmostree_vardict_lookup_value_required (&rpm_diff_dict, "upgraded",
-                                                  G_VARIANT_TYPE ("a(us(ss)(ss))"), error);
+                                                  RPMOSTREE_DIFF_MODIFIED_GVARIANT_FORMAT,
+                                                  error);
       if (!upgraded)
         return FALSE;
 
       g_autoptr(GVariant) downgraded =
         _rpmostree_vardict_lookup_value_required (&rpm_diff_dict, "downgraded",
-                                                  G_VARIANT_TYPE ("a(us(ss)(ss))"), error);
+                                                  RPMOSTREE_DIFF_MODIFIED_GVARIANT_FORMAT,
+                                                  error);
       if (!downgraded)
         return FALSE;
 
       g_autoptr(GVariant) removed =
         _rpmostree_vardict_lookup_value_required (&rpm_diff_dict, "removed",
-                                                  G_VARIANT_TYPE ("a(usss)"), error);
+                                                  RPMOSTREE_DIFF_SINGLE_GVARIANT_FORMAT,
+                                                  error);
       if (!removed)
         return FALSE;
 
       g_autoptr(GVariant) added =
         _rpmostree_vardict_lookup_value_required (&rpm_diff_dict, "added",
-                                                  G_VARIANT_TYPE ("a(usss)"), error);
+                                                  RPMOSTREE_DIFF_SINGLE_GVARIANT_FORMAT,
+                                                  error);
       if (!added)
         return FALSE;
 

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -122,3 +122,9 @@ rpmostree_update_deployment (RPMOSTreeOS  *os_proxy,
                              char        **out_transaction_address,
                              GCancellable *cancellable,
                              GError      **error);
+
+gboolean
+rpmostree_print_cached_update (GVariant         *cached_update,
+                               gboolean          verbose,
+                               GCancellable     *cancellable,
+                               GError          **error);

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -50,6 +50,9 @@
     <method name="ReloadConfig">
     </method>
 
+    <!-- none, check, reboot -->
+    <property name="AutomaticUpdatePolicy" type="s" access="read"/>
+
     <method name="CreateOSName">
       <arg type="s" name="name"/>
       <arg type="o" name="result" direction="out"/>
@@ -77,12 +80,32 @@
        'origin' (type 's')
        'signatures' (type 'av')
        'gpg-enabled' (type 'b')
+       'ref-has-new-commit' (type 'b')
+          TRUE if 'checksum' refers to a new commit we're not booted in.
+       'rpm-diff' (type 'a{sv}')
+          'upgraded' (type 'a(us(ss)(ss))')
+          'downgraded' (type 'a(us(ss)(ss))')
+          'removed' (type 'a(usss)')
+          'added' (type 'a(usss)')
     -->
     <property name="CachedUpdate" type="a{sv}" access="read"/>
     <property name="HasCachedUpdateRpmDiff" type="b" access="read"/>
 
-    <!-- NONE, DIFF, PREPARE, REBOOT -->
-    <property name="AutomaticUpdatePolicy" type="s" access="read"/>
+    <!-- Available options:
+         "mode" (type 's')
+            One of auto, none, check, reboot. Defaults to
+            auto, which follows configured policy (available in
+            AutomaticUpdatePolicy property).
+
+         If automatic updates are not enabled, @enabled will be FALSE and
+         @transaction_address will be the empty string.
+    -->
+    <method name="AutomaticUpdateTrigger">
+      <arg type="a{sv}" name="options" direction="in"/>
+      <arg type="b" name="enabled" direction="out"/>
+      <arg type="s" name="transaction_address" direction="out"/>
+    </method>
+
     <property name="Name" type="s" access="read"/>
 
     <method name="GetDeploymentsRpmDiff">

--- a/src/daemon/rpm-ostreed-automatic.service.in
+++ b/src/daemon/rpm-ostreed-automatic.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=RPM-OSTree Automatic Update
+Documentation=man:rpm-ostree(1) man:rpm-ostreed.conf(5)
+ConditionPathExists=/run/ostree-booted
+
+[Service]
+Type=oneshot
+ExecStart=@bindir@/rpm-ostree upgrade --automatic

--- a/src/daemon/rpm-ostreed-automatic.timer
+++ b/src/daemon/rpm-ostreed-automatic.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=RPM-OSTree Automatic Update Trigger
+Documentation=man:rpm-ostree(1) man:rpm-ostreed.conf(5)
+ConditionPathExists=/run/ostree-booted
+
+[Timer]
+OnBootSec=1h
+OnUnitInactiveSec=1d
+
+[Install]
+WantedBy=timers.target

--- a/src/daemon/rpm-ostreed.conf
+++ b/src/daemon/rpm-ostreed.conf
@@ -3,4 +3,5 @@
 # For option meanings, see rpm-ostreed.conf(5).
 
 [Daemon]
+#AutomaticUpdatePolicy=none
 #IdleExitTimeout=60

--- a/src/daemon/rpmostreed-daemon.h
+++ b/src/daemon/rpmostreed-daemon.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "rpmostreed-types.h"
+#include "rpmostree-util.h"
 
 #define RPMOSTREED_TYPE_DAEMON   (rpmostreed_daemon_get_type ())
 #define RPMOSTREED_DAEMON(o)     (G_TYPE_CHECK_INSTANCE_CAST ((o), RPMOSTREED_TYPE_DAEMON, RpmostreedDaemon))
@@ -50,3 +51,6 @@ void               rpmostreed_daemon_unpublish      (RpmostreedDaemon *self,
 gboolean           rpmostreed_daemon_reload_config  (RpmostreedDaemon *self,
                                                      gboolean         *out_changed,
                                                      GError          **error);
+
+RpmostreedAutomaticUpdatePolicy
+rpmostreed_get_automatic_update_policy (RpmostreedDaemon *self);

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -21,6 +21,7 @@
 #include <systemd/sd-journal.h>
 #include <libglnx.h>
 
+#include "rpmostree-types.h"
 #include "rpmostreed-deployment-utils.h"
 #include "rpmostree-origin.h"
 #include "rpmostree-util.h"
@@ -570,6 +571,7 @@ sort_pkgvariant_by_name (gconstpointer  pkga_pp,
 
   return strcmp (pkgname_a, pkgname_b);
 }
+
 static GVariant*
 array_to_variant_new (const char *format, GPtrArray *array)
 {
@@ -592,14 +594,14 @@ rpm_diff_variant_new (RpmDiff *diff)
   g_assert (diff->initialized);
   g_auto(GVariantDict) dict;
   g_variant_dict_init (&dict, NULL);
-  g_variant_dict_insert_value (&dict, "upgraded",
-                               array_to_variant_new ("a(us(ss)(ss))", diff->upgraded));
-  g_variant_dict_insert_value (&dict, "downgraded",
-                               array_to_variant_new ("a(us(ss)(ss))", diff->downgraded));
-  g_variant_dict_insert_value (&dict, "removed",
-                               array_to_variant_new ("a(usss)", diff->removed));
-  g_variant_dict_insert_value (&dict, "added",
-                               array_to_variant_new ("a(usss)", diff->added));
+  g_variant_dict_insert_value (&dict, "upgraded", array_to_variant_new (
+                                 RPMOSTREE_DIFF_MODIFIED_GVARIANT_STRING, diff->upgraded));
+  g_variant_dict_insert_value (&dict, "downgraded", array_to_variant_new (
+                                 RPMOSTREE_DIFF_MODIFIED_GVARIANT_STRING, diff->downgraded));
+  g_variant_dict_insert_value (&dict, "removed", array_to_variant_new (
+                                 RPMOSTREE_DIFF_SINGLE_GVARIANT_STRING, diff->removed));
+  g_variant_dict_insert_value (&dict, "added", array_to_variant_new (
+                                 RPMOSTREE_DIFF_SINGLE_GVARIANT_STRING, diff->added));
   return g_variant_dict_end (&dict);
 }
 

--- a/src/daemon/rpmostreed-deployment-utils.h
+++ b/src/daemon/rpmostreed-deployment-utils.h
@@ -44,3 +44,9 @@ GVariant *      rpmostreed_commit_generate_cached_details_variant (OstreeDeploym
                                                                    OstreeRepo       *repo,
                                                                    const gchar      *refspec,
                                                                    GError          **error);
+gboolean
+rpmostreed_update_generate_variant (OstreeSysroot *sysroot,
+                                    OstreeDeployment *deployment,
+                                    OstreeRepo *repo,
+                                    GVariant **out_update,
+                                    GError **error);

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -970,13 +970,6 @@ os_handle_automatic_update_trigger (RPMOSTreeOS *interface,
     case RPMOSTREED_AUTOMATIC_UPDATE_POLICY_CHECK:
       dfault = RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_METADATA_ONLY;
       break;
-    case RPMOSTREED_AUTOMATIC_UPDATE_POLICY_REBOOT:
-      /* XXX: We should tease this out a bit more; e.g. we may only want to auto-reboot if
-       * it's an ostree update, not just a layered pkg update, or if there's a medium+
-       * severity advisory open. This would probably have to be implemented with more
-       * configs like AutomaticUpdateRebootPolicy. */
-      dfault = RPMOSTREE_TRANSACTION_DEPLOY_FLAG_REBOOT;
-      break;
     default:
       g_assert_not_reached ();
     }

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -20,6 +20,7 @@
 #include "ostree.h"
 
 #include <libglnx.h>
+#include <systemd/sd-journal.h>
 
 #include "rpmostreed-sysroot.h"
 #include "rpmostreed-daemon.h"
@@ -119,7 +120,9 @@ os_authorize_method (GDBusInterfaceSkeleton *interface,
     {
       g_ptr_array_add (actions, "org.projectatomic.rpmostree1.deploy");
     }
-  else if (g_strcmp0 (method_name, "Upgrade") == 0)
+  /* unite these for now; it could make sense at least to make "check" its own action */
+  else if (g_strcmp0 (method_name, "Upgrade") == 0 ||
+           g_strcmp0 (method_name, "AutomaticUpdateTrigger") == 0)
     {
       g_ptr_array_add (actions, "org.projectatomic.rpmostree1.upgrade");
     }
@@ -713,6 +716,20 @@ start_deployment_txn (GDBusMethodInvocation  *invocation,
                                             cancellable, error);
 }
 
+static gboolean
+refresh_cached_update (RpmostreedOS*, GError **error);
+
+static void
+on_auto_update_done (RpmostreedTransaction *transaction, RpmostreedOS *self)
+{
+  g_autoptr(GError) local_error = NULL;
+  if (!refresh_cached_update (self, &local_error))
+    {
+      sd_journal_print (LOG_WARNING, "Failed to refresh CachedUpdate property: %s",
+                        local_error->message);
+    }
+}
+
 typedef void (*InvocationCompleter)(RPMOSTreeOS*,
                                     GDBusMethodInvocation*,
                                     GUnixFDList*,
@@ -772,8 +789,15 @@ os_merge_or_start_deployment_txn (RPMOSTreeOS            *interface,
                                           fd_list,
                                           &local_error);
       if (transaction)
-        rpmostreed_transaction_monitor_add (self->transaction_monitor,
-                                            transaction);
+        rpmostreed_transaction_monitor_add (self->transaction_monitor, transaction);
+
+      /* For the AutomaticUpdateTrigger "check" and "download" cases, we want to make sure
+       * we refresh CachedUpdate after; "deploy" will do this through sysroot_changed */
+      const char *method_name = g_dbus_method_invocation_get_method_name (invocation);
+      if (g_str_equal (method_name, "AutomaticUpdateTrigger") &&
+          (default_flags & (RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_ONLY |
+                            RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_METADATA_ONLY)))
+        g_signal_connect (transaction, "closed", G_CALLBACK (on_auto_update_done), self);
     }
 
   if (transaction)
@@ -891,6 +915,82 @@ os_handle_update_deployment (RPMOSTreeOS *interface,
                                            0, arg_options, modifiers, fd_list,
                                            rpmostree_os_complete_update_deployment);
 }
+
+/* compat shim for call completer */
+static void automatic_update_trigger_completer (RPMOSTreeOS            *os,
+                                                GDBusMethodInvocation  *invocation,
+                                                GUnixFDList            *dummy,
+                                                const gchar            *address)
+{                                                              /* enabled */
+  rpmostree_os_complete_automatic_update_trigger (os, invocation, TRUE, address);
+}
+
+
+/* we make this a separate method to keep the D-Bus API clean, but the actual
+ * implementation is done by our dear friend deploy_transaction_execute(). ❤️
+ */
+
+static gboolean
+os_handle_automatic_update_trigger (RPMOSTreeOS *interface,
+                                    GDBusMethodInvocation *invocation,
+                                    GVariant *arg_options)
+{
+  g_auto(GVariantDict) dict;
+  g_variant_dict_init (&dict, arg_options);
+  const char *mode = vardict_lookup_ptr (&dict, "mode", "&s") ?: "auto";
+  g_autoptr(GError) local_error = NULL;
+  GError **error = &local_error;
+
+  RpmostreedAutomaticUpdatePolicy autoupdate_policy;
+  if (g_str_equal (mode, "auto"))
+    autoupdate_policy = rpmostreed_get_automatic_update_policy (rpmostreed_daemon_get ());
+  else
+    {
+      if (!rpmostree_str_to_auto_update_policy (mode, &autoupdate_policy, error))
+        {
+          g_dbus_method_invocation_take_error (invocation, g_steal_pointer (&local_error));
+          return TRUE;
+        }
+    }
+
+  /* Now we translate policy into flags the deploy transaction understands. But avoid
+   * starting it at all if we're not even on. The benefit of this approach is that we keep
+   * the Deploy transaction simpler. */
+
+  RpmOstreeTransactionDeployFlags dfault = 0;
+  switch (autoupdate_policy)
+    {
+    case RPMOSTREED_AUTOMATIC_UPDATE_POLICY_NONE:
+      {
+        /* NB: we return the empty string here rather than NULL, because gdbus converts this
+         * to a gvariant, which doesn't support NULL strings */             /* enabled */
+        rpmostree_os_complete_automatic_update_trigger (interface, invocation, FALSE, "");
+        return TRUE;
+      }
+    case RPMOSTREED_AUTOMATIC_UPDATE_POLICY_CHECK:
+      dfault = RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_METADATA_ONLY;
+      break;
+    case RPMOSTREED_AUTOMATIC_UPDATE_POLICY_REBOOT:
+      /* XXX: We should tease this out a bit more; e.g. we may only want to auto-reboot if
+       * it's an ostree update, not just a layered pkg update, or if there's a medium+
+       * severity advisory open. This would probably have to be implemented with more
+       * configs like AutomaticUpdateRebootPolicy. */
+      dfault = RPMOSTREE_TRANSACTION_DEPLOY_FLAG_REBOOT;
+      break;
+    default:
+      g_assert_not_reached ();
+    }
+
+  return os_merge_or_start_deployment_txn (
+      interface,
+      invocation,
+      dfault,
+      NULL,
+      NULL,
+      NULL,
+      automatic_update_trigger_completer);
+}
+
 
 static gboolean
 os_handle_rollback (RPMOSTreeOS *interface,
@@ -1597,22 +1697,51 @@ out:
 }
 
 static gboolean
+refresh_cached_update (RpmostreedOS *self, GError **error)
+{
+  const char *name = rpmostree_os_get_name (RPMOSTREE_OS (self));
+  OstreeSysroot *sysroot = rpmostreed_sysroot_get_root (rpmostreed_sysroot_get ());
+  OstreeRepo *repo = ostree_sysroot_repo (sysroot);
+
+  /* if we're not handling the system sysroot, then let's just skip all this (e.g. `make
+   * check` tests) */
+  const char *sysroot_path = gs_file_get_path_cached (ostree_sysroot_get_path (sysroot));
+  if (!g_str_equal (sysroot_path, "/"))
+    return TRUE;
+
+  /* Note here we're *not* using rpmostree_syscore_get_origin_merge_deployment(): cached
+   * updates are always relative to the booted/merge deployment; e.g. we still want to be
+   * able to show details about a pending deployment. */
+  g_autoptr(OstreeDeployment) merge_deployment =
+    ostree_sysroot_get_merge_deployment (sysroot, name);
+
+  g_autoptr(GVariant) cached_update = NULL;
+
+  if (!rpmostreed_update_generate_variant (sysroot, merge_deployment, repo,
+                                           &cached_update, error))
+    return FALSE;
+
+  rpmostree_os_set_cached_update (RPMOSTREE_OS (self), cached_update);
+
+  /* for backwards compatibility */
+  gboolean has_cached_updates = (cached_update != NULL);
+  rpmostree_os_set_has_cached_update_rpm_diff (RPMOSTREE_OS (self), has_cached_updates);
+  return TRUE;
+}
+
+static gboolean
 rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
 {
   const gchar *name;
 
   OstreeDeployment *booted = NULL; /* owned by sysroot */
   g_autofree gchar* booted_id = NULL;
-  glnx_unref_object  OstreeDeployment *merge_deployment = NULL; /* transfered */
-
   g_autoptr(GPtrArray) deployments = NULL;
   OstreeSysroot *ot_sysroot;
   OstreeRepo *ot_repo;
   GVariant *booted_variant = NULL;
   GVariant *default_variant = NULL;
   GVariant *rollback_variant = NULL;
-  g_autoptr(GVariant) cached_update = NULL;
-  gboolean has_cached_updates = FALSE;
 
   name = rpmostree_os_get_name (RPMOSTREE_OS (self));
   g_debug ("loading %s", name);
@@ -1661,25 +1790,6 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
         }
     }
 
-  merge_deployment = ostree_sysroot_get_merge_deployment (ot_sysroot, name);
-  if (merge_deployment)
-    {
-      g_autoptr(RpmOstreeOrigin) origin = NULL;
-
-      /* Don't fail here for unknown origin types */
-      origin = rpmostree_origin_parse_deployment (merge_deployment, NULL);
-      if (origin)
-        {
-          cached_update = rpmostreed_commit_generate_cached_details_variant (merge_deployment,
-                                                                             ot_repo,
-                                                                             rpmostree_origin_get_refspec (origin),
-                                                                             error);
-          if (!cached_update)
-            return FALSE;
-          has_cached_updates = cached_update != NULL;
-        }
-   }
-
   if (!booted_variant)
     booted_variant = rpmostreed_deployment_generate_blank_variant ();
   rpmostree_os_set_booted_deployment (RPMOSTREE_OS (self),
@@ -1695,10 +1805,10 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
   rpmostree_os_set_rollback_deployment (RPMOSTREE_OS (self),
                                         rollback_variant);
 
-  rpmostree_os_set_cached_update (RPMOSTREE_OS (self), cached_update);
-  rpmostree_os_set_has_cached_update_rpm_diff (RPMOSTREE_OS (self),
-                                               has_cached_updates);
-  g_dbus_interface_skeleton_flush(G_DBUS_INTERFACE_SKELETON (self));
+  if (!refresh_cached_update (self, error))
+    return FALSE;
+
+  g_dbus_interface_skeleton_flush (G_DBUS_INTERFACE_SKELETON (self));
 
   return TRUE;
 }
@@ -1706,6 +1816,7 @@ rpmostreed_os_load_internals (RpmostreedOS *self, GError **error)
 static void
 rpmostreed_os_iface_init (RPMOSTreeOSIface *iface)
 {
+  iface->handle_automatic_update_trigger   = os_handle_automatic_update_trigger;
   iface->handle_cleanup                    = os_handle_cleanup;
   iface->handle_get_deployment_boot_config = os_handle_get_deployment_boot_config;
   iface->handle_kernel_args                = os_handle_kernel_args;

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "rpmostreed-types.h"
+#include "rpmostreed-daemon.h"
 
 #include <gio/gunixfdlist.h>
 
@@ -56,6 +57,7 @@ typedef enum {
   RPMOSTREE_TRANSACTION_DEPLOY_FLAG_NO_OVERRIDES = (1 << 6),
   RPMOSTREE_TRANSACTION_DEPLOY_FLAG_CACHE_ONLY = (1 << 7),
   RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_ONLY = (1 << 8),
+  RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_METADATA_ONLY = (1 << 9),
 } RpmOstreeTransactionDeployFlags;
 
 

--- a/src/libpriv/libsd-time-util.c
+++ b/src/libpriv/libsd-time-util.c
@@ -1,0 +1,128 @@
+/***
+  This file was originally part of systemd.
+
+  Copyright 2010 Lennart Poettering
+
+  systemd is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  systemd is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with systemd; If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#include <glib.h>
+#include <sys/time.h>
+
+#include "libsd-time-util.h"
+
+static clockid_t map_clock_id(clockid_t c) {
+
+        /* Some more exotic archs (s390, ppc, …) lack the "ALARM" flavour of the clocks. Thus, clock_gettime() will
+         * fail for them. Since they are essentially the same as their non-ALARM pendants (their only difference is
+         * when timers are set on them), let's just map them accordingly. This way, we can get the correct time even on
+         * those archs. */
+
+        switch (c) {
+
+        case CLOCK_BOOTTIME_ALARM:
+                return CLOCK_BOOTTIME;
+
+        case CLOCK_REALTIME_ALARM:
+                return CLOCK_REALTIME;
+
+        default:
+                return c;
+        }
+}
+
+static usec_t timespec_load(const struct timespec *ts) {
+        g_assert(ts);
+
+        if (ts->tv_sec < 0 || ts->tv_nsec < 0)
+                return USEC_INFINITY;
+
+        if ((usec_t) ts->tv_sec > (UINT64_MAX - (ts->tv_nsec / NSEC_PER_USEC)) / USEC_PER_SEC)
+                return USEC_INFINITY;
+
+        return
+                (usec_t) ts->tv_sec * USEC_PER_SEC +
+                (usec_t) ts->tv_nsec / NSEC_PER_USEC;
+}
+
+static usec_t now(clockid_t clock_id) {
+        struct timespec ts;
+
+        g_assert_cmpint (clock_gettime(map_clock_id(clock_id), &ts), ==, 0);
+
+        return timespec_load(&ts);
+}
+
+char *libsd_format_timestamp_relative(char *buf, size_t l, usec_t t) {
+        const char *s;
+        usec_t n, d;
+
+        if (t <= 0 || t == USEC_INFINITY)
+                return NULL;
+
+        n = now(CLOCK_REALTIME);
+        if (n > t) {
+                d = n - t;
+                s = "ago";
+        } else {
+                d = t - n;
+                s = "left";
+        }
+
+        if (d >= USEC_PER_YEAR)
+                snprintf(buf, l, USEC_FMT " years " USEC_FMT " months %s",
+                         d / USEC_PER_YEAR,
+                         (d % USEC_PER_YEAR) / USEC_PER_MONTH, s);
+        else if (d >= USEC_PER_MONTH)
+                snprintf(buf, l, USEC_FMT " months " USEC_FMT " days %s",
+                         d / USEC_PER_MONTH,
+                         (d % USEC_PER_MONTH) / USEC_PER_DAY, s);
+        else if (d >= USEC_PER_WEEK)
+                snprintf(buf, l, USEC_FMT " weeks " USEC_FMT " days %s",
+                         d / USEC_PER_WEEK,
+                         (d % USEC_PER_WEEK) / USEC_PER_DAY, s);
+        else if (d >= 2*USEC_PER_DAY)
+                snprintf(buf, l, USEC_FMT " days %s", d / USEC_PER_DAY, s);
+        else if (d >= 25*USEC_PER_HOUR)
+                snprintf(buf, l, "1 day " USEC_FMT "h %s",
+                         (d - USEC_PER_DAY) / USEC_PER_HOUR, s);
+        else if (d >= 6*USEC_PER_HOUR)
+                snprintf(buf, l, USEC_FMT "h %s",
+                         d / USEC_PER_HOUR, s);
+        else if (d >= USEC_PER_HOUR)
+                snprintf(buf, l, USEC_FMT "h " USEC_FMT "min %s",
+                         d / USEC_PER_HOUR,
+                         (d % USEC_PER_HOUR) / USEC_PER_MINUTE, s);
+        else if (d >= 5*USEC_PER_MINUTE)
+                snprintf(buf, l, USEC_FMT "min %s",
+                         d / USEC_PER_MINUTE, s);
+        else if (d >= USEC_PER_MINUTE)
+                snprintf(buf, l, USEC_FMT "min " USEC_FMT "s %s",
+                         d / USEC_PER_MINUTE,
+                         (d % USEC_PER_MINUTE) / USEC_PER_SEC, s);
+        else if (d >= USEC_PER_SEC)
+                snprintf(buf, l, USEC_FMT "s %s",
+                         d / USEC_PER_SEC, s);
+        else if (d >= USEC_PER_MSEC)
+                snprintf(buf, l, USEC_FMT "ms %s",
+                         d / USEC_PER_MSEC, s);
+        else if (d > 0)
+                snprintf(buf, l, USEC_FMT"us %s",
+                         d, s);
+        else
+                snprintf(buf, l, "now");
+
+        buf[l-1] = 0;
+        return buf;
+}

--- a/src/libpriv/libsd-time-util.h
+++ b/src/libpriv/libsd-time-util.h
@@ -1,0 +1,67 @@
+#pragma once
+
+/***
+  This file was originally part of systemd.
+
+  Copyright 2010 Lennart Poettering
+
+  systemd is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  systemd is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with systemd; If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+
+typedef uint64_t usec_t;
+typedef uint64_t nsec_t;
+
+#define PRI_NSEC PRIu64
+#define PRI_USEC PRIu64
+#define NSEC_FMT "%" PRI_NSEC
+#define USEC_FMT "%" PRI_USEC
+
+#define USEC_INFINITY ((usec_t) -1)
+#define NSEC_INFINITY ((nsec_t) -1)
+
+#define MSEC_PER_SEC  1000ULL
+#define USEC_PER_SEC  ((usec_t) 1000000ULL)
+#define USEC_PER_MSEC ((usec_t) 1000ULL)
+#define NSEC_PER_SEC  ((nsec_t) 1000000000ULL)
+#define NSEC_PER_MSEC ((nsec_t) 1000000ULL)
+#define NSEC_PER_USEC ((nsec_t) 1000ULL)
+
+#define USEC_PER_MINUTE ((usec_t) (60ULL*USEC_PER_SEC))
+#define NSEC_PER_MINUTE ((nsec_t) (60ULL*NSEC_PER_SEC))
+#define USEC_PER_HOUR ((usec_t) (60ULL*USEC_PER_MINUTE))
+#define NSEC_PER_HOUR ((nsec_t) (60ULL*NSEC_PER_MINUTE))
+#define USEC_PER_DAY ((usec_t) (24ULL*USEC_PER_HOUR))
+#define NSEC_PER_DAY ((nsec_t) (24ULL*NSEC_PER_HOUR))
+#define USEC_PER_WEEK ((usec_t) (7ULL*USEC_PER_DAY))
+#define NSEC_PER_WEEK ((nsec_t) (7ULL*NSEC_PER_DAY))
+#define USEC_PER_MONTH ((usec_t) (2629800ULL*USEC_PER_SEC))
+#define NSEC_PER_MONTH ((nsec_t) (2629800ULL*NSEC_PER_SEC))
+#define USEC_PER_YEAR ((usec_t) (31557600ULL*USEC_PER_SEC))
+#define NSEC_PER_YEAR ((nsec_t) (31557600ULL*NSEC_PER_SEC))
+
+/* We assume a maximum timezone length of 6. TZNAME_MAX is not defined on Linux, but glibc internally initializes this
+ * to 6. Let's rely on that. */
+#define FORMAT_TIMESTAMP_MAX (3+1+10+1+8+1+6+1+6+1)
+#define FORMAT_TIMESTAMP_WIDTH 28 /* when outputting, assume this width */
+#define FORMAT_TIMESTAMP_RELATIVE_MAX 256
+#define FORMAT_TIMESPAN_MAX 64
+
+char *libsd_format_timestamp_relative(char *buf, size_t l, usec_t t);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -46,10 +46,6 @@
 #define RPMOSTREE_MESSAGE_PKG_REPOS SD_ID128_MAKE(0e,ea,67,9b,bf,a3,4d,43,80,2d,ec,99,b2,74,eb,e7)
 #define RPMOSTREE_MESSAGE_PKG_IMPORT SD_ID128_MAKE(df,8b,b5,4f,04,fa,47,08,ac,16,11,1b,bf,4b,a3,52)
 
-#define RPMOSTREE_DIR_CACHE_REPOMD "repomd"
-#define RPMOSTREE_DIR_CACHE_SOLV "solv"
-#define RPMOSTREE_DIR_LOCK "lock"
-
 static OstreeRepo * get_pkgcache_repo (RpmOstreeContext *self);
 
 /* Given a string, look for ostree:// or rojig:// prefix and

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -27,6 +27,10 @@
 #include "libglnx.h"
 
 #define RPMOSTREE_CORE_CACHEDIR "/var/cache/rpm-ostree/"
+#define RPMOSTREE_DIR_CACHE_REPOMD "repomd"
+#define RPMOSTREE_DIR_CACHE_SOLV "solv"
+#define RPMOSTREE_DIR_LOCK "lock"
+
 /* See http://lists.rpm.org/pipermail/rpm-maint/2017-October/006681.html */
 #define RPMOSTREE_RPMDB_LOCATION "usr/share/rpm"
 #define RPMOSTREE_SYSIMAGE_DIR "usr/lib/sysimage"

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -143,7 +143,7 @@ static char *
 pkg_nevra_strdup (Header h1)
 {
   return rpmostree_header_custom_nevra_strdup (h1, PKG_NEVRA_FLAGS_NAME |
-                                                   PKG_NEVRA_FLAGS_EPOCH_VERSION_RELEASE |
+                                                   PKG_NEVRA_FLAGS_EVR |
                                                    PKG_NEVRA_FLAGS_ARCH);
 }
 
@@ -893,9 +893,9 @@ rpmostree_get_refts_for_commit (OstreeRepo                *repo,
   return TRUE;
 }
 
-static gint
-pkg_array_compare (DnfPackage **p_pkg1,
-                   DnfPackage **p_pkg2)
+gint
+rpmostree_pkg_array_compare (DnfPackage **p_pkg1,
+                             DnfPackage **p_pkg2)
 {
   return dnf_package_cmp (*p_pkg1, *p_pkg2);
 }
@@ -915,7 +915,7 @@ rpmostree_sighandler_reset_cleanup (RpmSighandlerResetCleanup *cleanup)
 static void
 print_pkglist (GPtrArray *pkglist)
 {
-  g_ptr_array_sort (pkglist, (GCompareFunc) pkg_array_compare);
+  g_ptr_array_sort (pkglist, (GCompareFunc) rpmostree_pkg_array_compare);
 
   for (guint i = 0; i < pkglist->len; i++)
     {
@@ -1124,7 +1124,7 @@ GPtrArray*
 rpmostree_sack_get_sorted_packages (DnfSack *sack)
 {
   g_autoptr(GPtrArray) pkglist = rpmostree_sack_get_packages (sack);
-  g_ptr_array_sort (pkglist, (GCompareFunc)pkg_array_compare);
+  g_ptr_array_sort (pkglist, (GCompareFunc)rpmostree_pkg_array_compare);
   return g_steal_pointer (&pkglist);
 }
 

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -114,6 +114,10 @@ rpmostree_get_refts_for_commit (OstreeRepo                *repo,
                                 GCancellable              *cancellable,
                                 GError                   **error);
 
+gint
+rpmostree_pkg_array_compare (DnfPackage **p_pkg1,
+                             DnfPackage **p_pkg2);
+
 void
 rpmostree_print_transaction (DnfContext   *context);
 

--- a/src/libpriv/rpmostree-types.h
+++ b/src/libpriv/rpmostree-types.h
@@ -1,0 +1,54 @@
+/* Copyright (C) 2018 Red Hat, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+/* These types are used by both the daemon and the client. Some of them should probably be
+ * added to the public API eventually. */
+
+typedef enum {
+  RPM_OSTREE_PKG_TYPE_BASE,
+  RPM_OSTREE_PKG_TYPE_LAYER,
+} RpmOstreePkgTypes;
+
+typedef enum {
+  RPMOSTREED_AUTOMATIC_UPDATE_POLICY_NONE,
+  RPMOSTREED_AUTOMATIC_UPDATE_POLICY_CHECK,
+} RpmostreedAutomaticUpdatePolicy;
+
+/**
+ * RPMOSTREE_DIFF_SINGLE_GVARIANT_FORMAT:
+ *
+ * - u - type (RpmOstreePkgTypes)
+ * - s - name
+ * - s - evr
+ * - s - arch
+ */
+#define RPMOSTREE_DIFF_SINGLE_GVARIANT_STRING "a(usss)"
+#define RPMOSTREE_DIFF_SINGLE_GVARIANT_FORMAT G_VARIANT_TYPE (RPMOSTREE_DIFF_SINGLE_GVARIANT_STRING)
+
+/**
+ * RPMOSTREE_DIFF_MODIFIED_GVARIANT_FORMAT:
+ *
+ * - u - type (RpmOstreePkgTypes)
+ * - s - name
+ * - (ss) - evr & arch of previous package
+ * - (ss) - evr & arch of new package
+ */
+#define RPMOSTREE_DIFF_MODIFIED_GVARIANT_STRING "a(us(ss)(ss))"
+#define RPMOSTREE_DIFF_MODIFIED_GVARIANT_FORMAT G_VARIANT_TYPE (RPMOSTREE_DIFF_MODIFIED_GVARIANT_STRING)

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -1012,8 +1012,6 @@ rpmostree_auto_update_policy_to_str (RpmostreedAutomaticUpdatePolicy policy,
       return "none";
     case RPMOSTREED_AUTOMATIC_UPDATE_POLICY_CHECK:
       return "check";
-    case RPMOSTREED_AUTOMATIC_UPDATE_POLICY_REBOOT:
-      return "reboot";
     default:
       return glnx_null_throw (error, "Invalid policy value %u", policy);
     }
@@ -1029,8 +1027,6 @@ rpmostree_str_to_auto_update_policy (const char *str,
     *out_policy = RPMOSTREED_AUTOMATIC_UPDATE_POLICY_NONE;
   else if (g_str_equal (str, "check"))
     *out_policy = RPMOSTREED_AUTOMATIC_UPDATE_POLICY_CHECK;
-  else if (g_str_equal (str, "reboot"))
-    *out_policy = RPMOSTREED_AUTOMATIC_UPDATE_POLICY_REBOOT;
   else
     return glnx_throw (error, "Invalid value for AutomaticUpdatePolicy: '%s'", str);
   return TRUE;

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -26,6 +26,7 @@
 #include <ostree.h>
 #include <libdnf/libdnf.h>
 #include "libglnx.h"
+#include "rpmostree.h"
 
 #define _N(single, plural, n) ( (n) == 1 ? (single) : (plural) )
 #define _NS(n) _N("", "s", n)
@@ -98,6 +99,13 @@ rpmostree_diff_print_formatted (GPtrArray *removed,
                                 GPtrArray *added,
                                 GPtrArray *modified_old,
                                 GPtrArray *modified_new);
+
+void
+rpmostree_variant_diff_print_formatted (guint     max_key_len,
+                                        GVariant *upgraded,
+                                        GVariant *downgraded,
+                                        GVariant *removed,
+                                        GVariant *added);
 
 void
 rpmostree_diff_print (GPtrArray *removed,
@@ -191,3 +199,25 @@ gboolean
 rpmostree_variant_bsearch_str (GVariant   *array,
                                const char *str,
                                int        *out_pos);
+
+/* these are kept here for easier sharing with the client */
+
+typedef enum {
+  RPMOSTREED_AUTOMATIC_UPDATE_POLICY_NONE,
+  RPMOSTREED_AUTOMATIC_UPDATE_POLICY_CHECK,
+  RPMOSTREED_AUTOMATIC_UPDATE_POLICY_REBOOT,
+} RpmostreedAutomaticUpdatePolicy;
+
+const char*
+rpmostree_auto_update_policy_to_str (RpmostreedAutomaticUpdatePolicy policy,
+                                     GError **error);
+
+gboolean
+rpmostree_str_to_auto_update_policy (const char *str,
+                                     RpmostreedAutomaticUpdatePolicy *out_policy,
+                                     GError **error);
+
+typedef enum {
+  RPM_OSTREE_PKG_TYPE_BASE,
+  RPM_OSTREE_PKG_TYPE_LAYER,
+} RpmOstreePkgTypes;

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -205,7 +205,6 @@ rpmostree_variant_bsearch_str (GVariant   *array,
 typedef enum {
   RPMOSTREED_AUTOMATIC_UPDATE_POLICY_NONE,
   RPMOSTREED_AUTOMATIC_UPDATE_POLICY_CHECK,
-  RPMOSTREED_AUTOMATIC_UPDATE_POLICY_REBOOT,
 } RpmostreedAutomaticUpdatePolicy;
 
 const char*

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -27,6 +27,7 @@
 #include <libdnf/libdnf.h>
 #include "libglnx.h"
 #include "rpmostree.h"
+#include "rpmostree-types.h"
 
 #define _N(single, plural, n) ( (n) == 1 ? (single) : (plural) )
 #define _NS(n) _N("", "s", n)
@@ -200,13 +201,6 @@ rpmostree_variant_bsearch_str (GVariant   *array,
                                const char *str,
                                int        *out_pos);
 
-/* these are kept here for easier sharing with the client */
-
-typedef enum {
-  RPMOSTREED_AUTOMATIC_UPDATE_POLICY_NONE,
-  RPMOSTREED_AUTOMATIC_UPDATE_POLICY_CHECK,
-} RpmostreedAutomaticUpdatePolicy;
-
 const char*
 rpmostree_auto_update_policy_to_str (RpmostreedAutomaticUpdatePolicy policy,
                                      GError **error);
@@ -215,8 +209,3 @@ gboolean
 rpmostree_str_to_auto_update_policy (const char *str,
                                      RpmostreedAutomaticUpdatePolicy *out_policy,
                                      GError **error);
-
-typedef enum {
-  RPM_OSTREE_PKG_TYPE_BASE,
-  RPM_OSTREE_PKG_TYPE_LAYER,
-} RpmOstreePkgTypes;

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -487,20 +487,21 @@ $files
 EOF
     (cd $test_tmpdir/yumrepo/specs &&
      rpmbuild -ba $name.spec \
+        --define "_topdir $PWD" \
         --define "_sourcedir $PWD" \
         --define "_specdir $PWD" \
         --define "_builddir $PWD/.build" \
         --define "_srcrpmdir $PWD" \
         --define "_rpmdir $test_tmpdir/yumrepo/packages" \
         --define "_buildrootdir $PWD")
-    (cd yumrepo && createrepo_c --no-database .)
-    if test '!' -f yumrepo.repo; then
-        cat > yumrepo.repo.tmp << EOF
+    (cd $test_tmpdir/yumrepo && createrepo_c --no-database .)
+    if test '!' -f $test_tmpdir/yumrepo.repo; then
+        cat > $test_tmpdir/yumrepo.repo.tmp << EOF
 [test-repo]
 name=test-repo
 baseurl=file:///$PWD/yumrepo
 EOF
-        mv yumrepo.repo{.tmp,}
+        mv $test_tmpdir/yumrepo.repo{.tmp,}
     fi
 }
 

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -48,7 +48,7 @@ vm_raw_rsync() {
 vm_rsync() {
   if ! test -f .vagrant/using_sshfs; then
     pushd ${topsrcdir}
-    vm_raw_rsync --exclude .git/ . $VM:/var/roothome/sync
+    vm_raw_rsync --delete --exclude .git/ . $VM:/var/roothome/sync
     popd
   fi
 }

--- a/tests/utils/inject-pkglist.c
+++ b/tests/utils/inject-pkglist.c
@@ -1,0 +1,99 @@
+/*
+Given a ref, read its pkglist, inject it in a new commit that is for our
+purposes identical to the one the ref is pointing to, then reset the ref to that
+commit. Essentially, we replace the tip with a copy, except that it has the
+pkglist metadata.
+
+This is used by tests that test features that require the new pkglist metadata
+and is also really useful for debugging.
+*/
+
+#include "config.h"
+
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <glib-unix.h>
+
+#include "libglnx.h"
+#include "rpmostree-rpm-util.h"
+
+static gboolean
+impl (const char *repo_path,
+      const char *refspec,
+      GError    **error)
+{
+  g_autofree char *remote = NULL;
+  g_autofree char *ref = NULL;
+  if (!ostree_parse_refspec (refspec, &remote, &ref, error))
+    return FALSE;
+
+  g_autoptr(OstreeRepo) repo = ostree_repo_open_at (AT_FDCWD, repo_path, NULL, error);
+  if (!repo)
+    return FALSE;
+
+  g_autofree char *checksum = NULL;
+  if (!ostree_repo_resolve_rev (repo, refspec, FALSE, &checksum, error))
+    return FALSE;
+
+  g_autoptr(GVariant) commit = NULL;
+  if (!ostree_repo_load_commit (repo, checksum, &commit, NULL, error))
+    return FALSE;
+
+  g_autoptr(GVariant) meta = g_variant_get_child_value (commit, 0);
+  g_autoptr(GVariantDict) meta_dict = g_variant_dict_new (meta);
+  if (g_variant_dict_contains (meta_dict, "rpmostree.rpmdb.pkglist"))
+    {
+      g_print ("Refspec '%s' already has pkglist metadata; exiting.\n", refspec);
+      return TRUE;
+    }
+
+  /* just an easy way to checkout the rpmdb */
+  g_autoptr(RpmOstreeRefSack) rsack =
+    rpmostree_get_refsack_for_commit (repo, checksum, NULL, error);
+  if (!rsack)
+    return FALSE;
+  g_assert (rsack->tmpdir.initialized);
+
+  g_autoptr(GVariant) pkglist = NULL;
+  if (!rpmostree_create_rpmdb_pkglist_variant (rsack->tmpdir.fd, ".", &pkglist, NULL, error))
+    return FALSE;
+
+  g_variant_dict_insert_value (meta_dict, "rpmostree.rpmdb.pkglist", pkglist);
+  g_autoptr(GVariant) new_meta = g_variant_ref_sink (g_variant_dict_end (meta_dict));
+
+  g_autoptr(GFile) root = NULL;
+  if (!ostree_repo_read_commit (repo,  checksum, &root, NULL, NULL, error))
+    return FALSE;
+
+  g_autofree char *new_checksum = NULL;
+  g_autofree char *parent = ostree_commit_get_parent (commit);
+  if (!ostree_repo_write_commit (repo, parent, "", "", new_meta, OSTREE_REPO_FILE (root),
+                                 &new_checksum, NULL, error))
+    return FALSE;
+
+  if (!ostree_repo_set_ref_immediate (repo, remote, ref, new_checksum, NULL, error))
+    return FALSE;
+
+  g_print("%s => %s\n", refspec, new_checksum);
+
+  return TRUE;
+}
+
+int
+main (int argc, char *argv[])
+{
+  if (argc != 3)
+    errx (EXIT_FAILURE, "Usage: %s <repo> <refspec>", argv[0]);
+
+  const char *repo_path = argv[1];
+  const char *refspec = argv[2];
+
+  g_autoptr(GError) local_error = NULL;
+  if (!impl (repo_path, refspec, &local_error))
+    errx (EXIT_FAILURE, "%s", local_error->message);
+  g_assert (local_error == NULL);
+
+  return EXIT_SUCCESS;
+}

--- a/tests/vmcheck/test-autoupdate.sh
+++ b/tests/vmcheck/test-autoupdate.sh
@@ -180,17 +180,7 @@ assert_default_deployment_is_update() {
   assert_file_has_content list.txt 'layered-cake-2.1-4.x86_64'
 }
 
-# now let's try reboot mode
-change_policy reboot
-vm_reboot_cmd rpm-ostree upgrade --trigger-automatic-update-policy
+# now let's upgrade and check that it matches what we expect
+vm_rpmostree upgrade
 assert_default_deployment_is_update
-echo "ok reboot mode"
-
-# let's do another reboot mode trigger to make sure we don't reboot if there's
-# nothing pending (use 77 exit to make it easier to test)
-rc=0
-vm_cmd rpm-ostree upgrade \
-  --upgrade-unchanged-exit-77 \
-  --trigger-automatic-update-policy || rc=$?
-assert_streq "$rc" "77"
-echo "ok reboot mode no upgrades"
+echo "ok upgrade"

--- a/tests/vmcheck/test-autoupdate.sh
+++ b/tests/vmcheck/test-autoupdate.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+#
+# Copyright (C) 2018 Jonathan Lebon
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# first, let's make sure the timer is disabled so it doesn't mess up with our
+# tests
+vm_cmd systemctl disable --now rpm-ostreed-automatic.timer
+
+# Really testing this like a user requires a remote ostree server setup.
+# Let's start by setting up the repo.
+REMOTE_OSTREE=/ostree/repo/tmp/vmcheck-remote
+vm_cmd mkdir -p $REMOTE_OSTREE
+vm_cmd ostree init --repo=$REMOTE_OSTREE --mode=archive
+vm_start_httpd ostree_server $REMOTE_OSTREE 8888
+
+# We need to build up a history on the server. Rather than wasting time
+# composing trees for real, we just use client package layering to create new
+# trees that we then "lift" into the server before cleaning them up client-side.
+
+# steal a commit from the system repo and make a branch out of it
+lift_commit() {
+  checksum=$1; shift
+  branch=$1; shift
+  vm_cmd ostree pull-local --repo=$REMOTE_OSTREE --disable-fsync \
+    /ostree/repo $checksum
+  vm_cmd ostree --repo=$REMOTE_OSTREE refs $branch --delete
+  vm_cmd ostree --repo=$REMOTE_OSTREE refs $checksum --create=$branch
+}
+
+# use a previously stolen commit to create an update on our vmcheck branch,
+# complete with version string and pkglist metadata
+create_update() {
+  branch=$1; shift
+  vm_cmd ostree commit --repo=$REMOTE_OSTREE -b vmcheck \
+    --tree=ref=$branch --add-metadata-string=version=$branch --fsync=no
+  # avoid libtool wrapper here since we're running on the VM and it would try to
+  # cd to topsrcdir/use gcc; libs are installed anyway
+  vm_cmd /var/roothome/sync/.libs/inject-pkglist $REMOTE_OSTREE vmcheck
+}
+
+# (delete ref but don't prune for easier debugging)
+vm_cmd ostree refs --repo=$REMOTE_OSTREE vmcheck --delete
+
+# now let's build some pkgs that we'll jury-rig into a base update
+# this whole block can be commented out for a speed-up when iterating locally
+vm_build_rpm base-pkg-foo version 1.4 release 7
+vm_build_rpm base-pkg-bar
+vm_build_rpm base-pkg-baz version 1.1 release 1
+vm_rpmostree install base-pkg-{foo,bar,baz}
+lift_commit $(vm_get_pending_csum) v1
+vm_rpmostree cleanup -p
+rm -rf $test_tmpdir/yumrepo
+vm_build_rpm base-pkg-foo version 1.4 release 8 # upgraded
+vm_build_rpm base-pkg-bar version 0.9 release 3 # downgraded
+vm_build_rpm base-pkg-boo version 3.7 release 2.11 # added
+vm_rpmostree install base-pkg-{foo,bar,boo}
+lift_commit $(vm_get_pending_csum) v2
+vm_rpmostree cleanup -p
+
+# ok, we're done with prep, now let's rebase on the first revision and install a
+# layered package
+create_update v1
+vm_cmd ostree remote add vmcheckmote --no-gpg-verify http://localhost:8888/
+vm_build_rpm layered-cake version 2.1 release 3
+vm_rpmostree rebase vmcheckmote:vmcheck --install layered-cake
+vm_reboot
+vm_rpmostree status -v
+vm_assert_status_jq \
+    ".deployments[0][\"origin\"] == \"vmcheckmote:vmcheck\"" \
+    ".deployments[0][\"version\"] == \"v1\"" \
+    '.deployments[0]["packages"]|length == 1' \
+    '.deployments[0]["packages"]|index("layered-cake") >= 0'
+echo "ok prep"
+
+# start it up again since we rebooted
+vm_start_httpd ostree_server $REMOTE_OSTREE 8888
+
+change_policy() {
+  policy=$1; shift
+  vm_cmd cp /usr/etc/rpm-ostreed.conf /etc
+  cat > tmp.sh << EOF
+echo -e "[Daemon]\nAutomaticUpdatePolicy=$policy" > /etc/rpm-ostreed.conf
+EOF
+  vm_cmdfile tmp.sh
+  vm_rpmostree reload
+}
+
+# make sure that off means off
+change_policy off
+vm_rpmostree status | grep 'auto updates disabled'
+vm_rpmostree upgrade --trigger-automatic-update-policy > out.txt
+assert_file_has_content out.txt "Automatic updates are not enabled; exiting"
+echo "ok disabled"
+
+# ok, let's test out check
+change_policy check
+vm_rpmostree status | grep 'auto updates enabled (check'
+
+# build an *older version* and check that we don't report an update
+vm_build_rpm layered-cake version 2.1 release 2
+vm_rpmostree upgrade --trigger-automatic-update-policy
+vm_rpmostree status -v > out.txt
+assert_not_file_has_content out.txt "Available update"
+
+# build a *newer version* and check that we report an update
+vm_build_rpm layered-cake version 2.1 release 4
+vm_rpmostree upgrade --trigger-automatic-update-policy
+vm_rpmostree status > out.txt
+assert_file_has_content out.txt "Available update"
+assert_file_has_content out.txt "Diff: 1 upgraded"
+vm_rpmostree status -v > out.txt
+assert_file_has_content out.txt "Upgraded: layered-cake 2.1-3 -> 2.1-4"
+# make sure we don't report ostree-based stuff somehow
+! grep -A999 'Available update' out.txt | grep "Version"
+! grep -A999 'Available update' out.txt | grep "Timestamp"
+! grep -A999 'Available update' out.txt | grep "Commit"
+echo "ok check mode layered only"
+
+# ok now let's add ostree updates in the picture
+create_update v2
+vm_rpmostree upgrade --trigger-automatic-update-policy
+
+# make sure we only pulled down the commit metadata
+if vm_cmd ostree checkout vmcheckmote:vmcheck --subpath /usr/share/rpm; then
+  assert_not_reached "Was able to checkout /usr/share/rpm?"
+fi
+
+assert_update() {
+  vm_assert_status_jq \
+    '.["cached-update"]["origin"] == "vmcheckmote:vmcheck"' \
+    '.["cached-update"]["version"] == "v2"' \
+    '.["cached-update"]["ref-has-new-commit"] == true' \
+    '.["cached-update"]["gpg-enabled"] == false'
+
+  # we could assert more json here, though how it's presented to users is
+  # important, and implicitly tests the json
+  vm_rpmostree status > out.txt
+  assert_file_has_content out.txt 'Diff: 2 upgraded, 1 downgraded, 1 removed, 1 added'
+
+  vm_rpmostree status -v > out.txt
+  assert_file_has_content out.txt 'Upgraded: base-pkg-foo 1.4-7 -> 1.4-8'
+  assert_file_has_content out.txt "          layered-cake 2.1-3 -> 2.1-4"
+  assert_file_has_content out.txt 'Downgraded: base-pkg-bar 1.0-1 -> 0.9-3'
+  assert_file_has_content out.txt 'Removed: base-pkg-baz-1.1-1.x86_64'
+  assert_file_has_content out.txt 'Added: base-pkg-boo-3.7-2.11.x86_64'
+}
+
+assert_update
+echo "ok check mode ostree"
+
+assert_default_deployment_is_update() {
+  vm_assert_status_jq \
+    '.deployments[0]["origin"] == "vmcheckmote:vmcheck"' \
+    '.deployments[0]["version"] == "v2"' \
+    '.deployments[0]["packages"]|length == 1' \
+    '.deployments[0]["packages"]|index("layered-cake") >= 0'
+  vm_rpmostree db list $(vm_get_pending_csum) > list.txt
+  assert_file_has_content list.txt 'layered-cake-2.1-4.x86_64'
+}
+
+# now let's try reboot mode
+change_policy reboot
+vm_reboot_cmd rpm-ostree upgrade --trigger-automatic-update-policy
+assert_default_deployment_is_update
+echo "ok reboot mode"
+
+# let's do another reboot mode trigger to make sure we don't reboot if there's
+# nothing pending (use 77 exit to make it easier to test)
+rc=0
+vm_cmd rpm-ostree upgrade \
+  --upgrade-unchanged-exit-77 \
+  --trigger-automatic-update-policy || rc=$?
+assert_streq "$rc" "77"
+echo "ok reboot mode no upgrades"

--- a/tests/vmcheck/test.sh
+++ b/tests/vmcheck/test.sh
@@ -76,6 +76,8 @@ if vm_cmd test -f /etc/rpm-ostreed.conf; then
 fi
 vm_cmd cp -f /usr/etc/rpm-ostreed.conf /etc
 
+vm_cmd ostree remote delete --if-exists vmcheckmote
+
 origdir=$(pwd)
 echo -n '' > ${LOG}
 
@@ -186,6 +188,7 @@ for tf in $(find . -name 'test-*.sh' | sort); do
     # and clean up any leftovers from our tmp
     osname=$(vm_get_booted_deployment_info osname)
     vm_cmd rm -rf /ostree/deploy/$osname/var/tmp/vmcheck
+    vm_cmd ostree remote delete --if-exists vmcheckmote
 done
 
 


### PR DESCRIPTION
Tracking issue: https://github.com/projectatomic/rpm-ostree/issues/247

Still a lot of things missing, but thought I'd push out what I've got so far!

The base infrastructure is set up, but there's still a lot of work left in the part that diffs against the booted system. For now just the (base) ostree rpm diff is implemented (no rpmmd analysis), viewable in `--json`:

```
$ rpm-ostree status --json | python -c 'import sys,json,pprint;j=json.load(sys.stdin);pprint.pprint(j["
cached-update"])'

{u'checksum': u'9e911b0583f21e6b227a53bf6f53f251da95ccb4ba34da2ea72fccfd95508798',
 u'gpg-enabled': False,
 u'is-new-checksum': True,
 u'origin': u'vmcheck',
 u'osname': u'fedora-atomic',
 u'ostree-rpm-diff': [[u'python-rhsm-certificates',
                       3,
                       {u'NewPackage': [u'python-rhsm-certificates',
                                        u'1.20.1-1.fc26',
                                        u'x86_64'],
                        u'PreviousPackage': [u'python-rhsm-certificates',
                                             u'1.20.2-1.fc26',
                                             u'x86_64']}]],
 u'timestamp': 1513199010,
 u'version': u'27.43'}
```