### PR TITLE
core: Don't try to relabel if no SELinux policy

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1275,7 +1275,9 @@ find_pkg_in_ostree (RpmOstreeContext *self,
 {
   OstreeRepo *repo = get_pkgcache_repo (self);
   /* Init output here, since we have several early returns */
-  *out_in_ostree = *out_selinux_match = FALSE;
+  *out_in_ostree = FALSE;
+  /* If there's no sepolicy, then we always match */
+  *out_selinux_match = (sepolicy == NULL);
 
   /* NB: we're not using a pkgcache yet in the compose path */
   if (repo == NULL)


### PR DESCRIPTION
This tripped up some local `ex container` work after:
https://github.com/projectatomic/rpm-ostree/pull/1173

Would be nice to have tests but...let's slide this one through for now since I
plan to get a lot more coverage as `ex container` morps into a `mock`
replacement.
