### PR TITLE
ci/papr: Bump compose tests to 4 min vCPUs

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -94,7 +94,9 @@ required: true
 # docker --privileged run.
 host:
   distro: fedora/27/atomic
-  cpus: 4
+  # Compose tests are slow and should be parallelized
+  specs:
+    cpus: 4
 
 # Copy yum.repos.d to get any injected repos from the host, which
 # will point to a closer mirror.  Note we substitute $releasever

--- a/.papr.yml
+++ b/.papr.yml
@@ -94,6 +94,7 @@ required: true
 # docker --privileged run.
 host:
   distro: fedora/27/atomic
+  cpus: 4
 
 # Copy yum.repos.d to get any injected repos from the host, which
 # will point to a closer mirror.  Note we substitute $releasever


### PR DESCRIPTION
Compose is a slow test right now.  Down the line what I'd
like to do is: https://github.com/projectatomic/papr/pull/70
Since this job can be scheduled as a container, not a VM.  There's
no reason to grab a whole 8GB of RAM for it, but we *do* want multiple
CPUs.  Containers do that by default.
