### PR TITLE
Makefile-daemon.am: work around gdbus-codegen path logic

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -4,7 +4,7 @@ dbus_built_sources = rpm-ostreed-generated.h rpm-ostreed-generated.c
 # https://github.com/projectatomic/rpm-ostree/pull/705
 rpm-ostreed-generated.h: rpm-ostreed-generated.c
 rpm-ostreed-generated.c: Makefile $(top_srcdir)/src/daemon/org.projectatomic.rpmostree1.xml
-	$(AM_V_GEN) gdbus-codegen \
+	$(AM_V_GEN) /usr/bin/gdbus-codegen \
 		--interface-prefix org.projectatomic.rpmostree1 \
 		--c-namespace RPMOSTree \
 		--c-generate-object-manager \


### PR DESCRIPTION
I just rebased my pet container to F27, and this was the only hiccup
when trying to build rpm-ostree. Basically, `gdbus-codegen` is sensitive
to how it's called when trying to find its own Python modules. Calling
it with the explicit `/usr` prefix works around that. This was fixed
upstream in [1], but hasn't made its way down the metaphorical stream
yet. See [2] for more information.

[1] https://github.com/GNOME/glib/commit/b9f2ea423526735f7fe7371fb1339eae91a618c2
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1485853