### PR TITLE
app/main: also return the bus type on option parsing

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -171,6 +171,7 @@ rpmostree_option_context_parse (GOptionContext *context,
                                 const char *const* *out_uninstall_pkgs,
                                 RPMOSTreeSysroot **out_sysroot_proxy,
                                 GPid *out_peer_pid,
+                                GBusType *out_bus_type,
                                 GError **error)
 {
   /* with --version there's no command, don't require a daemon for it */
@@ -236,6 +237,7 @@ rpmostree_option_context_parse (GOptionContext *context,
                                    cancellable,
                                    out_sysroot_proxy,
                                    out_peer_pid,
+                                   out_bus_type,
                                    error))
         return FALSE;
     }
@@ -323,7 +325,7 @@ rpmostree_handle_subcommand (int argc, char **argv,
                                              &argc, &argv,
                                              invocation,
                                              cancellable,
-                                             NULL, NULL, NULL, NULL, NULL);
+                                             NULL, NULL, NULL, NULL, NULL, NULL);
       if (subcommand_name == NULL)
         {
           g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
@@ -404,7 +406,7 @@ main (int    argc,
       /* This will not return for some options (e.g. --version). */
       (void) rpmostree_option_context_parse (context, NULL, &argc, &argv,
                                              NULL, NULL, NULL, NULL, NULL,
-                                             NULL, NULL);
+                                             NULL, NULL, NULL);
       if (command_name == NULL)
         {
           local_error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_FAILED,

--- a/src/app/rpmostree-builtin-cancel.c
+++ b/src/app/rpmostree-builtin-cancel.c
@@ -75,6 +75,7 @@ rpmostree_builtin_cancel (int             argc,
                                        NULL, NULL,
                                        &sysroot_proxy,
                                        &peer_pid,
+                                       NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-cleanup.c
+++ b/src/app/rpmostree-builtin-cleanup.c
@@ -67,6 +67,7 @@ rpmostree_builtin_cleanup (int             argc,
                                        NULL, NULL,
                                        &sysroot_proxy,
                                        &peer_pid,
+                                       NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-db.c
+++ b/src/app/rpmostree-builtin-db.c
@@ -61,7 +61,7 @@ rpmostree_db_option_context_parse (GOptionContext *context,
                                        argc, argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-deploy.c
+++ b/src/app/rpmostree-builtin-deploy.c
@@ -74,6 +74,7 @@ rpmostree_builtin_deploy (int            argc,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
                                        &peer_pid,
+                                       NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-initramfs.c
+++ b/src/app/rpmostree-builtin-initramfs.c
@@ -74,6 +74,7 @@ rpmostree_builtin_initramfs (int             argc,
                                        NULL, NULL,
                                        &sysroot_proxy,
                                        &peer_pid,
+                                       NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-kargs.c
+++ b/src/app/rpmostree-builtin-kargs.c
@@ -187,6 +187,7 @@ rpmostree_ex_builtin_kargs (int            argc,
                                        NULL, NULL,
                                        &sysroot_proxy,
                                        &peer_pid,
+                                       NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-livefs.c
+++ b/src/app/rpmostree-builtin-livefs.c
@@ -68,6 +68,7 @@ rpmostree_ex_builtin_livefs (int             argc,
                                        NULL, NULL,
                                        &sysroot_proxy,
                                        &peer_pid,
+                                       NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -79,7 +79,7 @@ rpmostree_builtin_rebase (int             argc,
                                        &install_pkgs,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
-                                       &peer_pid,
+                                       &peer_pid, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-refresh-md.c
+++ b/src/app/rpmostree-builtin-refresh-md.c
@@ -67,6 +67,7 @@ rpmostree_builtin_refresh_md (int             argc,
                                        NULL, NULL,
                                        &sysroot_proxy,
                                        &peer_pid,
+                                       NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-reload.c
+++ b/src/app/rpmostree-builtin-reload.c
@@ -52,6 +52,7 @@ rpmostree_builtin_reload (int             argc,
                                        NULL, NULL,
                                        &sysroot_proxy,
                                        &peer_pid,
+                                       NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-rollback.c
+++ b/src/app/rpmostree-builtin-rollback.c
@@ -68,6 +68,7 @@ rpmostree_builtin_rollback (int             argc,
                                        NULL, NULL,
                                        &sysroot_proxy,
                                        &peer_pid,
+                                       NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -674,7 +674,7 @@ rpmostree_builtin_status (int             argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
+                                       &peer_pid, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -77,7 +77,7 @@ rpmostree_builtin_upgrade (int             argc,
                                        &install_pkgs,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
-                                       &peer_pid,
+                                       &peer_pid, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -67,6 +67,7 @@ rpmostree_option_context_parse (GOptionContext *context,
                                 const char *const* *out_uninstall_pkgs,
                                 RPMOSTreeSysroot **out_sysroot_proxy,
                                 GPid *out_peer_pid,
+                                GBusType *out_bus_type,
                                 GError **error);
 
 int

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1240,7 +1240,7 @@ rpmostree_compose_builtin_install (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -1291,7 +1291,7 @@ rpmostree_compose_builtin_postprocess (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -1348,7 +1348,7 @@ rpmostree_compose_builtin_commit (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -1394,7 +1394,7 @@ rpmostree_compose_builtin_tree (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-container-builtins.c
+++ b/src/app/rpmostree-container-builtins.c
@@ -140,7 +140,7 @@ rpmostree_container_builtin_init (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -241,7 +241,7 @@ rpmostree_container_builtin_assemble (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 
@@ -378,7 +378,7 @@ rpmostree_container_builtin_upgrade (int argc, char **argv,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -42,6 +42,7 @@ rpmostree_load_sysroot                       (gchar *sysroot,
                                               GCancellable *cancellable,
                                               RPMOSTreeSysroot **out_sysroot_proxy,
                                               GPid *out_peer_pid,
+                                              GBusType *out_bus_type,
                                               GError **error);
 
 gboolean

--- a/src/app/rpmostree-ex-builtin-commit2jigdo.c
+++ b/src/app/rpmostree-ex-builtin-commit2jigdo.c
@@ -65,7 +65,7 @@ rpmostree_ex_builtin_commit2jigdo (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-ex-builtin-jigdo2commit.c
+++ b/src/app/rpmostree-ex-builtin-jigdo2commit.c
@@ -147,7 +147,7 @@ rpmostree_ex_builtin_jigdo2commit (int             argc,
                                        &argc, &argv,
                                        invocation,
                                        cancellable,
-                                       NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-override-builtins.c
+++ b/src/app/rpmostree-override-builtins.c
@@ -132,7 +132,7 @@ rpmostree_override_builtin_replace (int argc, char **argv,
                                        &install_pkgs,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
-                                       &peer_pid,
+                                       &peer_pid, NULL,
                                        error))
     return FALSE;
 
@@ -173,7 +173,7 @@ rpmostree_override_builtin_remove (int argc, char **argv,
                                        &install_pkgs,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
-                                       &peer_pid,
+                                       &peer_pid, NULL,
                                        error))
     return FALSE;
 
@@ -216,7 +216,7 @@ rpmostree_override_builtin_reset (int argc, char **argv,
                                        &install_pkgs,
                                        &uninstall_pkgs,
                                        &sysroot_proxy,
-                                       &peer_pid,
+                                       &peer_pid, NULL,
                                        error))
     return FALSE;
 

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -152,7 +152,7 @@ rpmostree_builtin_install (int            argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
+                                       &peer_pid, NULL,
                                        error))
     return FALSE;
 
@@ -195,7 +195,7 @@ rpmostree_builtin_uninstall (int            argc,
                                        cancellable,
                                        NULL, NULL,
                                        &sysroot_proxy,
-                                       &peer_pid,
+                                       &peer_pid, NULL,
                                        error))
     return FALSE;
 


### PR DESCRIPTION
This is prep for automatic updates. There, we want to know which D-Bus
we're connected to and e.g. only try to reach out to other services like
systemd if we're on the system bus.