### PR TITLE
libpriv/rpm-util: just encode evr in pkglist

### DIFF
--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -1129,17 +1129,15 @@ rpmostree_create_rpmdb_pkglist_variant (int              rootfs_dfd,
   g_autoptr(GPtrArray) pkglist = rpmostree_sack_get_sorted_packages (refsack->sack);
 
   GVariantBuilder pkglist_v_builder;
-  g_variant_builder_init (&pkglist_v_builder, (GVariantType*)"a(stsss)");
+  g_variant_builder_init (&pkglist_v_builder, (GVariantType*)"a(sss)");
 
   const guint n = pkglist->len;
   for (guint i = 0; i < n; i++)
     {
       DnfPackage *pkg = pkglist->pdata[i];
-      g_variant_builder_add (&pkglist_v_builder, "(stsss)",
+      g_variant_builder_add (&pkglist_v_builder, "(sss)",
                              dnf_package_get_name (pkg),
-                             dnf_package_get_epoch (pkg),
-                             dnf_package_get_version (pkg),
-                             dnf_package_get_release (pkg),
+                             dnf_package_get_evr (pkg),
                              dnf_package_get_arch (pkg));
     }
 


### PR DESCRIPTION
I initially wanted to include all of `epoch`, `version`, and `release`
individually in the rpmdb.pkglist metadata in case we needed them
separately. Thinking more on this, I can't think of a really good reason
to have them, so since we're not public yet, let's just encode the `evr`
as a single string.

The reason I'm revisiting this is because it took me a while to hunt
down issues when handling epoch, which turned out to be the fact that we
weren't consistently committing as big endian (i.e. we did so in the
`compose tree` case, but not the layering case), and neither were we
consistently converting back from big endian. It's doable of course, but
the added gymnastics doesn't feel justified for the gains here.

This also nicely cleans up the `RpmOstreePackage` implementation to be
leaner and faster.