### PR TITLE
bwrap: Use rofiles-fuse --copyup by default

### DIFF
--- a/src/libpriv/rpmostree-bwrap.c
+++ b/src/libpriv/rpmostree-bwrap.c
@@ -150,13 +150,13 @@ static gboolean
 setup_rofiles_usr (RpmOstreeBwrap *bwrap,
                    GError **error)
 {
-  const char *rofiles_argv[] = { "rofiles-fuse", "./usr", NULL, NULL};
+  const char *rofiles_argv[] = { "rofiles-fuse", "--copyup", "./usr", NULL, NULL};
 
   if (!glnx_mkdtemp ("rpmostree-rofiles-fuse.XXXXXX", 0700, &bwrap->rofiles_mnt, error))
     return FALSE;
 
   const char *rofiles_mntpath = bwrap->rofiles_mnt.path;
-  rofiles_argv[2] = rofiles_mntpath;
+  rofiles_argv[3] = rofiles_mntpath;
 
   int estatus;
   if (!g_spawn_sync (NULL, (char**)rofiles_argv, NULL, G_SPAWN_SEARCH_PATH,

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -154,18 +154,8 @@ fi
 
 # Should work now that we're using --copyup
 # https://github.com/projectatomic/rpm-ostree/pull/1171
-test_overwritepath=
-for path in /usr/share/licenses/glibc/COPYING
-            /usr/share/systemd/kbd-model-map
-            /usr/share/rpm-ostree/treefile.json; do
-    if vm_cmd test -f ${path}; then
-        test_overwritepath=${path}
-        break
-    fi
-done
-test -n "${test_overwritepath}" || fatal "failed to find test file"
 vm_build_rpm rofiles-copyup \
-  post "echo copyup >> ${test_overwritepath}"
+             post "echo copyup >> /usr/share/rpm-ostree/treefile.json"
 vm_rpmostree install rofiles-copyup
 vm_rpmostree uninstall rofiles-copyup
 

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -152,12 +152,12 @@ vm_rpmostree uninstall scriptpkg{4,5}
 echo "ok transfiletriggerin"
 fi
 
-# And now, things that should fail
-vm_build_rpm rofiles-violation \
-  post "echo should fail >> /usr/share/licenses/glibc/COPYING"
-if vm_rpmostree install rofiles-violation; then
-    assert_not_reached "installed test-post-rofiles-violation!"
-fi
+# Should work now that we're using --copyup
+# https://github.com/projectatomic/rpm-ostree/pull/1171
+vm_build_rpm rofiles-copyup \
+  post "echo copyup >> /usr/share/licenses/glibc/COPYING"
+vm_rpmostree install rofiles-copyup
+vm_rpmostree uninstall rofiles-copyup
 
 # Test cancellation via having a script hang; we interrupt directly by sending
 # SIGINT to the client binary.
@@ -212,10 +212,10 @@ vm_rpmostree ex livefs
 vm_cmd cat /usr/share/rpmostree-capsh.txt > caps.txt
 assert_not_file_has_content caps.test '^Current: =.*cap_sys_admin'
 
+# See also rofiles-copyup above
 vm_build_rpm etc-mutate post "truncate -s 0 /etc/selinux/config"
-if vm_rpmostree install etc-mutate; then
-  assert_not_reached "successfully installed etc-mutate?"
-fi
+vm_rpmostree install etc-mutate
+vm_rpmostree uninstall etc-mutate
 
 # SYSTEMD_OFFLINE
 vm_build_rpm test-systemd-offline post 'test "${SYSTEMD_OFFLINE}" = 1'

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -154,8 +154,18 @@ fi
 
 # Should work now that we're using --copyup
 # https://github.com/projectatomic/rpm-ostree/pull/1171
+test_overwritepath=
+for path in /usr/share/licenses/glibc/COPYING
+            /usr/share/systemd/kbd-model-map
+            /usr/share/rpm-ostree/treefile.json; do
+    if vm_cmd test -f ${path}; then
+        test_overwritepath=${path}
+        break
+    fi
+done
+test -n "${test_overwritepath}" || fatal "failed to find test file"
 vm_build_rpm rofiles-copyup \
-  post "echo copyup >> /usr/share/licenses/glibc/COPYING"
+  post "echo copyup >> ${test_overwritepath}"
 vm_rpmostree install rofiles-copyup
 vm_rpmostree uninstall rofiles-copyup
 


### PR DESCRIPTION
This fixes a large swath of compatibility issues, for the same reasons as
overlayfs makes a lot of things Just Work.  The ugly part of course is
doing hidden copyups inside the filesystem.

We've gone quite a long time with the "pure rofiles" mode, and have made changes
to various bits of userspace to be compatible with it. But what finally made me
give up on that is glibc's locale-archive; there's a patch for it that
is stalled, but even if it was applied we would still need to work with
older glibc.

This issue comes to the fore in unified core 🌐 mode, as without this
we won't get a correct locale archive.
