### PR TITLE
scripts: Ignore %verifyscript

### DIFF
--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -66,6 +66,10 @@ static const KnownRpmScriptKind ignored_scripts[] = {
   { "%triggerpostun", RPMSENSE_TRIGGERPOSTUN,
     RPMTAG_TRIGGERPOSTUN, 0, 0 },
 
+  /* https://github.com/projectatomic/rpm-ostree/issues/1216 */
+  { "%verifyscript", 0,
+    RPMTAG_VERIFYSCRIPT, RPMTAG_VERIFYSCRIPTPROG, RPMTAG_VERIFYSCRIPTFLAGS},
+
   /* In practice, %pretrans are hack-arounds for broken upgrades.
    * Again, since we always assemble a new root, there's no point
    * to running them.
@@ -89,8 +93,6 @@ static const KnownRpmScriptKind unsupported_scripts[] = {
     RPMTAG_TRIGGERPREIN, 0, 0 },
   { "%triggerin", RPMSENSE_TRIGGERIN,
     RPMTAG_TRIGGERIN, 0, 0 },
-  { "%verify", 0,
-    RPMTAG_VERIFYSCRIPT, RPMTAG_VERIFYSCRIPTPROG, RPMTAG_VERIFYSCRIPTFLAGS},
 };
 
 typedef struct {

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -402,6 +402,7 @@ License: GPLv2+
 EOF
 
     local build= install= files= pretrans= pre= post= posttrans= post_args=
+    local verifyscript=
     local transfiletriggerin= transfiletriggerin_patterns=
     local transfiletriggerin2= transfiletriggerin2_patterns=
     local transfiletriggerun= transfiletriggerun_patterns=
@@ -417,7 +418,7 @@ EOF
             echo "Conflicts: $arg" >> $spec;;
         post_args)
             post_args="$arg";;
-        version|release|epoch|arch|build|install|files|pretrans|pre|post|posttrans)
+        version|release|epoch|arch|build|install|files|pretrans|pre|post|posttrans|verifyscript)
             declare $section="$arg";;
         transfiletriggerin)
             transfiletriggerin_patterns="$arg";
@@ -468,6 +469,9 @@ $transfiletriggerin2
 
 ${transfiletriggerun:+%transfiletriggerun -- ${transfiletriggerun_patterns}}
 $transfiletriggerun
+
+${verifyscript:+%verifyscript}
+$verifyscript
 
 %install
 mkdir -p %{buildroot}/usr/bin

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -28,10 +28,13 @@ set -x
 
 # do a bunch of tests together so that we only have to reboot once
 
+# For the expected semantics of these scripts, see the comments in
+# rpmostree-scripts.c.
 vm_build_rpm scriptpkg1 \
   pre "groupadd -r scriptpkg1" \
   pretrans "# http://lists.rpm.org/pipermail/rpm-ecosystem/2016-August/000391.html
-            echo i should've been ignored && exit 1" \
+            echo pretrans should've been ignored && exit 1" \
+  verifyscript "echo verifyscript should've been ignored && exit 1" \
   post_args "-p /usr/bin/python" \
   post 'open("/usr/lib/rpmostreetestinterp", "w")' \
   posttrans "# Firewalld; https://github.com/projectatomic/rpm-ostree/issues/638


### PR DESCRIPTION
It obviously shouldn't block the ability to install, and anyways
the single use in `ksh` is not compelling.  If someone comes up with
one we can revisit supporting this.

Closes: https://github.com/projectatomic/rpm-ostree/issues/1216
