### PR TITLE
 Add support for `rebase rojig://`

### DIFF
--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -38,6 +38,7 @@ static char * opt_branch;
 static char * opt_remote;
 static gboolean opt_cache_only;
 static gboolean opt_download_only;
+static gboolean opt_experimental;
 
 static GOptionEntry option_entries[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
@@ -47,6 +48,7 @@ static GOptionEntry option_entries[] = {
   { "skip-purge", 0, 0, G_OPTION_ARG_NONE, &opt_skip_purge, "Keep previous refspec after rebase", NULL },
   { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Do not download latest ostree and RPM data", NULL },
   { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only, "Just download latest ostree and RPM data, don't deploy", NULL },
+  { "experimental", 0, 0, G_OPTION_ARG_NONE, &opt_experimental, "Enable experimental features", NULL },
   { NULL }
 };
 
@@ -120,6 +122,12 @@ rpmostree_builtin_rebase (int             argc,
       else
         new_provided_refspec = opt_branch;
     }
+
+  RpmOstreeRefspecType refspectype;
+  if (!rpmostree_refspec_classify (new_provided_refspec, &refspectype, NULL, error))
+    return FALSE;
+  if (!opt_experimental && refspectype == RPMOSTREE_REFSPEC_TYPE_ROJIG)
+    return glnx_throw (error, "rojig:// refspec requires --experimental");
 
   g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
   g_autoptr(GVariant) options =

--- a/src/daemon/rpmostree-sysroot-core.c
+++ b/src/daemon/rpmostree-sysroot-core.c
@@ -190,7 +190,15 @@ clean_pkgcache_orphans (OstreeSysroot            *sysroot,
                                                   NULL, NULL, error))
         return FALSE;
 
-      if (is_layered)
+      g_autoptr(RpmOstreeOrigin) origin = rpmostree_origin_parse_deployment (deployment, error);
+      if (!origin)
+        return FALSE;
+
+      RpmOstreeRefspecType refspectype;
+      rpmostree_origin_classify_refspec (origin, &refspectype, NULL);
+
+      /* In rojig mode, we need to also reference all packages */
+      if (is_layered || refspectype == RPMOSTREE_REFSPEC_TYPE_ROJIG)
         {
           g_autofree char *deployment_dirpath =
             ostree_sysroot_get_deployment_dirpath (sysroot, deployment);
@@ -209,8 +217,6 @@ clean_pkgcache_orphans (OstreeSysroot            *sysroot,
         }
 
       /* also add any inactive local replacements */
-      g_autoptr(RpmOstreeOrigin) origin =
-        rpmostree_origin_parse_deployment (deployment, error);
       GHashTable *local_replace = rpmostree_origin_get_overrides_local_replace (origin);
       GLNX_HASH_TABLE_FOREACH (local_replace, const char*, nevra)
         {

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -301,7 +301,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
 
   gboolean gpg_enabled = FALSE;
   g_autoptr(GVariant) sigs = NULL;
-  if (refspec && refspec_type == RPMOSTREE_REFSPEC_TYPE_OSTREE)
+  if (refspec_type == RPMOSTREE_REFSPEC_TYPE_OSTREE)
     {
       if (!rpmostreed_deployment_gpg_results (repo, refspec, base_checksum, &sigs, &gpg_enabled, error))
         return NULL;
@@ -311,7 +311,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
                                     &pending_base_commitrev, error))
         return NULL;
 
-      if (pending_base_commitrev && strcmp (pending_base_commitrev, base_checksum) != 0)
+      if (pending_base_commitrev && !g_str_equal (pending_base_commitrev, base_checksum))
         {
           g_autoptr(GVariant) pending_base_commit = NULL;
 

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -24,6 +24,7 @@
 #include "rpmostree-types.h"
 #include "rpmostreed-deployment-utils.h"
 #include "rpmostree-origin.h"
+#include "rpmostree-core.h"
 #include "rpmostree-util.h"
 #include "rpmostree-rpm-util.h"
 #include "rpmostree-sysroot-core.h"
@@ -245,7 +246,8 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
   if (!origin)
     return NULL;
 
-  const char *refspec = rpmostree_origin_get_refspec (origin);
+  RpmOstreeRefspecType refspec_type;
+  g_autofree char *refspec = rpmostree_origin_get_full_refspec (origin, &refspec_type);
 
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
@@ -295,31 +297,32 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
   { g_autoptr(GVariant) base_meta = g_variant_get_child_value (commit, 0);
     g_variant_dict_insert (&dict, "base-commit-meta", "@a{sv}", base_meta);
   }
+  variant_add_commit_details (&dict, NULL, commit);
 
   gboolean gpg_enabled = FALSE;
   g_autoptr(GVariant) sigs = NULL;
-  if (!rpmostreed_deployment_gpg_results (repo, refspec, base_checksum, &sigs, &gpg_enabled, error))
-    return NULL;
-  variant_add_commit_details (&dict, NULL, commit);
-
-  g_autofree char *pending_base_commitrev = NULL;
-  if (!ostree_repo_resolve_rev (repo, refspec, TRUE,
-                                &pending_base_commitrev, error))
-    return NULL;
-
-  if (pending_base_commitrev && strcmp (pending_base_commitrev, base_checksum) != 0)
+  if (refspec && refspec_type == RPMOSTREE_REFSPEC_TYPE_OSTREE)
     {
-      g_autoptr(GVariant) pending_base_commit = NULL;
-
-      if (!ostree_repo_load_variant (repo,
-                                     OSTREE_OBJECT_TYPE_COMMIT,
-                                     pending_base_commitrev,
-                                     &pending_base_commit,
-                                     error))
+      if (!rpmostreed_deployment_gpg_results (repo, refspec, base_checksum, &sigs, &gpg_enabled, error))
         return NULL;
 
-      g_variant_dict_insert (&dict, "pending-base-checksum", "s", pending_base_commitrev);
-      variant_add_commit_details (&dict, "pending-base-", pending_base_commit);
+      g_autofree char *pending_base_commitrev = NULL;
+      if (!ostree_repo_resolve_rev (repo, refspec, TRUE,
+                                    &pending_base_commitrev, error))
+        return NULL;
+
+      if (pending_base_commitrev && strcmp (pending_base_commitrev, base_checksum) != 0)
+        {
+          g_autoptr(GVariant) pending_base_commit = NULL;
+
+          if (!ostree_repo_load_variant (repo, OSTREE_OBJECT_TYPE_COMMIT,
+                                         pending_base_commitrev, &pending_base_commit,
+                                         error))
+            return NULL;
+
+          g_variant_dict_insert (&dict, "pending-base-checksum", "s", pending_base_commitrev);
+          variant_add_commit_details (&dict, "pending-base-", pending_base_commit);
+        }
     }
 
   g_autofree char *live_inprogress = NULL;
@@ -333,7 +336,8 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
   if (live_replaced)
     g_variant_dict_insert (&dict, "live-replaced", "s", live_replaced);
 
-  g_variant_dict_insert (&dict, "origin", "s", refspec);
+  if (refspec)
+    g_variant_dict_insert (&dict, "origin", "s", refspec);
 
   variant_add_from_hash_table (&dict, "requested-packages",
                                rpmostree_origin_get_packages (origin));
@@ -380,13 +384,16 @@ add_all_commit_details_to_vardict (OstreeDeployment *deployment,
   const gchar *osname = ostree_deployment_get_osname (deployment);
 
   g_autofree gchar *refspec_owned = NULL;
+  gboolean refspec_is_ostree = FALSE;
   if (!refspec)
     {
       g_autoptr(RpmOstreeOrigin) origin =
         rpmostree_origin_parse_deployment (deployment, error);
       if (!origin)
         return FALSE;
-      refspec = refspec_owned = g_strdup (rpmostree_origin_get_refspec (origin));
+      RpmOstreeRefspecType refspec_type;
+      refspec = refspec_owned = rpmostree_origin_get_full_refspec (origin, &refspec_type);
+      refspec_is_ostree = (refspec_type == RPMOSTREE_REFSPEC_TYPE_OSTREE);
     }
 
   g_assert (refspec);
@@ -395,8 +402,11 @@ add_all_commit_details_to_vardict (OstreeDeployment *deployment,
   g_autofree gchar *checksum_owned = NULL;
   if (!checksum)
     {
-      if (!ostree_repo_resolve_rev (repo, refspec, TRUE, &checksum_owned, error))
-        return FALSE;
+      if (refspec_is_ostree)
+        {
+          if (!ostree_repo_resolve_rev (repo, refspec, TRUE, &checksum_owned, error))
+            return FALSE;
+        }
 
       /* in that case, use deployment csum */
       checksum = checksum_owned ?: ostree_deployment_get_csum (deployment);
@@ -411,11 +421,14 @@ add_all_commit_details_to_vardict (OstreeDeployment *deployment,
       commit = commit_owned;
     }
 
-  gboolean gpg_enabled;
+  gboolean gpg_enabled = FALSE;
   g_autoptr(GVariant) sigs = NULL;
-  if (!rpmostreed_deployment_gpg_results (repo, refspec, checksum,
-                                          &sigs, &gpg_enabled, error))
-    return FALSE;
+  if (refspec_is_ostree)
+    {
+      if (!rpmostreed_deployment_gpg_results (repo, refspec, checksum,
+                                              &sigs, &gpg_enabled, error))
+        return FALSE;
+    }
 
   if (osname != NULL)
     g_variant_dict_insert (dict, "osname", "s", osname);

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -686,18 +686,9 @@ start_deployment_txn (GDBusMethodInvocation  *invocation,
   g_autofree char *canon_refspec = NULL;
   if (refspec)
     {
-      RpmOstreeRefspecType refspectype;
-      const char *refspecdata;
-      if (!rpmostree_refspec_classify (refspec, &refspectype, &refspecdata, error))
-        return NULL;
-      switch (refspectype)
-        {
-        case RPMOSTREE_REFSPEC_TYPE_OSTREE:
-          break;
-        case RPMOSTREE_REFSPEC_TYPE_ROJIG:
-          return glnx_null_throw (error, "Unsupported refspec: %s", refspec);
-        }
-      canon_refspec = rpmostree_refspec_to_string (refspectype, refspecdata);
+      canon_refspec = rpmostree_refspec_canonicalize (refspec, error);
+      if (!canon_refspec)
+        return FALSE;
     }
 
   default_flags = deploy_flags_from_options (options, default_flags);

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -719,7 +719,7 @@ on_deploy_changed (GFileMonitor *monitor,
 
  out:
   if (error)
-    g_critical ("Unable to update state: %s", error->message);
+    sd_journal_print (LOG_ERR, "Unable to update state: %s", error->message);
 }
 
 static void

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -58,15 +58,24 @@ change_origin_refspec (OstreeSysroot *sysroot,
    * `rpm-ostree rebase fedora-atomic-workstation` instead of
    * `rpm-ostree rebase updates:fedora-atomic-workstation` etc.
    */
-  if (refspectype == RPMOSTREE_REFSPEC_TYPE_ROJIG)
+  switch (refspectype)
     {
-      if (!rpmostree_origin_set_rebase (origin, src_refspec, error))
-        return FALSE;
+      case RPMOSTREE_REFSPEC_TYPE_ROJIG:
+        {
+          if (!rpmostree_origin_set_rebase (origin, src_refspec, error))
+            return FALSE;
 
-      if (out_old_refspec != NULL)
-        *out_old_refspec = g_strdup (current_refspecdata);
-      *out_new_refspec = g_strdup (src_refspec);
-      return TRUE;
+          if (current_refspectype == RPMOSTREE_REFSPEC_TYPE_ROJIG
+              && strcmp (current_refspecdata, refspecdata) == 0)
+            return glnx_throw (error, "Old and new refs are equal: %s", src_refspec);
+
+          if (out_old_refspec != NULL)
+            *out_old_refspec = g_strdup (current_refspecdata);
+          *out_new_refspec = g_strdup (src_refspec);
+          return TRUE;
+        }
+    case RPMOSTREE_REFSPEC_TYPE_OSTREE:
+      break;
     }
 
   /* Now here we "peel" it since the rest of the code assumes libostree */

--- a/src/daemon/rpmostreed-utils.c
+++ b/src/daemon/rpmostreed-utils.c
@@ -136,10 +136,9 @@ rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
                                   gchar **out_refspec,
                                   GError **error)
 {
-
   g_autofree gchar *ref = NULL;
   g_autofree gchar *remote = NULL;
-  gboolean infer_remote = TRUE;;
+  gboolean infer_remote = TRUE;
 
   /* Allow just switching remotes */
   if (g_str_has_suffix (new_provided_refspec, ":"))

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -24,6 +24,7 @@
 
 #include "libglnx.h"
 #include "rpmostree-origin.h"
+#include "rpmostree-core.h"
 #include "rpmostree-util.h"
 
 struct RpmOstreeOrigin {
@@ -32,8 +33,14 @@ struct RpmOstreeOrigin {
   /* this is the single source of truth */
   GKeyFile *kf;
 
+  /* An origin can have either a refspec or a jigdospec */
+  RpmOstreeRefspecType refspec_type;
   char *cached_refspec;
+
+  /* Version data that goes along with the refspec */
   char *cached_override_commit;
+  char *cached_jigdo_version;
+
   char *cached_unconfigured_state;
   char **cached_initramfs_args;
   GHashTable *cached_packages;                  /* set of reldeps */
@@ -107,32 +114,48 @@ rpmostree_origin_parse_keyfile (GKeyFile         *origin,
 
   ret->cached_unconfigured_state = g_key_file_get_string (ret->kf, "origin", "unconfigured-state", NULL);
 
-  ret->cached_refspec = g_key_file_get_string (ret->kf, "origin", "refspec", NULL);
-  if (!ret->cached_refspec)
+  g_autofree char *refspec = g_key_file_get_string (ret->kf, "origin", "refspec", NULL);
+  if (!refspec)
     {
-      ret->cached_refspec = g_key_file_get_string (ret->kf, "origin", "baserefspec", NULL);
-      if (!ret->cached_refspec)
+      refspec = g_key_file_get_string (ret->kf, "origin", "baserefspec", NULL);
+      if (!refspec)
         return glnx_null_throw (error, "No origin/refspec or origin/baserefspec in current deployment origin; cannot handle via rpm-ostree");
-
-      if (!parse_packages_strv (ret->kf, "packages", "requested", FALSE,
-                                ret->cached_packages, error))
-        return FALSE;
-
-      if (!parse_packages_strv (ret->kf, "packages", "requested-local", TRUE,
-                                ret->cached_local_packages, error))
-        return FALSE;
-
-      if (!parse_packages_strv (ret->kf, "overrides", "remove", FALSE,
-                                ret->cached_overrides_remove, error))
-        return FALSE;
-
-      if (!parse_packages_strv (ret->kf, "overrides", "replace-local", TRUE,
-                                ret->cached_overrides_local_replace, error))
-        return FALSE;
     }
 
-  ret->cached_override_commit =
-    g_key_file_get_string (ret->kf, "origin", "override-commit", NULL);
+  const char *refspecdata;
+  if (!rpmostree_refspec_classify (refspec, &ret->refspec_type, &refspecdata, error))
+    return FALSE;
+  /* We "peel" here so that code that just calls
+   * rpmostree_origin_get_refspec() in the ostree:// case
+   * sees it without the prefix for compatibility.
+   */
+  ret->cached_refspec = g_strdup (refspecdata);
+  switch (ret->refspec_type)
+    {
+    case RPMOSTREE_REFSPEC_TYPE_OSTREE:
+      ret->cached_override_commit =
+        g_key_file_get_string (ret->kf, "origin", "override-commit", NULL);
+      break;
+    case RPMOSTREE_REFSPEC_TYPE_ROJIG:
+      ret->cached_jigdo_version = g_key_file_get_string (ret->kf, "origin", "jigdo-version", NULL);
+      break;
+    }
+
+  if (!parse_packages_strv (ret->kf, "packages", "requested", FALSE,
+                            ret->cached_packages, error))
+    return FALSE;
+
+  if (!parse_packages_strv (ret->kf, "packages", "requested-local", TRUE,
+                            ret->cached_local_packages, error))
+    return FALSE;
+
+  if (!parse_packages_strv (ret->kf, "overrides", "remove", FALSE,
+                            ret->cached_overrides_remove, error))
+    return FALSE;
+
+  if (!parse_packages_strv (ret->kf, "overrides", "replace-local", TRUE,
+                            ret->cached_overrides_local_replace, error))
+    return FALSE;
 
   ret->cached_initramfs_args =
     g_key_file_get_string_list (ret->kf, "rpmostree", "initramfs-args", NULL, NULL);
@@ -143,13 +166,50 @@ rpmostree_origin_parse_keyfile (GKeyFile         *origin,
 RpmOstreeOrigin *
 rpmostree_origin_dup (RpmOstreeOrigin *origin)
 {
-  return rpmostree_origin_parse_keyfile (origin->kf, NULL);
+  g_autoptr(GError) local_error = NULL;
+  RpmOstreeOrigin *ret = rpmostree_origin_parse_keyfile (origin->kf, &local_error);
+  g_assert_no_error (local_error);
+  return ret;
 }
 
 const char *
 rpmostree_origin_get_refspec (RpmOstreeOrigin *origin)
 {
   return origin->cached_refspec;
+}
+
+/* For rojig:// refspecs, includes the prefix. */
+char *
+rpmostree_origin_get_full_refspec (RpmOstreeOrigin *origin,
+                                   RpmOstreeRefspecType *out_refspectype)
+{
+  if (out_refspectype)
+    *out_refspectype = origin->refspec_type;
+  switch (origin->refspec_type)
+    {
+    case RPMOSTREE_REFSPEC_TYPE_OSTREE:
+      return g_strdup (origin->cached_refspec);
+    case RPMOSTREE_REFSPEC_TYPE_ROJIG:
+      return g_strconcat (RPMOSTREE_REFSPEC_ROJIG_PREFIX, origin->cached_refspec, NULL);
+    }
+  g_assert_not_reached ();
+  return NULL;
+}
+
+void
+rpmostree_origin_classify_refspec (RpmOstreeOrigin      *origin,
+                                   RpmOstreeRefspecType *out_type,
+                                   const char          **out_refspecdata)
+{
+  *out_type = origin->refspec_type;
+  if (out_refspecdata)
+    *out_refspecdata = origin->cached_refspec;
+}
+
+const char *
+rpmostree_origin_get_jigdo_version (RpmOstreeOrigin *origin)
+{
+  return origin->cached_jigdo_version;
 }
 
 GHashTable *
@@ -256,6 +316,7 @@ rpmostree_origin_unref (RpmOstreeOrigin *origin)
     return;
   g_key_file_unref (origin->kf);
   g_free (origin->cached_refspec);
+  g_free (origin->cached_jigdo_version);
   g_free (origin->cached_unconfigured_state);
   g_strfreev (origin->cached_initramfs_args);
   g_clear_pointer (&origin->cached_packages, g_hash_table_unref);
@@ -325,38 +386,31 @@ rpmostree_origin_set_override_commit (RpmOstreeOrigin *origin,
   origin->cached_override_commit = g_strdup (checksum);
 }
 
-/* updates an origin's refspec without migrating format */
-static gboolean
-origin_set_refspec (GKeyFile   *origin,
-                    const char *new_refspec,
-                    GError    **error)
-{
-  if (g_key_file_has_key (origin, "origin", "baserefspec", error))
-    {
-      g_key_file_set_value (origin, "origin", "baserefspec", new_refspec);
-      return TRUE;
-    }
-
-  if (error && *error)
-    return FALSE;
-
-  g_key_file_set_value (origin, "origin", "refspec", new_refspec);
-  return TRUE;
-}
-
 gboolean
 rpmostree_origin_set_rebase (RpmOstreeOrigin *origin,
                              const char      *new_refspec,
                              GError         **error)
 {
-  if (!origin_set_refspec (origin->kf, new_refspec, error))
-    return FALSE;
-
-  /* we don't want to carry any commit overrides during a rebase */
+  /* We don't want to carry any commit overrides or version pinning during a
+   * rebase by default.
+   */
   rpmostree_origin_set_override_commit (origin, NULL, NULL);
+  g_key_file_remove_key (origin->kf, "origin", "jigdo-version", NULL);
 
+  /* See related code in rpmostree_origin_parse_keyfile() */
+  const char *refspecdata;
+  if (!rpmostree_refspec_classify (new_refspec, &origin->refspec_type, &refspecdata, error))
+    return FALSE;
   g_free (origin->cached_refspec);
-  origin->cached_refspec = g_strdup (new_refspec);
+  origin->cached_refspec = g_strdup (refspecdata);
+
+  const char *refspec_key =
+    g_key_file_has_key (origin->kf, "origin", "baserefspec", NULL) ?
+      "baserefspec" : "refspec";
+  /* Peel for ostree:// types for compatibility */
+  const char *refspec_value =
+    origin->refspec_type == RPMOSTREE_REFSPEC_TYPE_OSTREE ? origin->cached_refspec : new_refspec;
+  g_key_file_set_string (origin->kf, "origin", refspec_key, refspec_value);
 
   return TRUE;
 }

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -132,6 +132,8 @@ rpmostree_origin_parse_keyfile (GKeyFile         *origin,
        * sees it without the prefix for compatibility.
        */
       ret->cached_refspec = g_steal_pointer (&refspec);
+      ret->cached_override_commit =
+        g_key_file_get_string (ret->kf, "origin", "override-commit", NULL);
     }
   else
     {

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <ostree.h>
+#include "rpmostree-core.h"
 
 typedef struct RpmOstreeOrigin RpmOstreeOrigin;
 RpmOstreeOrigin *rpmostree_origin_ref (RpmOstreeOrigin *origin);
@@ -53,6 +54,18 @@ rpmostree_origin_dup (RpmOstreeOrigin *origin);
 
 const char *
 rpmostree_origin_get_refspec (RpmOstreeOrigin *origin);
+
+void
+rpmostree_origin_classify_refspec (RpmOstreeOrigin      *origin,
+                                   RpmOstreeRefspecType *out_type,
+                                   const char          **out_refspecdata);
+
+char *
+rpmostree_origin_get_full_refspec (RpmOstreeOrigin *origin,
+                                   RpmOstreeRefspecType *out_refspectype);
+
+const char *
+rpmostree_origin_get_jigdo_version (RpmOstreeOrigin *origin);
 
 GHashTable *
 rpmostree_origin_get_packages (RpmOstreeOrigin *origin);

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -180,10 +180,6 @@ echo "ok rebase new syntax"
 
 rpm-ostree rebase --skip-purge --os=testos ostree://testos:testos/buildmaster/x86_64-runtime
 assert_status_jq '.deployments[0].origin == "testos:testos/buildmaster/x86_64-runtime"'
-if rpm-ostree rebase --skip-purge --os=testos rojig://testos:testos/buildmaster/x86_64-runtime 2>err.txt; then
-    fatal "rebase rojig worked?"
-fi
-assert_file_has_content_literal err.txt 'error: Unsupported refspec: rojig://'
 echo "ok rebase refspec syntax"
 
 rpm-ostree rebase --os=testos :another-branch

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -30,6 +30,7 @@ setup_os_repository "archive-z2" "syslinux"
 
 echo "ok setup"
 
+set -x
 # Note: Daemon already knows what sysroot to use, so avoid passing
 #       --sysroot=sysroot to rpm-ostree commands as it will result
 #       in a warning message.

--- a/tests/vmcheck/test-jigdo-client.sh
+++ b/tests/vmcheck/test-jigdo-client.sh
@@ -33,7 +33,11 @@ baseurl=https://ci.centos.org/artifacts/sig-atomic/fahc/jigdo
 gpgcheck=0
 EOF
 
-vm_rpmostree rebase rojig://fahc:fedora-atomic-host
+if vm_rpmostree rebase rojig://fahc:fedora-atomic-host 2>err.txt; then
+    fatal "Did rojig rebase without --experimental"
+fi
+assert_file_has_content_literal err.txt 'rojig:// refspec requires --experimental'
+vm_rpmostree rebase --experimental rojig://fahc:fedora-atomic-host
 vm_assert_status_jq '.deployments[0].origin|startswith("rojig://fahc:fedora-atomic-host")'
 vm_cmd ostree refs > refs.txt
 assert_file_has_content refs.txt '^rpmostree/pkg/kernel-core/'

--- a/tests/vmcheck/test-jigdo-client.sh
+++ b/tests/vmcheck/test-jigdo-client.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# Test rebasing to https://pagure.io/fedora-atomic-host-continuous
+# in rojig:// mode.
+
+vm_cmd 'cat >/etc/yum.repos.d/fahc.repo' <<EOF
+[fahc]
+baseurl=https://ci.centos.org/artifacts/sig-atomic/fahc/jigdo
+gpgcheck=0
+EOF
+
+vm_rpmostree rebase rojig://fahc:fedora-atomic-host
+vm_assert_status_jq '.deployments[0].origin|startswith("rojig://fahc:fedora-atomic-host")'
+vm_cmd ostree refs > refs.txt
+assert_file_has_content refs.txt '^rpmostree/pkg/kernel-core/'
+echo "ok jigdo client"


### PR DESCRIPTION

This is an initial drop of support for:
`rpm-ostree rebase rojig://fahc:fedora-atomic-host`.  We also
then support `rpm-ostree upgrade` from that.

There's a lot that could be improved here; the test coverage is relatively
minimal. A blocking issue there is having a realistic jigdo setup, and that's
going to require changing how we do testing. For now, this means that if we want
to e.g. change the format we'll have to temporarily disable this test, get the
format change in, update FAHC, then re-enable the test.

---

```
# rpm-ostree status
● ostree://fedora-atomic:fedora/27/x86_64/atomic-host
                   Version: 27.16 (2017-11-28 23:08:35)
                    Commit: 86727cdbc928b7f7dd0e32f62d3b973a8395d61e0ff751cfea7cc0bc5222142f
              GPGSignature: Valid signature by 860E19B0AFA800A1751881A6F55E7430F5282EE4
                  Unlocked: development
# cat /etc/yum.repos.d/local.repo 
[local]
baseurl=http://192.168.121.1:8000/f27-jigdo-test
gpgcheck=0
# rpm-ostree rebase --ex-jigdo local:fedora-atomic-host
Enabled rpm-md repositories: local

Updating metadata for 'local': [=============] 100%
rpm-md repo 'local'; generated: 2017-12-21 22:25:22
oirpm: fedora-atomic-host-27.26-1.fc27.x86_64 (local) commit=5e467248abd238bfcd9b6c49f34ecae3b1c3e8831b76ae7fad173eabe83cdd8b
457 packages to import, download size: 322.9 MB
Will download: 457 packages (322.9 MB)
Importing (457/457) [=============] 100%
# rpm-ostree status
State: idle
Deployments:
  jigdo://local:fedora-atomic-host
                   Version: 27.26 (2017-12-21 22:19:00)
                    Commit: 5e467248abd238bfcd9b6c49f34ecae3b1c3e8831b76ae7fad173eabe83cdd8b

● ostree://fedora-atomic:fedora/27/x86_64/atomic-host
                   Version: 27.16 (2017-11-28 23:08:35)
                    Commit: 86727cdbc928b7f7dd0e32f62d3b973a8395d61e0ff751cfea7cc0bc5222142f
              GPGSignature: Valid signature by 860E19B0AFA800A1751881A6F55E7430F5282EE4
                  Unlocked: development
```