### PR TITLE
daemon: bump idle exit timeout to 60s

### DIFF
--- a/src/daemon/rpmostreed-daemon.c
+++ b/src/daemon/rpmostreed-daemon.c
@@ -29,8 +29,10 @@
 #include <stdio.h>
 
 #define RPMOSTREE_MESSAGE_TRANSACTION_STARTED SD_ID128_MAKE(d5,be,a3,7a,8f,c8,4f,f5,9d,bc,fd,79,17,7b,7d,f8)
-/* I picked this arbitrarily */
-#define IDLE_EXIT_TIMEOUT_SECONDS 10
+
+/* let's not exit super fast; our startup is non-trivial so staying around will ensure
+ * follow-up requests are more responsive */
+#define IDLE_EXIT_TIMEOUT_SECONDS 60
 
 /**
  * SECTION: daemon


### PR DESCRIPTION
Since it usually takes more than 10s for users to enter consecutive
commands, let's bump the timeout to 60s. That way, we avoid the churn of
starting up twice and e.g. polluting the journal.

On a user interface level, this doesn't make a big difference: a
`status` from cold takes around 100ms, whereas with the daemon running,
it takes slightly less than 50ms. Slightly noticeable, but a non-issue.

However, auto-update will require some more work at startup, and a cold
`status` will bump to about 350ms, which is definitely more noticeable.
Bumping the timeout will ensure that at least within the span of one
"interaction" (multiple commands), we only do this work once.