### PR TITLE
WIP --quiet option

### DIFF
--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -69,6 +69,8 @@ rpmostree_builtin_upgrade (int             argc,
   const char *const *install_pkgs = NULL;
   const char *const *uninstall_pkgs = NULL;
 
+  g_option_context_add_group (context, rpmostree_txn_common_options ());
+
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
                                        &argc, &argv,

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -91,6 +91,9 @@ rpmostree_print_signatures                   (GVariant *variant,
 void
 rpmostree_print_package_diffs                (GVariant *variant);
 
+
+GOptionGroup *rpmostree_txn_common_options (void);
+
 gboolean
 rpmostree_sort_pkgs_strv (const char *const* pkgs,
                           GUnixFDList  *fd_list,


### PR DESCRIPTION
For https://github.com/projectatomic/rpm-ostree/issues/1183

Playing with this briefly it's going to need some nontrivial work
to at least emit status information "once" so the user sees
*something* when we start a download etc.

  