### PR TITLE
scripts: Suppress microcode_ctl posttrans

### DIFF
--- a/src/libpriv/rpmostree-script-gperf.gperf
+++ b/src/libpriv/rpmostree-script-gperf.gperf
@@ -41,3 +41,5 @@ systemd.transfiletriggerin, RPMOSTREE_SCRIPT_ACTION_IGNORE
 man-db.transfiletriggerin, RPMOSTREE_SCRIPT_ACTION_IGNORE
 # https://src.fedoraproject.org/rpms/nfs-utils/pull-request/1
 nfs-utils.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
+# https://bugzilla.redhat.com/show_bug.cgi?id=1199582
+microcode_ctl.posttrans, RPMOSTREE_SCRIPT_ACTION_IGNORE


### PR DESCRIPTION
Only applies to CentOS7.  Currently the package unconditionally
runs `dracut -f` which we need to handle internally.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1199582
