### PR TITLE
tests/compose: Pull in Fedora updates

### DIFF
--- a/tests/composedata/fedora-base.json
+++ b/tests/composedata/fedora-base.json
@@ -1,7 +1,7 @@
 {
     "ref": "fedora/stable/${basearch}",
 
-    "repos": ["fedora"],
+    "repos": ["fedora", "updates"],
 
     "packages": ["kernel", "nss-altfiles", "systemd", "ostree", "selinux-policy-targeted", "chrony",
                  "tuned", "iputils"],


### PR DESCRIPTION
In particular this gets us the selinux-policy fix for:
https://github.com/projectatomic/rpm-ostree/pull/1173#issuecomment-355014583

We might as well do updates since they have to work anyways.
