### PR TITLE
compose: Add --ex-output-jigdo-{rpm,set}

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -196,3 +196,13 @@ It supports the following parameters:
    and further, we don't want to encourage `/sysroot` to be writable.
    For host system composes, we recommend turning this on; it's left off
    by default to ease the transition.
+
+Experimental options
+--------
+
+All options listed here are subject to change or removal in a future
+version of `rpm-ostree`.
+
+ * `ex-jigdo-spec`: string, optional:  If specified, will also cause
+   a run of `rpm-ostree ex commit2jigdo` on changes.  Also requires the
+   `--ex-jigdo-output-rpm` commandline option.

--- a/tests/compose-tests/test-compose2jigdo.sh
+++ b/tests/compose-tests/test-compose2jigdo.sh
@@ -19,4 +19,13 @@ grep 'fedora-atomic-host.*x86_64\.rpm' rpms.txt | while read p; do
     rpm -qp --provides ${p} >>provides.txt
 done
 assert_file_has_content_literal provides.txt "rpmostree-jigdo-commit(${rev})"
-echo "ok compose2jigdo"
+echo "ok compose2jigdoRPM"
+
+runcompose --force-nocache --ex-jigdo-output-set $(pwd)/jigdo-output --cachedir $(pwd)/cache --add-metadata-string version=42.1
+rev=$(ostree --repo=repo-build rev-parse ${treeref})
+find jigdo-output -name '*.rpm' | tee rpms.txt
+assert_file_has_content rpms.txt 'systemd.*x86_64'
+assert_file_has_content rpms.txt 'ostree.*x86_64'
+assert_file_has_content rpms.txt 'fedora-atomic-host-42.1.*x86_64'
+echo "ok compose2jigdoSet"
+

--- a/tests/compose-tests/test-compose2jigdo.sh
+++ b/tests/compose-tests/test-compose2jigdo.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Test rpm-ostree compose tree --ex-jigdo-output-rpm
+
+set -xeuo pipefail
+
+dn=$(cd $(dirname $0) && pwd)
+. ${dn}/libcomposetest.sh
+. ${dn}/../common/libtest.sh
+
+prepare_compose_test "compose2jigdo"
+pysetjsonmember "ex-jigdo-spec" '"fedora-atomic-host-oirpm.spec"'
+mkdir cache
+mkdir jigdo-output
+runcompose --ex-jigdo-output-rpm $(pwd)/jigdo-output --cachedir $(pwd)/cache --add-metadata-string version=42.0
+rev=$(ostree --repo=repo-build rev-parse ${treeref})
+find jigdo-output -name '*.rpm' | tee rpms.txt
+assert_file_has_content rpms.txt 'fedora-atomic-host-42.0.*x86_64'
+grep 'fedora-atomic-host.*x86_64\.rpm' rpms.txt | while read p; do
+    rpm -qp --provides ${p} >>provides.txt
+done
+assert_file_has_content_literal provides.txt "rpmostree-jigdo-commit(${rev})"
+echo "ok compose2jigdo"


### PR DESCRIPTION
Part of the goal of jigdo ♲:package: is to support organizations switching to *only*
providing RPMs. An intermediate step there is to "lock" the repo and jigdo
together; we don't want to update the ref if building the jigdoRPM fails.

Add an option to perform `rpm-ostree compose tree` and `rpm-ostree ex
commit2jigdo` together; notably we generate a commit, but only update the ref
once the jigdoRPM is built.

---

Following up on `--ex-output-jigdo-rpm`, add support for writing the entire set
to an output directory. This is intended for use cases like FAHC, where we're
generating data outside of the upstream Fedora infrastructure. Further, we want
to support having our own history stored reliably, even if upstream prunes RPMs.

Now, this can be interesting even for upstreams like Fedora, as it naturally
captures just the subset of RPMs; doing full history support for that would
likely be a lot more palatable than for Everything.