### PR TITLE
Make use of the new pkglist metadata in more places

### DIFF
--- a/src/app/rpmostree-libbuiltin.c
+++ b/src/app/rpmostree-libbuiltin.c
@@ -110,7 +110,7 @@ rpmostree_print_treepkg_diff (OstreeSysroot    *sysroot,
                                cancellable, error))
         return FALSE;
 
-      rpmostree_diff_print (removed, added, modified_old, modified_new);
+      rpmostree_diff_print_formatted (removed, added, modified_old, modified_new);
     }
 
   return TRUE;

--- a/src/daemon/rpmostree-package-variants.h
+++ b/src/daemon/rpmostree-package-variants.h
@@ -34,6 +34,7 @@ gboolean
 rpm_ostree_db_diff_variant (OstreeRepo *repo,
                             const char *from_rev,
                             const char *to_rev,
+                            gboolean    allow_noent,
                             GVariant  **out_variant,
                             GCancellable *cancellable,
                             GError **error);

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -346,7 +346,7 @@ os_handle_get_deployments_rpm_diff (RPMOSTreeOS *interface,
     }
   ref1 = ostree_deployment_get_csum (deployment1);
 
-  if (!rpm_ostree_db_diff_variant (ot_repo, ref0, ref1, &value,
+  if (!rpm_ostree_db_diff_variant (ot_repo, ref0, ref1, FALSE, &value,
                                    cancellable, &local_error))
     goto out;
 
@@ -414,7 +414,7 @@ os_handle_get_cached_update_rpm_diff (RPMOSTreeOS *interface,
     goto out;
 
   if (!rpm_ostree_db_diff_variant (ot_repo, ostree_deployment_get_csum (base_deployment),
-                                   rpmostree_origin_get_refspec (origin), &value,
+                                   rpmostree_origin_get_refspec (origin), FALSE, &value,
                                    cancellable, &local_error))
     goto out;
 
@@ -1399,7 +1399,7 @@ os_handle_get_cached_rebase_rpm_diff (RPMOSTreeOS *interface,
     goto out;
 
   if (!rpm_ostree_db_diff_variant (ot_repo, ostree_deployment_get_csum (base_deployment),
-                                   comp_ref, &value, cancellable, &local_error))
+                                   comp_ref, FALSE, &value, cancellable, &local_error))
     goto out;
 
   details = rpmostreed_commit_generate_cached_details_variant (base_deployment,
@@ -1534,7 +1534,7 @@ os_handle_get_cached_deploy_rpm_diff (RPMOSTreeOS *interface,
         goto out;
     }
 
-  if (!rpm_ostree_db_diff_variant (ot_repo, base_checksum, checksum, &value,
+  if (!rpm_ostree_db_diff_variant (ot_repo, base_checksum, checksum, FALSE, &value,
                                    cancellable, &local_error))
     goto out;
 

--- a/src/lib/rpmostree-db.c
+++ b/src/lib/rpmostree-db.c
@@ -36,25 +36,6 @@
  * OSTree repository.
  */
 
-static GPtrArray *
-query_all_packages_in_sack (RpmOstreeRefSack *rsack)
-{
-  hy_autoquery HyQuery hquery = hy_query_create (rsack->sack);
-  hy_query_filter (hquery, HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
-  g_autoptr(GPtrArray) pkglist = hy_query_run (hquery);
-
-  g_autoptr(GPtrArray) result = g_ptr_array_new_with_free_func (g_object_unref);
-
-  const guint c = pkglist->len;
-  for (guint i = 0; i < c; i++)
-    {
-      DnfPackage *pkg = pkglist->pdata[i];
-      g_ptr_array_add (result, _rpm_ostree_package_new (rsack, pkg));
-    }
-
-  return g_steal_pointer (&result);
-}
-
 /**
  * rpm_ostree_db_query_all:
  * @repo: An OSTree repository
@@ -73,9 +54,10 @@ rpm_ostree_db_query_all (OstreeRepo                *repo,
                          GCancellable              *cancellable,
                          GError                   **error)
 {
-  g_autoptr(RpmOstreeRefSack) rsack =
-    rpmostree_get_refsack_for_commit (repo, ref, cancellable, error);
-  return query_all_packages_in_sack (rsack);
+  g_autoptr(GPtrArray) pkglist = NULL;
+  if (!_rpm_ostree_package_list_for_commit (repo, ref, FALSE, &pkglist, cancellable, error))
+    return NULL;
+  return g_steal_pointer (&pkglist);
 }
 
 /**
@@ -83,25 +65,21 @@ rpm_ostree_db_query_all (OstreeRepo                *repo,
  * @repo: An OSTree repository
  * @orig_ref: Original ref (branch or commit)
  * @new_ref: New ref (branch or commit)
- * @out_removed: (out) (transfer container) (element-type RpmOstreePackage): Return location for removed packages
- * @out_added: (out) (transfer container) (element-type RpmOstreePackage): Return location for added packages
- * @out_modified_old: (out) (transfer container) (element-type RpmOstreePackage): Return location for modified old packages
- * @out_modified_new: (out) (transfer container) (element-type RpmOstreePackage): Return location for modified new packages
+ * @out_removed: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for removed packages
+ * @out_added: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for added packages
+ * @out_modified_old: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for modified old packages
+ * @out_modified_new: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for modified new packages
  *
- * Compute the RPM package delta between two commits.  Currently you
- * must use %NULL for the @query parameter; in a future version this
- * function may allow looking at a subset of the packages.
+ * Compute the RPM package delta between two commits.
  *
- * The @out_modified_old and @out_modified_new arrays will always be
- * the same length, and indicies will refer to the same base package
- * name.  It is possible in RPM databases to have multiple packages
- * installed with the same name; in this case, the behavior will
- * depend on whether the package set is transitioning from 1 -> N or N
- * -> 1.  In the former case, an arbitrary single instance of one of
- * the new packages will be in @out_modified_new.  If the latter, then
- * multiple entries with the same name will be returned in
- * the array @out_modified_old, with each having a reference to the
- * single corresponding new package.
+ * If there are multiple packages with the same name, they are dealt
+ * with as follow:
+ *   - if there are N pkgs of the same name in @orig_ref, and 0 pkgs of the same name in
+ *     @new_ref, then there will be N entries in @out_removed (and vice-versa for
+ *     @new_ref/@out_added)
+ *   - if there are N pkgs of the same name in @orig_ref, and M pkgs of the same name in
+ *     @new_ref, then there will be M entries in @out_modified_new, where all M entries will
+ *     be paired with the same arbitrary pkg coming from one of the N entries.
  */
 gboolean
 rpm_ostree_db_diff (OstreeRepo               *repo,
@@ -114,86 +92,75 @@ rpm_ostree_db_diff (OstreeRepo               *repo,
                     GCancellable             *cancellable,
                     GError                  **error)
 {
-  g_autoptr(GPtrArray) ret_removed = g_ptr_array_new_with_free_func (g_object_unref);
-  g_autoptr(GPtrArray) ret_added = g_ptr_array_new_with_free_func (g_object_unref);
-  g_autoptr(GPtrArray) ret_modified_old = g_ptr_array_new_with_free_func (g_object_unref);
-  g_autoptr(GPtrArray) ret_modified_new = g_ptr_array_new_with_free_func (g_object_unref);
+  return rpm_ostree_db_diff_ext (repo,
+                                 orig_ref,
+                                 new_ref,
+                                 0,
+                                 out_removed,
+                                 out_added,
+                                 out_modified_old,
+                                 out_modified_new,
+                                 cancellable,
+                                 error);
+}
 
+/**
+ * rpm_ostree_db_diff_ext:
+ * @repo: An OSTree repository
+ * @orig_ref: Original ref (branch or commit)
+ * @new_ref: New ref (branch or commit)
+ * @flags: Flags controlling diff behaviour
+ * @out_removed: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for removed packages
+ * @out_added: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for added packages
+ * @out_modified_old: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for modified old packages
+ * @out_modified_new: (out) (transfer container) (element-type RpmOstreePackage) (allow-none): Return location for modified new packages
+ *
+ * This function is identical to rpm_ostree_db_diff_ext(), but supports a @flags argument to
+ * further control behaviour.
+ *
+ * Since: 2017.12
+ */
+gboolean
+rpm_ostree_db_diff_ext (OstreeRepo               *repo,
+                        const char               *orig_ref,
+                        const char               *new_ref,
+                        RpmOstreeDbDiffExtFlags   flags,
+                        GPtrArray               **out_removed,
+                        GPtrArray               **out_added,
+                        GPtrArray               **out_modified_old,
+                        GPtrArray               **out_modified_new,
+                        GCancellable             *cancellable,
+                        GError                  **error)
+{
   g_return_val_if_fail (out_removed != NULL && out_added != NULL &&
                         out_modified_old != NULL && out_modified_new != NULL, FALSE);
 
-  g_autoptr(RpmOstreeRefSack) orig_sack =
-    rpmostree_get_refsack_for_commit (repo, orig_ref, cancellable, error);
-  if (!orig_sack)
-    return FALSE;
+  const gboolean allow_noent = ((flags & RPM_OSTREE_DB_DIFF_EXT_ALLOW_NOENT) > 0);
 
   g_autoptr(GPtrArray) orig_pkglist = NULL;
-  { hy_autoquery HyQuery query = hy_query_create (orig_sack->sack);
-    hy_query_filter (query, HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
-    orig_pkglist = hy_query_run (query);
-  }
-
-  g_autoptr(RpmOstreeRefSack) new_sack =
-    rpmostree_get_refsack_for_commit (repo, new_ref, cancellable, error);
-  if (!new_sack)
+  if (!_rpm_ostree_package_list_for_commit (repo, orig_ref, allow_noent, &orig_pkglist,
+                                            cancellable, error))
     return FALSE;
 
   g_autoptr(GPtrArray) new_pkglist = NULL;
-  { hy_autoquery HyQuery query = hy_query_create (new_sack->sack);
-    hy_query_filter (query, HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
-    new_pkglist = hy_query_run (query);
-  }
-
-  for (guint i = 0; i < new_pkglist->len; i++)
+  if (orig_pkglist)
     {
-      DnfPackage *pkg = new_pkglist->pdata[i];
-
-      hy_autoquery HyQuery query = hy_query_create (orig_sack->sack);
-      hy_query_filter (query, HY_PKG_NAME, HY_EQ, dnf_package_get_name (pkg));
-      hy_query_filter (query, HY_PKG_EVR, HY_NEQ, dnf_package_get_evr (pkg));
-      hy_query_filter (query, HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
-      g_autoptr(GPtrArray) pkglist = hy_query_run (query);
-
-      guint count = pkglist->len;
-      if (count > 0)
-        {
-          /* See comment above about transitions from N -> 1 */
-          DnfPackage *oldpkg = pkglist->pdata[0];
-
-          g_ptr_array_add (ret_modified_old, _rpm_ostree_package_new (orig_sack, oldpkg));
-          g_ptr_array_add (ret_modified_new, _rpm_ostree_package_new (new_sack, pkg));
-        }
+      if (!_rpm_ostree_package_list_for_commit (repo, new_ref, allow_noent, &new_pkglist,
+                                                cancellable, error))
+        return FALSE;
     }
 
-  for (guint i = 0; i < orig_pkglist->len; i++)
+  if (!orig_pkglist || !new_pkglist)
     {
-      DnfPackage *pkg = orig_pkglist->pdata[i];
-
-      hy_autoquery HyQuery query = hy_query_create (new_sack->sack);
-      hy_query_filter (query, HY_PKG_NAME, HY_EQ, dnf_package_get_name (pkg));
-      hy_query_filter (query, HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
-      g_autoptr(GPtrArray) pkglist = hy_query_run (query);
-
-      if (pkglist->len == 0)
-        g_ptr_array_add (ret_removed, _rpm_ostree_package_new (orig_sack, pkg));
+      /* it's the only way we could've gotten this far */
+      g_assert (allow_noent);
+      *out_removed = NULL;
+      *out_added = NULL;
+      *out_modified_old = NULL;
+      *out_modified_new = NULL;
+      return TRUE;
     }
 
-  for (guint i = 0; i < new_pkglist->len; i++)
-    {
-      DnfPackage *pkg = new_pkglist->pdata[i];
-
-      hy_autoquery HyQuery query = hy_query_create (orig_sack->sack);
-      hy_query_filter (query, HY_PKG_NAME, HY_EQ, dnf_package_get_name (pkg));
-      hy_query_filter (query, HY_PKG_REPONAME, HY_EQ, HY_SYSTEM_REPO_NAME);
-      g_autoptr(GPtrArray) pkglist = hy_query_run (query);
-
-      if (pkglist->len == 0)
-        g_ptr_array_add (ret_added, _rpm_ostree_package_new (new_sack, pkg));
-    }
-
-  *out_removed = g_steal_pointer (&ret_removed);
-  *out_added = g_steal_pointer (&ret_added);
-  *out_modified_old = g_steal_pointer (&ret_modified_old);
-  *out_modified_new = g_steal_pointer (&ret_modified_new);
-  return TRUE;
+  return _rpm_ostree_diff_package_lists (orig_pkglist, new_pkglist, out_removed, out_added,
+                                         out_modified_old, out_modified_new, NULL);
 }

--- a/src/lib/rpmostree-db.h
+++ b/src/lib/rpmostree-db.h
@@ -40,4 +40,27 @@ _RPMOSTREE_EXTERN gboolean rpm_ostree_db_diff (OstreeRepo               *repo,
                                                GCancellable             *cancellable,
                                                GError                  **error);
 
+/**
+ * RpmOstreeDbDiffFlags:
+ * @RPM_OSTREE_DB_DIFF_EXT_NONE: No flags.
+ * @RPM_OSTREE_DB_DIFF_EXT_ALLOW_NOENT: Don't error out if there is insufficient information
+ *    to retrieve the list of packages (e.g. /usr/share/rpm or commit metadata missing).
+ *
+ * Since: 2017.12
+ */
+typedef enum {
+  RPM_OSTREE_DB_DIFF_EXT_NONE        = 0,
+  RPM_OSTREE_DB_DIFF_EXT_ALLOW_NOENT = (1 << 0),
+} RpmOstreeDbDiffExtFlags;
+
+_RPMOSTREE_EXTERN gboolean rpm_ostree_db_diff_ext (OstreeRepo               *repo,
+                                                   const char               *orig_ref,
+                                                   const char               *new_ref,
+                                                   RpmOstreeDbDiffExtFlags   flags,
+                                                   GPtrArray               **out_removed,
+                                                   GPtrArray               **out_added,
+                                                   GPtrArray               **out_modified_old,
+                                                   GPtrArray               **out_modified_new,
+                                                   GCancellable             *cancellable,
+                                                   GError                  **error);
 G_END_DECLS

--- a/src/lib/rpmostree-package-priv.h
+++ b/src/lib/rpmostree-package-priv.h
@@ -21,8 +21,18 @@
 
 #pragma once
 
+#include <ostree.h>
 #include "rpmostree-package.h"
 #include "rpmostree-refsack.h"
 
 RpmOstreePackage * _rpm_ostree_package_new (RpmOstreeRefSack *rsack, DnfPackage *hypkg);
 
+RpmOstreePackage * _rpm_ostree_package_new_from_variant (GVariant *gv_nevra);
+
+gboolean
+_rpm_ostree_package_list_for_commit (OstreeRepo   *repo,
+                                     const char   *rev,
+                                     gboolean      allow_noent,
+                                     GPtrArray   **out_pkglist,
+                                     GCancellable *cancellable,
+                                     GError      **error);

--- a/src/lib/rpmostree-package-priv.h
+++ b/src/lib/rpmostree-package-priv.h
@@ -36,3 +36,11 @@ _rpm_ostree_package_list_for_commit (OstreeRepo   *repo,
                                      GPtrArray   **out_pkglist,
                                      GCancellable *cancellable,
                                      GError      **error);
+gboolean
+_rpm_ostree_diff_package_lists (GPtrArray  *a,
+                                GPtrArray  *b,
+                                GPtrArray **out_unique_a,
+                                GPtrArray **out_unique_b,
+                                GPtrArray **out_modified_a,
+                                GPtrArray **out_modified_b,
+                                GPtrArray **out_common);

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -130,8 +130,12 @@ rpmostree_fcap_to_xattr_variant (const char *fcap);
 typedef enum {
   PKG_NEVRA_FLAGS_NAME = (1 << 0),
   PKG_NEVRA_FLAGS_EPOCH_VERSION_RELEASE = (1 << 1),
+  PKG_NEVRA_FLAGS_EVR = PKG_NEVRA_FLAGS_EPOCH_VERSION_RELEASE,
   PKG_NEVRA_FLAGS_VERSION_RELEASE = (1 << 2),
-  PKG_NEVRA_FLAGS_ARCH = (1 << 3)
+  PKG_NEVRA_FLAGS_ARCH = (1 << 3),
+  PKG_NEVRA_FLAGS_NEVRA = (PKG_NEVRA_FLAGS_NAME |
+                           PKG_NEVRA_FLAGS_EVR  |
+                           PKG_NEVRA_FLAGS_ARCH),
 } RpmOstreePkgNevraFlags;
 
 void

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -86,10 +86,17 @@ gs_file_get_path_cached (GFile *file)
 
 gboolean rpmostree_stdout_is_journal (void);
 
-void rpmostree_diff_print (GPtrArray *removed,
-                           GPtrArray *added,
-                           GPtrArray *modified_old,
-                           GPtrArray *modified_new);
+void
+rpmostree_diff_print_formatted (GPtrArray *removed,
+                                GPtrArray *added,
+                                GPtrArray *modified_old,
+                                GPtrArray *modified_new);
+
+void
+rpmostree_diff_print (GPtrArray *removed,
+                      GPtrArray *added,
+                      GPtrArray *modified_old,
+                      GPtrArray *modified_new);
 
 gboolean
 rpmostree_str_has_prefix_in_strv (const char *str,

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -373,6 +373,13 @@ assert_status_jq() {
     assert_status_file_jq status.json "$@"
 }
 
+get_obj_path() {
+  repo=$1; shift
+  csum=$1; shift
+  objtype=$1; shift
+  echo "${repo}/objects/${csum:0:2}/${csum:2}.${objtype}"
+}
+
 # builds a new RPM and adds it to the testdir's repo
 # $1 - name
 # $2+ - optional, treated as directive/value pairs

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -302,6 +302,11 @@ vm_get_booted_csum() {
   vm_get_booted_deployment_info checksum
 }
 
+# retrieve the checksum of the pending deployment
+vm_get_pending_csum() {
+  vm_get_deployment_info 0 checksum
+}
+
 # make multiple consistency checks on a test pkg
 # - $1    package to check for
 # - $2    either "present" or "absent"

--- a/tests/vmcheck/test-db.sh
+++ b/tests/vmcheck/test-db.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Copyright (C) 2017 Jonathan Lebon <jlebon@redhat.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# SUMMARY: check that `db` commands work correctly. Right now, we're only
+# testing `db diff`.
+
+YUMREPO=/tmp/vmcheck/yumrepo/packages/x86_64
+
+check_diff() {
+  from=$1; shift
+  to=$1; shift
+  vm_rpmostree db diff --format=diff $from $to > diff.txt
+  assert_file_has_content diff.txt "$@"
+}
+
+vm_build_rpm pkg-to-remove
+vm_build_rpm pkg-to-replace
+vm_rpmostree install pkg-to-remove pkg-to-replace
+
+booted_csum=$(vm_get_booted_csum)
+pending_csum=$(vm_get_pending_csum)
+check_diff $booted_csum $pending_csum \
+  +pkg-to-remove \
+  +pkg-to-replace
+
+# now let's make the pending csum become an update
+vm_cmd ostree commit -b vmcheck --tree=ref=$pending_csum
+vm_rpmostree cleanup -p
+vm_rpmostree upgrade
+pending_csum=$(vm_get_pending_csum)
+check_diff $booted_csum $pending_csum \
+  +pkg-to-remove \
+  +pkg-to-replace
+echo "ok setup"
+
+vm_rpmostree override remove pkg-to-remove
+vm_build_rpm pkg-to-replace version 2.0
+vm_rpmostree override replace $YUMREPO/pkg-to-replace-2.0-1.x86_64.rpm
+vm_build_rpm pkg-to-overlay
+vm_rpmostree install pkg-to-overlay
+pending_layered_csum=$(vm_get_pending_csum)
+check_diff $booted_csum $pending_layered_csum \
+  +pkg-to-overlay \
+  +pkg-to-replace-2.0
+check_diff $pending_csum $pending_layered_csum \
+  +pkg-to-overlay \
+  -pkg-to-remove \
+  !pkg-to-replace-1.0 \
+  =pkg-to-replace-2.0
+echo "ok db diff"
+
+# this is a bit convoluted; basically, we prune the commit and only keep its
+# metadata to check that `db diff` is indeed using the rpmdb.pkglist metadata
+commit_path=$(get_obj_path /ostree/repo $pending_layered_csum commit)
+vm_cmd test -f $commit_path
+vm_cmd cp $commit_path $commit_path.bak
+vm_rpmostree cleanup -p
+vm_cmd test ! -f $commit_path
+vm_cmd mv $commit_path.bak $commit_path
+if vm_cmd ostree checkout --subpath /usr/share/rpm $pending_layered_csum; then
+  assert_not_reached "Was able to checkout /usr/share/rpm?"
+fi
+check_diff $pending_csum $pending_layered_csum \
+  +pkg-to-overlay \
+  -pkg-to-remove \
+  !pkg-to-replace-1.0 \
+  =pkg-to-replace-2.0
+echo "ok db from pkglist.metadata"


### PR DESCRIPTION
This patch series teaches `RpmOstreePackage` about the new pkglist metadata format, and then makes the db diff API use it. There are a lot of advantages to this, the major one being one can perform a `db diff` with only the commit metadata present. See commit messages for more details.

Requires #1158 and #1160. (Only the last three commits are new here.)