### PR TITLE
compose: Move txn+ref to toplevel, out of postprocess/commit  code

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1211,13 +1211,13 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
       if (!ostree_repo_commit_transaction (self->repo, &stats, cancellable, error))
         return glnx_prefix_error (error, "Commit");
 
-      g_print ("Wrote commit: %s\n", new_revision);
       g_print ("Metadata Total: %u\n", stats.metadata_objects_total);
       g_print ("Metadata Written: %u\n", stats.metadata_objects_written);
       g_print ("Content Total: %u\n", stats.content_objects_total);
       g_print ("Content Written: %u\n", stats.content_objects_written);
       g_print ("Content Bytes Written: %" G_GUINT64_FORMAT "\n", stats.content_bytes_written);
     }
+  g_print ("Wrote commit: %s\n", new_revision);
 
   if (opt_write_commitid_to)
     {

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -79,14 +79,13 @@ rpmostree_postprocess_final (int            rootfs_dfd,
                              GError       **error);
 
 gboolean
-rpmostree_commit (int            rootfs_dfd,
-                  OstreeRepo    *repo,
-                  const char    *refname,
-                  const char    *write_commitid_to,
-                  GVariant      *metadata,
-                  const char    *gpg_keyid,
-                  gboolean       enable_selinux,
-                  OstreeRepoDevInoCache *devino_cache,
-                  char         **out_new_revision,
-                  GCancellable  *cancellable,
-                  GError       **error);
+rpmostree_compose_commit (int            rootfs_dfd,
+                          OstreeRepo    *repo,
+                          const char    *parent,
+                          GVariant      *metadata,
+                          const char    *gpg_keyid,
+                          gboolean       enable_selinux,
+                          OstreeRepoDevInoCache *devino_cache,
+                          char         **out_new_revision,
+                          GCancellable  *cancellable,
+                          GError       **error);

--- a/tests/compose-tests/test-write-commitid.sh
+++ b/tests/compose-tests/test-write-commitid.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+dn=$(cd $(dirname $0) && pwd)
+. ${dn}/libcomposetest.sh
+
+prepare_compose_test "write-commitid"
+runcompose --write-commitid-to $(pwd)/commitid.txt
+wc -c < commitid.txt > wc.txt
+assert_file_has_content_literal wc.txt 64
+echo "ok compose"
+
+# --write-commitid-to should not set the ref
+if ostree --repo=${repobuild} rev-parse ${treeref}; then
+    fatal "Found ${treeref} ?"
+fi
+echo "ok ref not written"


### PR DESCRIPTION
Prep for `compose tree --ex-jigdo`; basically we want to generate the jigdoRPM
and only then set the ref to help bind the two things together.  The main
thing to achieve is that if generating the jigdoRPM fails, the ref isn't
updated.