### PR TITLE
rebase: Add support for providing ostree:// prefix

### DIFF
--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -25,6 +25,7 @@
 
 #include "rpmostree-builtins.h"
 #include "rpmostree-util.h"
+#include "rpmostree-core.h"
 #include "rpmostree-libbuiltin.h"
 #include "rpmostree-dbus-helpers.h"
 
@@ -102,13 +103,19 @@ rpmostree_builtin_rebase (int             argc,
       new_provided_refspec = argv[1];
       if (argc == 3)
         revision = argv[2];
+
+      /* Canonicalize */
+      new_provided_refspec = new_refspec_owned =
+        rpmostree_refspec_canonicalize (new_provided_refspec, error);
+      if (!new_provided_refspec)
+        return FALSE;
     }
   else
     {
       if (opt_remote)
         {
           new_provided_refspec = new_refspec_owned =
-            g_strconcat (opt_remote, ":", opt_branch ?: "", NULL);
+            g_strconcat (RPMOSTREE_REFSPEC_OSTREE_PREFIX, opt_remote, ":", opt_branch ?: "", NULL);
         }
       else
         new_provided_refspec = opt_branch;

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -38,12 +38,22 @@
 static gboolean
 change_origin_refspec (OstreeSysroot *sysroot,
                        RpmOstreeOrigin *origin,
-                       const gchar *refspec,
+                       const gchar *src_refspec,
                        GCancellable *cancellable,
                        gchar **out_old_refspec,
                        gchar **out_new_refspec,
                        GError **error)
 {
+  RpmOstreeRefspecType refspectype;
+  const char *refspecdata;
+  if (!rpmostree_refspec_classify (src_refspec, &refspectype, &refspecdata, error))
+    return FALSE;
+  /* Should have been canonicalized earlier */
+  g_assert_cmpint (refspectype, ==, RPMOSTREE_REFSPEC_TYPE_OSTREE);
+
+  /* Now here we "peel" it since the rest of the code assumes libostree */
+  const char *refspec = refspecdata;
+
   g_autofree gchar *current_refspec =
     g_strdup (rpmostree_origin_get_refspec (origin));
   g_autofree gchar *new_refspec = NULL;

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -105,6 +105,20 @@ rpmostree_refspec_to_string (RpmOstreeRefspecType  reftype,
   return g_strconcat (prefix, data, NULL);
 }
 
+
+/* Primarily this makes sure that ostree refspecs start with `ostree://`.
+ */
+char*
+rpmostree_refspec_canonicalize (const char *orig_refspec,
+                                GError    **error)
+{
+  RpmOstreeRefspecType refspectype;
+  const char *refspec_data;
+  if (!rpmostree_refspec_classify (orig_refspec, &refspectype, &refspec_data, error))
+    return NULL;
+  return rpmostree_refspec_to_string (refspectype, refspec_data);
+}
+
 static int
 compare_pkgs (gconstpointer ap,
               gconstpointer bp)

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -57,6 +57,9 @@ gboolean rpmostree_refspec_classify (const char *refspec,
 char* rpmostree_refspec_to_string (RpmOstreeRefspecType  reftype,
                                    const char           *data);
 
+char* rpmostree_refspec_canonicalize (const char           *orig_refspec,
+                                      GError              **error);
+
 RpmOstreeContext *rpmostree_context_new_system (OstreeRepo   *repo,
                                                 GCancellable *cancellable,
                                                 GError      **error);

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -24,7 +24,7 @@ export RPMOSTREE_SUPPRESS_REQUIRES_ROOT_CHECK=yes
 
 ensure_dbus
 
-echo "1..25"
+echo "1..26"
 
 setup_os_repository "archive-z2" "syslinux"
 
@@ -176,6 +176,14 @@ ostree --repo=${test_tmpdir}/sysroot/ostree/repo commit -b localbranch --tree=re
 rpm-ostree rebase --skip-purge --os=testos -m '' -b localbranch
 assert_status_jq '.deployments[0].origin == "localbranch"'
 echo "ok rebase new syntax"
+
+rpm-ostree rebase --skip-purge --os=testos ostree://testos:testos/buildmaster/x86_64-runtime
+assert_status_jq '.deployments[0].origin == "testos:testos/buildmaster/x86_64-runtime"'
+if rpm-ostree rebase --skip-purge --os=testos rojig://testos:testos/buildmaster/x86_64-runtime 2>err.txt; then
+    fatal "rebase rojig worked?"
+fi
+assert_file_has_content_literal err.txt 'error: Unsupported refspec: rojig://'
+echo "ok rebase refspec syntax"
 
 rpm-ostree rebase --os=testos :another-branch
 originpath=$(ostree admin --sysroot=sysroot --print-current-dir).origin


### PR DESCRIPTION
This fixes an asymmetry we introduced when rendering using the `ostree://`
prefix; we now support parsing it as well.  We reject the `rojig://` prefix
explicitly for now.

On the implementation side...things are messy. My thought is that we do our best
to canonicalize at the entrypoints for both the client side as well as the
server side. However, for backwards compatibility we can't go all the way to
writing out `ostree://` to disk in the origin files.

I'm actually uncertain if Cockpit will deal with this...need to test that.
