### PR TITLE
core,status: Add API to parse refspecs, use in status

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -31,6 +31,7 @@
 #include "rpmostree-libbuiltin.h"
 #include "rpmostree-dbus-helpers.h"
 #include "rpmostree-util.h"
+#include "rpmostree-core.h"
 #include "rpmostree-rpm-util.h"
 #include "libsd-locale-util.h"
 
@@ -304,8 +305,15 @@ status_generic (RPMOSTreeSysroot *sysroot_proxy,
 
       g_print ("%s ", is_booted ? libsd_special_glyph (BLACK_CIRCLE) : " ");
 
+      RpmOstreeRefspecType refspectype = RPMOSTREE_REFSPEC_TYPE_OSTREE;
       if (origin_refspec)
-        g_print ("ostree://%s", origin_refspec);
+        {
+          const char *refspec_data;
+          if (!rpmostree_refspec_classify (origin_refspec, &refspectype, &refspec_data, error))
+            return FALSE;
+          g_autofree char *canonrefspec = rpmostree_refspec_to_string (refspectype, refspec_data);
+          g_print ("%s", canonrefspec);
+        }
       else
         g_print ("%s", checksum);
       g_print ("\n");

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -52,6 +52,59 @@
 
 static OstreeRepo * get_pkgcache_repo (RpmOstreeContext *self);
 
+/* Given a string, look for ostree:// or rojig:// prefix and
+ * return its type and the remainder of the string.
+ */
+gboolean
+rpmostree_refspec_classify (const char *refspec,
+                            RpmOstreeRefspecType *out_type,
+                            const char **out_remainder,
+                            GError     **error)
+{
+  if (g_str_has_prefix (refspec, RPMOSTREE_REFSPEC_OSTREE_PREFIX))
+    {
+      *out_type = RPMOSTREE_REFSPEC_TYPE_OSTREE;
+      if (out_remainder)
+        *out_remainder = refspec + strlen (RPMOSTREE_REFSPEC_OSTREE_PREFIX);
+      return TRUE;
+    }
+  else if (g_str_has_prefix (refspec, RPMOSTREE_REFSPEC_ROJIG_PREFIX))
+    {
+      *out_type = RPMOSTREE_REFSPEC_TYPE_ROJIG;
+      if (out_remainder)
+        *out_remainder = refspec + strlen (RPMOSTREE_REFSPEC_ROJIG_PREFIX);
+      return TRUE;
+    }
+
+  /* Fallback case when we have no explicit prefix - treat this as ostree://
+   * for compatibility.  In the future we may do some error checking here,
+   * i.e. trying to parse the refspec.
+   */
+  *out_type = RPMOSTREE_REFSPEC_TYPE_OSTREE;
+  if (out_remainder)
+    *out_remainder = refspec;
+
+  return TRUE;
+}
+
+char*
+rpmostree_refspec_to_string (RpmOstreeRefspecType  reftype,
+                             const char           *data)
+{
+  const char *prefix = NULL;
+  switch (reftype)
+    {
+    case RPMOSTREE_REFSPEC_TYPE_OSTREE:
+      prefix = RPMOSTREE_REFSPEC_OSTREE_PREFIX;
+      break;
+    case RPMOSTREE_REFSPEC_TYPE_ROJIG:
+      prefix = RPMOSTREE_REFSPEC_ROJIG_PREFIX;
+      break;
+    }
+  g_assert (prefix);
+  return g_strconcat (prefix, data, NULL);
+}
+
 static int
 compare_pkgs (gconstpointer ap,
               gconstpointer bp)

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -38,6 +38,25 @@ G_DECLARE_FINAL_TYPE (RpmOstreeContext, rpmostree_context, RPMOSTREE, CONTEXT, G
 #define RPMOSTREE_TYPE_TREESPEC (rpmostree_treespec_get_type ())
 G_DECLARE_FINAL_TYPE (RpmOstreeTreespec, rpmostree_treespec, RPMOSTREE, TREESPEC, GObject)
 
+/* Now in the code we handle "refspec" types of rojig (rpm-ostree jigdo),
+ * in addition to ostree.
+ */
+typedef enum {
+  RPMOSTREE_REFSPEC_TYPE_OSTREE,
+  RPMOSTREE_REFSPEC_TYPE_ROJIG,
+} RpmOstreeRefspecType;
+
+#define RPMOSTREE_REFSPEC_OSTREE_PREFIX "ostree://"
+#define RPMOSTREE_REFSPEC_ROJIG_PREFIX "rojig://"
+
+gboolean rpmostree_refspec_classify (const char *refspec,
+                                     RpmOstreeRefspecType *out_type,
+                                     const char **out_remainder,
+                                     GError     **error);
+
+char* rpmostree_refspec_to_string (RpmOstreeRefspecType  reftype,
+                                   const char           *data);
+
 RpmOstreeContext *rpmostree_context_new_system (OstreeRepo   *repo,
                                                 GCancellable *cancellable,
                                                 GError      **error);


### PR DESCRIPTION
In preparation for rojig (rpm-ostree jigdo) client work.  Changing
all of the code where we currently use refspecs (i.e. pure ostree)
to also learn about jigdo would be really painful - basically adding
new DBus APIs and all of the places we pass through data.

A simpler path then is to overload the meaning of refspecs to have an (optional)
URI scheme. If we don't recognize the scheme, assume it's ostree for now.

Change the status command to parse and then render as a way of "canonicalizing"
so that we have the same behavior as before of rendering with `ostree://`.
