### PR TITLE
tests/compose: Various fixes

### DIFF
--- a/tests/compose
+++ b/tests/compose
@@ -80,11 +80,19 @@ fi
 echo "Compose tests starting: $(date)"
 echo "Executing: ${tests}"
 echo "Writing logs to ${LOGDIR}"
+function postprocess_logs() {
+    # Help out S3 to have the right MIME type
+    for x in ${LOGDIR}/1/*.sh; do
+        if test -d ${x}; then
+            mv ${x}/{stdout,output.txt}
+            rm ${x}/stderr
+        fi
+    done
+}
+trap postprocess_logs EXIT
+# Note we merge stdout/stderr here since I don't see value
+# in separating them.
 (for tf in ${tests}; do echo $tf; done) | \
-    parallel --halt soon,fail=1 --results ${LOGDIR} ${dn}/compose-tests/{} |& tail
+    parallel -j +1 --progress --halt soon,fail=1 \
+             --results ${LOGDIR} /bin/sh -c "${dn}/compose-tests/{} 2>&1" |& tail
 echo "$(date): All tests passed"
-# Help out S3 to have the right MIME type
-for x in ${LOGDIR}/1/*.sh; do
-    mv ${x}/stdout{,.txt}
-    mv ${x}/stderr{,.txt}
-done

--- a/tests/compose-tests/libcomposetest.sh
+++ b/tests/compose-tests/libcomposetest.sh
@@ -1,8 +1,8 @@
 dn=$(cd $(dirname $0) && pwd)
-. ${dn}/../common/libtest.sh
 test_tmpdir=$(mktemp -d /var/tmp/rpm-ostree-compose-test.XXXXXX)
 touch ${test_tmpdir}/.test
 trap _cleanup_tmpdir EXIT
+. ${dn}/../common/libtest.sh
 cd ${test_tmpdir}
 
 pyeditjson() {

--- a/tests/compose-tests/libcomposetest.sh
+++ b/tests/compose-tests/libcomposetest.sh
@@ -2,8 +2,8 @@ dn=$(cd $(dirname $0) && pwd)
 test_tmpdir=$(mktemp -d /var/tmp/rpm-ostree-compose-test.XXXXXX)
 touch ${test_tmpdir}/.test
 trap _cleanup_tmpdir EXIT
-. ${dn}/../common/libtest.sh
 cd ${test_tmpdir}
+. ${dn}/../common/libtest.sh
 
 pyeditjson() {
     cat >editjson.py <<EOF


### PR DESCRIPTION
 - Actually use separate `${test_tmpdir}` for test setup (closes a race)
 - Ensure logs are renamed to `.txt` even on failure
 - Use `--progress` for some feedback
 - Use `-j +1` so that even on unicore machines we get at least 2
   jobs (and in general NCPUS+1)
