### PR TITLE
core,compose: Fix unified core pkgcache labeling

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -531,8 +531,6 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
       /* Depending on cache state, we may have some pkgs already
        * labeled with a final target policy.
        */
-      if (!rpmostree_context_relabel (self->corectx, cancellable, error))
-        return FALSE;
       rpmostree_context_set_tmprootfs_dfd (self->corectx, rootfs_dfd);
       if (!rpmostree_context_assemble (self->corectx, cancellable, error))
         return FALSE;
@@ -545,7 +543,7 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
       g_autoptr(OstreeSePolicy) sepolicy = ostree_sepolicy_new_at (rootfs_dfd, cancellable, error);
       rpmostree_context_set_sepolicy (self->corectx, sepolicy);
 
-      if (!rpmostree_context_relabel (self->corectx, cancellable, error))
+      if (!rpmostree_context_force_relabel (self->corectx, cancellable, error))
         return FALSE;
     }
   else

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -528,9 +528,6 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
     {
       if (!rpmostree_context_import (self->corectx, cancellable, error))
         return FALSE;
-      /* Depending on cache state, we may have some pkgs already
-       * labeled with a final target policy.
-       */
       rpmostree_context_set_tmprootfs_dfd (self->corectx, rootfs_dfd);
       if (!rpmostree_context_assemble (self->corectx, cancellable, error))
         return FALSE;

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -886,9 +886,6 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
 
   if (self->layering_type == RPMOSTREE_SYSROOT_UPGRADER_LAYERING_RPMMD_REPOS)
     {
-      if (!rpmostree_context_relabel (self->ctx, cancellable, error))
-        return FALSE;
-
       g_clear_pointer (&self->final_revision, g_free);
 
       /* --- override/overlay and commit --- */

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1430,6 +1430,7 @@ sort_packages (RpmOstreeContext *self,
           g_ptr_array_add (self->pkgs_to_download, g_object_ref (pkg));
         if (!in_ostree)
           g_ptr_array_add (self->pkgs_to_import, g_object_ref (pkg));
+        /* This logic is equivalent to that in rpmostree_context_force_relabel() */
         if (in_ostree && !selinux_match)
           g_ptr_array_add (self->pkgs_to_relabel, g_object_ref (pkg));
       }
@@ -2671,10 +2672,10 @@ on_async_relabel_done (GObject                    *obj,
     self->async_running = FALSE;
 }
 
-gboolean
-rpmostree_context_relabel (RpmOstreeContext *self,
-                           GCancellable     *cancellable,
-                           GError          **error)
+static gboolean
+relabel_if_necessary (RpmOstreeContext *self,
+                      GCancellable     *cancellable,
+                      GError          **error)
 {
   if (!self->pkgs_to_relabel)
     return TRUE;
@@ -2737,6 +2738,40 @@ rpmostree_context_relabel (RpmOstreeContext *self,
   self->n_async_pkgs_relabeled = 0;
 
   return TRUE;
+}
+
+/* Forcibly relabel all packages */
+gboolean
+rpmostree_context_force_relabel (RpmOstreeContext *self,
+                                 GCancellable     *cancellable,
+                                 GError          **error)
+{
+  g_clear_pointer (&self->pkgs_to_relabel, (GDestroyNotify)g_ptr_array_unref);
+  self->pkgs_to_relabel = g_ptr_array_new_with_free_func ((GDestroyNotify)g_object_unref);
+
+  g_autoptr(GPtrArray) packages = dnf_goal_get_packages (dnf_context_get_goal (self->dnfctx),
+                                                         DNF_PACKAGE_INFO_INSTALL,
+                                                         DNF_PACKAGE_INFO_UPDATE,
+                                                         DNF_PACKAGE_INFO_DOWNGRADE, -1);
+
+  for (guint i = 0; i < packages->len; i++)
+    {
+      DnfPackage *pkg = packages->pdata[i];
+
+      if (g_cancellable_set_error_if_cancelled (cancellable, error))
+        return FALSE;
+
+      /* This logic is equivalent to that in sort_packages() */
+      gboolean in_ostree, selinux_match;
+      if (!find_pkg_in_ostree (self, pkg, self->sepolicy,
+                               &in_ostree, &selinux_match, error))
+        return FALSE;
+
+      if (in_ostree && !selinux_match)
+        g_ptr_array_add (self->pkgs_to_relabel, g_object_ref (pkg));
+    }
+
+  return relabel_if_necessary (self, cancellable, error);
 }
 
 typedef struct {
@@ -3181,6 +3216,12 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
     }
 
   int tmprootfs_dfd = self->tmprootfs_dfd; /* Alias to avoid bigger diff */
+
+  /* We need up to date labels; the set of things needing relabeling
+   * will have been calculated in sort_packages()
+   */
+  if (!relabel_if_necessary (self, cancellable, error))
+    return FALSE;
 
   DnfContext *dnfctx = self->dnfctx;
   TransactionData tdata = { 0, NULL };

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -173,9 +173,9 @@ gboolean rpmostree_context_import_jigdo (RpmOstreeContext *self,
                                          GCancellable     *cancellable,
                                          GError          **error);
 
-gboolean rpmostree_context_relabel (RpmOstreeContext *self,
-                                    GCancellable     *cancellable,
-                                    GError          **error);
+gboolean rpmostree_context_force_relabel (RpmOstreeContext *self,
+                                          GCancellable     *cancellable,
+                                          GError          **error);
 
 typedef enum {
   RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE,

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -38,6 +38,10 @@ ostree --repo=${repobuild} ls ${treeref} usr/etc/systemd/system/multi-user.targe
 assert_file_has_content_literal preset.txt '-> /usr/lib/systemd/system/chronyd.service'
 echo "ok systemctl preset"
 
+ostree --repo=${repobuild} ls -X ${treeref} usr/bin/docker-current > docker.txt
+assert_file_has_content_literal docker.txt 'system_u:object_r:container_runtime_exec_t:s0'
+echo "ok container-selinux"
+
 ostree --repo=${repobuild} ls ${treeref} /usr/bin/su > su.txt
 assert_file_has_content su.txt '^-04[71][0-7][0-7]'
 echo "ok setuid"

--- a/tests/composedata/fedora-base.json
+++ b/tests/composedata/fedora-base.json
@@ -4,7 +4,7 @@
     "repos": ["fedora", "updates"],
 
     "packages": ["kernel", "nss-altfiles", "systemd", "ostree", "selinux-policy-targeted", "chrony",
-                 "tuned", "iputils"],
+                 "tuned", "iputils", "fedora-release-atomichost", "docker", "container-selinux"],
 
     "packages-aarch64": ["grub2-efi", "ostree-grub2",
                          "efibootmgr", "shim"],


### PR DESCRIPTION
Basically the `rpmostree_context_relabel()` call we had in the treecompose path
for unified core didn't actually have any effect as the core code did a relabel
and unset the array.

I think this may actually be a regression from: https://github.com/projectatomic/rpm-ostree/pull/1137
though I didn't verify.

Anyways looking at this, the code is a lot simpler if we change the API so that
the "normal" relabeling is folded into `rpmostree_context_assemble()`. Then we
change the public relabel API to be "force relabel" which we use in the unified
core 🌐 treecompose path.

This shrinks the jigdoRPM for FAH from 90MB to 68MB.

Closes: https://github.com/projectatomic/rpm-ostree/issues/1172
