### PR TITLE
cli: Rework exit status processing

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -432,6 +432,7 @@ main (int    argc,
     {
       if (invocation.exit_code == -1)
         invocation.exit_code = EXIT_FAILURE;
+      g_assert (local_error);
       goto out;
     }
   else

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -340,15 +340,20 @@ rpmostree_handle_subcommand (int argc, char **argv,
 
       g_autofree char *help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   g_autofree char *prgname =
     g_strdup_printf ("%s %s", g_get_prgname (), subcommand_name);
   g_set_prgname (prgname);
 
-  RpmOstreeCommandInvocation sub_invocation = { .command = subcommand };
-  return subcommand->fn (argc, argv, &sub_invocation, cancellable, error);
+  /* We need a new sub-invocation with the new command, which also carries a new
+   * exit code, but we'll proxy the latter. */
+  RpmOstreeCommandInvocation sub_invocation = { .command = subcommand, .exit_code = -1 };
+  gboolean ret = subcommand->fn (argc, argv, &sub_invocation, cancellable, error);
+  /* Proxy the exit code */
+  invocation->exit_code = sub_invocation.exit_code;
+  return ret;
 }
 
 int
@@ -357,10 +362,15 @@ main (int    argc,
 {
   GCancellable *cancellable = g_cancellable_new ();
   RpmOstreeCommand *command;
-  int exit_status = EXIT_SUCCESS;
   const char *command_name = NULL;
   g_autofree char *prgname = NULL;
   GError *local_error = NULL;
+  /* We can leave this function with an error status from both a command
+   * invocation, as well as an option processing failure. Keep an alias to the
+   * two places that hold status codes.
+   */
+  int exit_status = EXIT_SUCCESS;
+  int *exit_statusp = &exit_status;
 
   /* avoid gvfs (http://bugzilla.gnome.org/show_bug.cgi?id=526454) */
   g_setenv ("GIO_USE_VFS", "local", TRUE);
@@ -409,16 +419,28 @@ main (int    argc,
       help = g_option_context_get_help (context, FALSE, NULL);
       g_printerr ("%s", help);
       exit_status = EXIT_FAILURE;
-
       goto out;
     }
 
   prgname = g_strdup_printf ("%s %s", g_get_prgname (), command_name);
   g_set_prgname (prgname);
 
-  { RpmOstreeCommandInvocation invocation = { .command = command };
-    exit_status = command->fn (argc, argv, &invocation, cancellable, &local_error);
-  }
+  RpmOstreeCommandInvocation invocation = { .command = command,
+                                            .exit_code = -1 };
+  exit_statusp = &(invocation.exit_code);
+  if (!command->fn (argc, argv, &invocation, cancellable, &local_error))
+    {
+      if (invocation.exit_code == -1)
+        invocation.exit_code = EXIT_FAILURE;
+      goto out;
+    }
+  else
+    {
+      if (invocation.exit_code == -1)
+        invocation.exit_code = EXIT_SUCCESS;
+      else
+        g_assert (invocation.exit_code != EXIT_SUCCESS);
+    }
 
  out:
   if (local_error != NULL)
@@ -434,13 +456,9 @@ main (int    argc,
       g_dbus_error_strip_remote_error (local_error);
       g_printerr ("%serror: %s%s\n", prefix, suffix, local_error->message);
       g_error_free (local_error);
-
-      /* Print a warning if the exit status indicates success when we
-       * actually had an error, so it gets reported and fixed quickly. */
-      g_warn_if_fail (exit_status != EXIT_SUCCESS);
     }
 
   rpmostree_polkit_agent_close ();
 
-  return exit_status;
+  return *exit_statusp;
 }

--- a/src/app/rpmostree-builtin-cancel.c
+++ b/src/app/rpmostree-builtin-cancel.c
@@ -56,7 +56,7 @@ on_active_txn_path_changed (GObject    *object,
   g_main_context_wakeup (NULL);
 }
 
-int
+gboolean
 rpmostree_builtin_cancel (int             argc,
                           char          **argv,
                           RpmOstreeCommandInvocation *invocation,
@@ -76,7 +76,7 @@ rpmostree_builtin_cancel (int             argc,
                                        &sysroot_proxy,
                                        &peer_pid,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
 
   /* Keep track of the txn path we saw first, as well as checking if it changed
@@ -86,7 +86,7 @@ rpmostree_builtin_cancel (int             argc,
   glnx_unref_object RPMOSTreeTransaction *txn_proxy = NULL;
   if (!rpmostree_transaction_connect_active (sysroot_proxy, &txn_path, &txn_proxy,
                                              cancellable, error))
-    return EXIT_FAILURE;
+    return FALSE;
   if (!txn_proxy)
     {
       /* Let's not make this an error; cancellation may race with completion.
@@ -94,7 +94,7 @@ rpmostree_builtin_cancel (int             argc,
        * "recently" but eh.
        */
       g_print ("No active transaction.\n");
-      return EXIT_SUCCESS;
+      return TRUE;
     }
 
   const char *title = rpmostree_transaction_get_title (txn_proxy);
@@ -117,5 +117,5 @@ rpmostree_builtin_cancel (int             argc,
     }
   g_print ("Cancelled.\n");
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }

--- a/src/app/rpmostree-builtin-cleanup.c
+++ b/src/app/rpmostree-builtin-cleanup.c
@@ -45,7 +45,7 @@ static GOptionEntry option_entries[] = {
   { NULL }
 };
 
-int
+gboolean
 rpmostree_builtin_cleanup (int             argc,
                            char          **argv,
                            RpmOstreeCommandInvocation *invocation,
@@ -68,12 +68,12 @@ rpmostree_builtin_cleanup (int             argc,
                                        &sysroot_proxy,
                                        &peer_pid,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (argc < 1 || argc > 2)
     {
       rpmostree_usage_error (context, "Too few or too many arguments", error);
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   if (opt_base)
@@ -87,27 +87,27 @@ rpmostree_builtin_cleanup (int             argc,
   if (cleanup_types->len == 0)
     {
       glnx_throw (error, "At least one cleanup option must be specified");
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   g_ptr_array_add (cleanup_types, NULL);
 
   if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
                                 cancellable, &os_proxy, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (!rpmostree_os_call_cleanup_sync (os_proxy,
                                        (const char *const*)cleanup_types->pdata,
                                        &transaction_address,
                                        cancellable,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
                                                 transaction_address,
                                                 cancellable,
                                                 error))
-    return EXIT_FAILURE;
+    return FALSE;
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }

--- a/src/app/rpmostree-builtin-compose.c
+++ b/src/app/rpmostree-builtin-compose.c
@@ -44,7 +44,7 @@ static RpmOstreeCommand compose_subcommands[] = {
   { NULL, 0, NULL, NULL }
 };
 
-int
+gboolean
 rpmostree_builtin_compose (int argc, char **argv,
                            RpmOstreeCommandInvocation *invocation,
                            GCancellable *cancellable, GError **error)

--- a/src/app/rpmostree-builtin-container.c
+++ b/src/app/rpmostree-builtin-container.c
@@ -34,7 +34,7 @@ static RpmOstreeCommand container_subcommands[] = {
   { NULL, 0, NULL, NULL }
 };
 
-int
+gboolean
 rpmostree_builtin_container (int argc, char **argv,
                              RpmOstreeCommandInvocation *invocation,
                              GCancellable *cancellable, GError **error)

--- a/src/app/rpmostree-builtin-db.c
+++ b/src/app/rpmostree-builtin-db.c
@@ -90,7 +90,7 @@ rpmostree_db_option_context_parse (GOptionContext *context,
   return TRUE;
 }
 
-int
+gboolean
 rpmostree_builtin_db (int argc, char **argv,
                       RpmOstreeCommandInvocation *invocation,
                       GCancellable *cancellable, GError **error)

--- a/src/app/rpmostree-builtin-ex.c
+++ b/src/app/rpmostree-builtin-ex.c
@@ -43,7 +43,7 @@ static GOptionEntry global_entries[] = {
 };
 */
 
-int
+gboolean
 rpmostree_builtin_ex (int argc, char **argv,
                       RpmOstreeCommandInvocation *invocation,
                       GCancellable *cancellable, GError **error)

--- a/src/app/rpmostree-builtin-initramfs.c
+++ b/src/app/rpmostree-builtin-initramfs.c
@@ -55,7 +55,7 @@ get_args_variant (void)
   return g_variant_dict_end (&dict);
 }
 
-int
+gboolean
 rpmostree_builtin_initramfs (int             argc,
                              char          **argv,
                              RpmOstreeCommandInvocation *invocation,
@@ -75,12 +75,12 @@ rpmostree_builtin_initramfs (int             argc,
                                        &sysroot_proxy,
                                        &peer_pid,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
                                 cancellable, &os_proxy, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (!(opt_enable || opt_disable))
     {
@@ -91,7 +91,7 @@ rpmostree_builtin_initramfs (int             argc,
         {
           g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                                "--reboot must be used with --enable or --disable");
-          return EXIT_FAILURE;
+          return FALSE;
         }
 
       g_variant_iter_init (&iter, deployments);
@@ -135,7 +135,7 @@ rpmostree_builtin_initramfs (int             argc,
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                    "Cannot simultaenously specify --enable and --disable");
-      return EXIT_FAILURE;
+      return FALSE;
     }
   else
     {
@@ -144,7 +144,7 @@ rpmostree_builtin_initramfs (int             argc,
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
                        "Cannot simultaenously specify --disable and --arg");
-          return EXIT_FAILURE;
+          return FALSE;
         }
       if (!opt_add_arg)
         opt_add_arg = empty_strv;
@@ -157,16 +157,16 @@ rpmostree_builtin_initramfs (int             argc,
                                                        &transaction_address,
                                                        cancellable,
                                                        error))
-        return EXIT_FAILURE;
+        return FALSE;
 
       if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
                                                     transaction_address,
                                                     cancellable,
                                                     error))
-        return EXIT_FAILURE;
+        return FALSE;
 
       g_print ("Initramfs regeneration is now: %s\n", opt_enable ? "enabled" : "disabled");
     }
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }

--- a/src/app/rpmostree-builtin-livefs.c
+++ b/src/app/rpmostree-builtin-livefs.c
@@ -69,14 +69,14 @@ rpmostree_ex_builtin_livefs (int             argc,
                                        &sysroot_proxy,
                                        &peer_pid,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeOSExperimental *osexperimental_proxy = NULL;
   if (!rpmostree_load_os_proxies (sysroot_proxy, NULL,
                                   cancellable, &os_proxy,
                                   &osexperimental_proxy, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   g_autofree char *transaction_address = NULL;
   if (!rpmostree_osexperimental_call_live_fs_sync (osexperimental_proxy,
@@ -84,13 +84,13 @@ rpmostree_ex_builtin_livefs (int             argc,
                                                    &transaction_address,
                                                    cancellable,
                                                    error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
                                                 transaction_address,
                                                 cancellable,
                                                 error))
-    return EXIT_FAILURE;
+    return FALSE;
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }

--- a/src/app/rpmostree-builtin-override.c
+++ b/src/app/rpmostree-builtin-override.c
@@ -36,7 +36,7 @@ static RpmOstreeCommand override_subcommands[] = {
   { NULL, 0, NULL, NULL }
 };
 
-int
+gboolean
 rpmostree_builtin_override (int argc, char **argv,
                             RpmOstreeCommandInvocation *invocation,
                             GCancellable *cancellable, GError **error)

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -49,7 +49,7 @@ static GOptionEntry option_entries[] = {
   { NULL }
 };
 
-int
+gboolean
 rpmostree_builtin_rebase (int             argc,
                           char          **argv,
                           RpmOstreeCommandInvocation *invocation,
@@ -81,17 +81,17 @@ rpmostree_builtin_rebase (int             argc,
                                        &sysroot_proxy,
                                        &peer_pid,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (argc > 3)
     {
       rpmostree_usage_error (context, "Too many arguments", error);
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
                                 cancellable, &os_proxy, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (argc < 2 && !(opt_branch || opt_remote))
     {
@@ -140,7 +140,7 @@ rpmostree_builtin_rebase (int             argc,
                                         &transaction_address,
                                         cancellable,
                                         error))
-        return EXIT_FAILURE;
+        return FALSE;
     }
   else
     {
@@ -163,10 +163,10 @@ rpmostree_builtin_rebase (int             argc,
                                           NULL,
                                           cancellable,
                                           error))
-        return EXIT_FAILURE;
+        return FALSE;
     }
 
-  return rpmostree_transaction_client_run (sysroot_proxy, os_proxy,
+  return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy,
                                            options, FALSE,
                                            transaction_address,
                                            previous_deployment,

--- a/src/app/rpmostree-builtin-refresh-md.c
+++ b/src/app/rpmostree-builtin-refresh-md.c
@@ -46,7 +46,7 @@ get_args_variant (void)
   return g_variant_dict_end (&dict);
 }
 
-int
+gboolean
 rpmostree_builtin_refresh_md (int             argc,
                               char          **argv,
                               RpmOstreeCommandInvocation *invocation,
@@ -68,30 +68,30 @@ rpmostree_builtin_refresh_md (int             argc,
                                        &sysroot_proxy,
                                        &peer_pid,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (argc < 1 || argc > 2)
     {
       rpmostree_usage_error (context, "Too few or too many arguments", error);
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
                                 cancellable, &os_proxy, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (!rpmostree_os_call_refresh_md_sync (os_proxy,
                                           get_args_variant (),
                                           &transaction_address,
                                           cancellable,
                                           error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
                                                 transaction_address,
                                                 cancellable,
                                                 error))
-    return EXIT_FAILURE;
+    return FALSE;
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }

--- a/src/app/rpmostree-builtin-reload.c
+++ b/src/app/rpmostree-builtin-reload.c
@@ -33,7 +33,7 @@ static GOptionEntry option_entries[] = {
   { NULL }
 };
 
-int
+gboolean
 rpmostree_builtin_reload (int             argc,
                           char          **argv,
                           RpmOstreeCommandInvocation *invocation,
@@ -53,10 +53,10 @@ rpmostree_builtin_reload (int             argc,
                                        &sysroot_proxy,
                                        &peer_pid,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (!rpmostree_sysroot_call_reload_config_sync (sysroot_proxy, cancellable, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }

--- a/src/app/rpmostree-builtin-rollback.c
+++ b/src/app/rpmostree-builtin-rollback.c
@@ -47,7 +47,7 @@ get_args_variant (void)
   return g_variant_dict_end (&dict);
 }
 
-int
+gboolean
 rpmostree_builtin_rollback (int             argc,
                             char          **argv,
                             RpmOstreeCommandInvocation *invocation,
@@ -69,11 +69,11 @@ rpmostree_builtin_rollback (int             argc,
                                        &sysroot_proxy,
                                        &peer_pid,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (!rpmostree_load_os_proxy (sysroot_proxy, NULL,
                                 cancellable, &os_proxy, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
   /* really, rollback only supports the "reboot" option; all others are ignored */
@@ -92,9 +92,9 @@ rpmostree_builtin_rollback (int             argc,
                                         &transaction_address,
                                         cancellable,
                                         error))
-    return EXIT_FAILURE;
+    return FALSE;
 
-  return rpmostree_transaction_client_run (sysroot_proxy, os_proxy,
+  return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy,
                                            options, FALSE,
                                            transaction_address,
                                            previous_deployment,

--- a/src/app/rpmostree-builtin-start-daemon.c
+++ b/src/app/rpmostree-builtin-start-daemon.c
@@ -288,8 +288,7 @@ connect_to_peer (int fd, GError **error)
   return TRUE;
 }
 
-
-int
+gboolean
 rpmostree_builtin_start_daemon (int             argc,
                                 char          **argv,
                                 RpmOstreeCommandInvocation *invocation,
@@ -300,7 +299,7 @@ rpmostree_builtin_start_daemon (int             argc,
   g_option_context_add_main_entries (opt_context, opt_entries, NULL);
 
   if (!g_option_context_parse (opt_context, &argc, &argv, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (opt_debug)
     {
@@ -339,15 +338,15 @@ rpmostree_builtin_start_daemon (int             argc,
       /* Get an explicit ref to the bus so we can use it later */
       bus = g_bus_get_sync (bus_type, NULL, error);
       if (!bus)
-        return EXIT_FAILURE;
+        return FALSE;
       if (!start_daemon (bus, error))
-        return EXIT_FAILURE;
+        return FALSE;
       (void) g_bus_own_name_on_connection (bus, DBUS_NAME, G_BUS_NAME_OWNER_FLAGS_NONE,
                                            on_name_acquired, on_name_lost,
                                            NULL, NULL);
     }
   else if (!connect_to_peer (service_dbus_fd, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   state_transition (APPSTATE_RUNNING);
 
@@ -386,5 +385,5 @@ rpmostree_builtin_start_daemon (int             argc,
   while (appstate == APPSTATE_FLUSHING)
     g_main_context_iteration (mainctx, TRUE);
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -654,7 +654,7 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
   return TRUE;
 }
 
-int
+gboolean
 rpmostree_builtin_status (int             argc,
                           char          **argv,
                           RpmOstreeCommandInvocation *invocation,
@@ -676,18 +676,18 @@ rpmostree_builtin_status (int             argc,
                                        &sysroot_proxy,
                                        &peer_pid,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (opt_json && opt_jsonpath)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
                    "Cannot specify both --json and --jsonpath");
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   if (!rpmostree_load_os_proxy (sysroot_proxy, NULL,
                                 cancellable, &os_proxy, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   deployments = rpmostree_sysroot_dup_deployments (sysroot_proxy);
 
@@ -716,7 +716,7 @@ rpmostree_builtin_status (int             argc,
           if (!result)
             {
               g_prefix_error (error, "While compiling jsonpath: ");
-              return EXIT_FAILURE;
+              return FALSE;
             }
           json_generator_set_root (generator, result);
           json_node_free (result);
@@ -727,14 +727,14 @@ rpmostree_builtin_status (int             argc,
       glnx_unref_object GOutputStream *stdout_gio = g_unix_output_stream_new (1, FALSE);
       if (json_generator_to_stream (generator, stdout_gio, NULL, error) <= 0
           || (error != NULL && *error != NULL))
-        return EXIT_FAILURE;
+        return FALSE;
     }
   else
     {
       if (!status_generic (sysroot_proxy, os_proxy, deployments,
                            cancellable, error))
-        return EXIT_FAILURE;
+        return FALSE;
     }
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }

--- a/src/app/rpmostree-builtin-types.h
+++ b/src/app/rpmostree-builtin-types.h
@@ -1,0 +1,57 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Colin Walters <walters@verbum.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include "ostree.h"
+
+G_BEGIN_DECLS
+
+/* Exit code for no change after pulling commits.
+ * Use alongside EXIT_SUCCESS and EXIT_FAILURE. */
+#define RPM_OSTREE_EXIT_UNCHANGED  (77)
+
+typedef enum {
+  RPM_OSTREE_BUILTIN_FLAG_NONE = 0,
+  RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD = 1 << 0,
+  RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT = 1 << 1,
+  RPM_OSTREE_BUILTIN_FLAG_HIDDEN = 1 << 2,
+  RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS = 1 << 3,
+} RpmOstreeBuiltinFlags;
+
+typedef struct RpmOstreeCommand RpmOstreeCommand;
+typedef struct RpmOstreeCommandInvocation RpmOstreeCommandInvocation;
+
+struct RpmOstreeCommand {
+  const char *name;
+  RpmOstreeBuiltinFlags flags;
+  const char *description; /* a short decription to describe the functionality */
+  int (*fn) (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
+};
+
+/* @command: Passed from core cmdline parsing to cmds
+ * @exit_code: Set by commands; default -1 meaning "if GError is set exit 1, otherwise 0"
+ */
+struct RpmOstreeCommandInvocation {
+  RpmOstreeCommand *command;
+  int exit_code;
+};
+G_END_DECLS
+

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -21,39 +21,10 @@
 #pragma once
 
 #include "ostree.h"
+#include "rpmostree-builtin-types.h"
 #include "rpmostree-dbus-helpers.h"
 
 G_BEGIN_DECLS
-
-/* Exit code for no change after pulling commits.
- * Use alongside EXIT_SUCCESS and EXIT_FAILURE. */
-#define RPM_OSTREE_EXIT_UNCHANGED  (77)
-
-typedef enum {
-  RPM_OSTREE_BUILTIN_FLAG_NONE = 0,
-  RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD = 1 << 0,
-  RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT = 1 << 1,
-  RPM_OSTREE_BUILTIN_FLAG_HIDDEN = 1 << 2,
-  RPM_OSTREE_BUILTIN_FLAG_SUPPORTS_PKG_INSTALLS = 1 << 3,
-} RpmOstreeBuiltinFlags;
-
-typedef struct RpmOstreeCommand RpmOstreeCommand;
-typedef struct RpmOstreeCommandInvocation RpmOstreeCommandInvocation;
-
-struct RpmOstreeCommand {
-  const char *name;
-  RpmOstreeBuiltinFlags flags;
-  const char *description; /* a short decription to describe the functionality */
-  int (*fn) (int argc, char **argv, RpmOstreeCommandInvocation *invocation, GCancellable *cancellable, GError **error);
-};
-
-/* Currently, this has just the command (which is mostly there for the
- * name/flags), but in the future if we want to add something new we won't need
- * to touch every prototype.
- */
-struct RpmOstreeCommandInvocation {
-  RpmOstreeCommand *command;
-};
 
 #define BUILTINPROTO(name) gboolean rpmostree_builtin_ ## name (int argc, char **argv, \
                                                                 RpmOstreeCommandInvocation *invocation, \

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -44,25 +44,25 @@ rpmostree_db_builtin_diff (int argc, char **argv,
   g_autoptr(OstreeRepo) repo = NULL;
   if (!rpmostree_db_option_context_parse (context, option_entries, &argc, &argv, invocation,
                                           &repo, cancellable, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (argc != 3)
     {
       g_autofree char *message =
         g_strdup_printf ("\"%s\" takes exactly 2 arguments", g_get_prgname ());
       rpmostree_usage_error (context, message, error);
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   const char *old_ref = argv[1];
   g_autofree char *old_checksum = NULL;
   if (!ostree_repo_resolve_rev (repo, old_ref, FALSE, &old_checksum, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   const char *new_ref = argv[2];
   g_autofree char *new_checksum = NULL;
   if (!ostree_repo_resolve_rev (repo, new_ref, FALSE, &new_checksum, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (!g_str_equal (old_ref, old_checksum))
     printf ("ostree diff commit old: %s (%s)\n", old_ref, old_checksum);
@@ -96,19 +96,16 @@ rpmostree_db_builtin_diff (int argc, char **argv,
     {
       if (!rpm_ostree_db_diff (repo, old_ref, new_ref, &removed, &added, &modified_old,
                                &modified_new, cancellable, error))
-        return EXIT_FAILURE;
+        return FALSE;
 
       if (g_str_equal (opt_format, "diff"))
         rpmostree_diff_print (removed, added, modified_old, modified_new);
       else if (g_str_equal (opt_format, "block"))
         rpmostree_diff_print_formatted (removed, added, modified_old, modified_new);
       else
-        {
-          glnx_throw (error, "Format argument is invalid, pick one of: diff, block");
-          return EXIT_FAILURE;
-        }
+        return glnx_throw (error, "Format argument is invalid, pick one of: diff, block");
     }
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }
 

--- a/src/app/rpmostree-db-builtin-list.c
+++ b/src/app/rpmostree-db-builtin-list.c
@@ -89,7 +89,7 @@ rpmostree_db_builtin_list (int argc, char **argv,
   g_autoptr(OstreeRepo) repo = NULL;
   if (!rpmostree_db_option_context_parse (context, option_entries, &argc, &argv,
                                           invocation, &repo, cancellable, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   /* Iterate over all arguments. When we see the first argument which
    * appears to be an OSTree commit, take all other arguments to be
@@ -119,8 +119,8 @@ rpmostree_db_builtin_list (int argc, char **argv,
     }
 
   if (!_builtin_db_list (repo, revs, patterns, cancellable, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }
 

--- a/src/app/rpmostree-db-builtin-version.c
+++ b/src/app/rpmostree-db-builtin-version.c
@@ -95,7 +95,7 @@ rpmostree_db_builtin_version (int argc, char **argv,
   if (!rpmostree_db_option_context_parse (context, db_version_entries, &argc,
                                           &argv, invocation, &repo, cancellable,
                                           error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   g_autoptr(GPtrArray) revs = g_ptr_array_new ();
 
@@ -103,8 +103,8 @@ rpmostree_db_builtin_version (int argc, char **argv,
     g_ptr_array_add (revs, argv[ii]);
 
   if (!_builtin_db_version (repo, revs, cancellable, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }
 

--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -781,11 +781,10 @@ out:
 /* Handles client-side processing for most command line tools
  * after a transaction has been started.  Wraps invocation
  * of rpmostree_transaction_get_response_sync().
- *
- * Returns: A Unix exit code (normally 0 or 1, may be 77 if exit_unchanged_77 is enabled)
  */
-int
-rpmostree_transaction_client_run (RPMOSTreeSysroot *sysroot_proxy,
+gboolean
+rpmostree_transaction_client_run (RpmOstreeCommandInvocation *invocation,
+                                  RPMOSTreeSysroot *sysroot_proxy,
                                   RPMOSTreeOS      *os_proxy,
                                   GVariant         *options,
                                   gboolean          exit_unchanged_77,
@@ -797,7 +796,7 @@ rpmostree_transaction_client_run (RPMOSTreeSysroot *sysroot_proxy,
   /* Wait for the txn to complete */
   if (!rpmostree_transaction_get_response_sync (sysroot_proxy, transaction_address,
                                                 cancellable, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   /* Process the result of the txn and our options */
 
@@ -817,8 +816,8 @@ rpmostree_transaction_client_run (RPMOSTreeSysroot *sysroot_proxy,
       if (!rpmostree_has_new_default_deployment (os_proxy, previous_deployment))
         {
           if (exit_unchanged_77)
-            return RPM_OSTREE_EXIT_UNCHANGED;
-          return EXIT_SUCCESS;
+            invocation->exit_code = RPM_OSTREE_EXIT_UNCHANGED;
+          return TRUE;
         }
       else
         {
@@ -827,13 +826,13 @@ rpmostree_transaction_client_run (RPMOSTreeSysroot *sysroot_proxy,
           if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                                cancellable,
                                                                error))
-            return EXIT_FAILURE;
+            return FALSE;
         }
 
       g_print ("Run \"systemctl reboot\" to start a reboot\n");
     }
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }
 
 void

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -23,6 +23,7 @@
 #include <gio/gunixfdlist.h>
 
 #include "rpm-ostreed-generated.h"
+#include "rpmostree-builtin-types.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -71,8 +72,9 @@ rpmostree_transaction_get_response_sync      (RPMOSTreeSysroot *sysroot_proxy,
                                               GCancellable *cancellable,
                                               GError **error);
 
-int /* Returns an exit status */
-rpmostree_transaction_client_run             (RPMOSTreeSysroot *sysroot_proxy,
+gboolean
+rpmostree_transaction_client_run             (RpmOstreeCommandInvocation *invocation,
+                                              RPMOSTreeSysroot *sysroot_proxy,
                                               RPMOSTreeOS      *os_proxy,
                                               GVariant         *options,
                                               gboolean          exit_unchanged_77,

--- a/src/app/rpmostree-ex-builtin-commit2jigdo.c
+++ b/src/app/rpmostree-ex-builtin-commit2jigdo.c
@@ -67,18 +67,18 @@ rpmostree_ex_builtin_commit2jigdo (int             argc,
                                        cancellable,
                                        NULL, NULL, NULL, NULL,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (argc != 4)
     {
       rpmostree_usage_error (context, "REV OIRPM-SPEC OUTPUTDIR are required", error);
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   if (!(opt_repo && opt_pkgcache_repo))
     {
       rpmostree_usage_error (context, "--repo and --pkgcache-repo must be specified", error);
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   const char *rev = argv[1];
@@ -89,13 +89,13 @@ rpmostree_ex_builtin_commit2jigdo (int             argc,
 
   g_autoptr(OstreeRepo) repo = ostree_repo_open_at (AT_FDCWD, opt_repo, cancellable, error);
   if (!repo)
-    return EXIT_FAILURE;
+    return FALSE;
   g_autoptr(OstreeRepo) pkgcache_repo = ostree_repo_open_at (AT_FDCWD, opt_pkgcache_repo, cancellable, error);
   if (!pkgcache_repo)
-    return EXIT_FAILURE;
+    return FALSE;
   if (!rpmostree_commit2jigdo (repo, pkgcache_repo, rev, oirpm_spec, outputdir,
                                cancellable, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }

--- a/src/app/rpmostree-ex-builtin-jigdo2commit.c
+++ b/src/app/rpmostree-ex-builtin-jigdo2commit.c
@@ -367,27 +367,27 @@ rpmostree_ex_builtin_jigdo2commit (int             argc,
                                        cancellable,
                                        NULL, NULL, NULL, NULL,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (argc != 2)
    {
       rpmostree_usage_error (context, "REPOID:OIRPM-NAME is required", error);
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   if (!opt_repo)
     {
       rpmostree_usage_error (context, "--repo must be specified", error);
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   const char *oirpm = argv[1];
 
   g_autoptr(RpmOstreeJigdo2CommitContext) self = NULL;
   if (!rpm_ostree_jigdo2commit_context_new (&self, cancellable, error))
-    return EXIT_FAILURE;
+    return FALSE;
   if (!impl_jigdo2commit (self, oirpm, cancellable, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }

--- a/src/app/rpmostree-override-builtins.c
+++ b/src/app/rpmostree-override-builtins.c
@@ -55,7 +55,7 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   if (!rpmostree_load_os_proxy (sysroot_proxy, opt_osname,
                                 cancellable, &os_proxy, error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   /* Perform uninstalls offline; users don't expect the "auto-update" behaviour here. But
    * note we might still need to fetch pkgs in the local replacement case (e.g. the
@@ -85,13 +85,13 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
                                     &transaction_address,
                                     cancellable,
                                     error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (!rpmostree_transaction_get_response_sync (sysroot_proxy,
                                                 transaction_address,
                                                 cancellable,
                                                 error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (opt_dry_run)
     {
@@ -104,12 +104,12 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
                                                            cancellable,
                                                            error))
-        return EXIT_FAILURE;
+        return FALSE;
 
       g_print ("Run \"systemctl reboot\" to start a reboot\n");
     }
 
-  return EXIT_SUCCESS;
+  return TRUE;
 }
 
 gboolean
@@ -134,13 +134,13 @@ rpmostree_override_builtin_replace (int argc, char **argv,
                                        &sysroot_proxy,
                                        &peer_pid,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (argc < 2)
     {
       rpmostree_usage_error (context, "At least one PACKAGE must be specified",
                              error);
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   /* shift to first pkgspec and ensure it's a proper strv (previous parsing
@@ -175,13 +175,13 @@ rpmostree_override_builtin_remove (int argc, char **argv,
                                        &sysroot_proxy,
                                        &peer_pid,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (argc < 2)
     {
       rpmostree_usage_error (context, "At least one PACKAGE must be specified",
                              error);
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   /* shift to first pkgspec and ensure it's a proper strv (previous parsing
@@ -218,19 +218,19 @@ rpmostree_override_builtin_reset (int argc, char **argv,
                                        &sysroot_proxy,
                                        &peer_pid,
                                        error))
-    return EXIT_FAILURE;
+    return FALSE;
 
   if (argc < 2 && !opt_reset_all)
     {
       rpmostree_usage_error (context, "At least one PACKAGE must be specified",
                              error);
-      return EXIT_FAILURE;
+      return FALSE;
     }
   else if (opt_reset_all && argc >= 2)
     {
       rpmostree_usage_error (context, "Cannot specify PACKAGEs with --all",
                              error);
-      return EXIT_FAILURE;
+      return FALSE;
     }
 
   /* shift to first pkgspec and ensure it's a proper strv (previous parsing

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -56,7 +56,7 @@ static GOptionEntry install_option_entry[] = {
   { NULL }
 };
 
-static int
+static gboolean
 pkg_change (RpmOstreeCommandInvocation *invocation,
             RPMOSTreeSysroot *sysroot_proxy,
             const char *const* packages_to_add,


### PR DESCRIPTION
We've had many bugs from internal helpers using `return EXIT_FAILURE` rather
than `return FALSE`.  The reason we need exit codes is to handle the
`RPM_OSTREE_EXIT_UNCHANGED` case. I realized recently that we had the handy
`RpmOstreeCommandInvocation` which we can use to signal back this special case.
Then all of our functions otherwise are just normal `GError`.

One minor wart here is the two cases of "usage error" versus "command
invocation" in `main.c`, but IMO the general cleanup is well worth that.