### PR TITLE
Fix "releasever" option, test it by default

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -247,11 +247,14 @@ rpmostree_treespec_new_from_keyfile (GKeyFile   *keyfile,
       g_variant_builder_add (&builder, "{sv}", "ref", g_variant_new_string (ref));
   }
 
-  /* See if we're using jigdo */
-  { g_autofree char *jigdo = g_key_file_get_string (keyfile, "tree", "jigdo", NULL);
-    if (jigdo)
-      g_variant_builder_add (&builder, "{sv}", "jigdo", g_variant_new_string (jigdo));
+#define BIND_STRING(k)                                                  \
+  { g_autofree char *v = g_key_file_get_string (keyfile, "tree", k, NULL); \
+    if (v)                                                              \
+      g_variant_builder_add (&builder, "{sv}", k, g_variant_new_string (v)); \
   }
+
+  BIND_STRING("jigdo");
+  BIND_STRING("releasever");
 
   add_canonicalized_string_array (&builder, "packages", NULL, keyfile);
   add_canonicalized_string_array (&builder, "cached-packages", NULL, keyfile);

--- a/tests/common/libcomposetest.sh
+++ b/tests/common/libcomposetest.sh
@@ -20,12 +20,10 @@
 setup_rpmmd_repos() {
     dest=$1
     shift
-    releasever=${1:-26}
     repos=${RPMOSTREE_COMPOSE_TEST_USE_REPOS:-/etc/yum.repos.d}
-    # When bumping 26 here, also bump fedora.repo, .papr.yml
     for x in ${repos}/fedora{,-updates}.repo; do
         bn=$(basename ${x})
-        sed -e "s,\$releasever,$releasever," < $x > ${dest}/${bn}
+        cp $x ${dest}/${bn}
     done
 }
 

--- a/tests/compose-tests/test-mutate-os-release.sh
+++ b/tests/compose-tests/test-mutate-os-release.sh
@@ -4,30 +4,31 @@ set -xeuo pipefail
 
 dn=$(cd $(dirname $0) && pwd)
 . ${dn}/libcomposetest.sh
+releasever=27
 
 # specifying the key but neither automatic_version_prefix nor
 # --add-metadata-string should cause no mutation
 
 prepare_compose_test "mutate-os-release-none"
-pysetjsonmember "mutate-os-release" '"26"'
+pysetjsonmember "mutate-os-release" '"'${releasever}'"'
 runcompose
 echo "ok compose (none)"
 
 ostree --repo=${repobuild} cat ${treeref} \
     /usr/lib/os.release.d/os-release-fedora > os-release.prop
 
-assert_file_has_content os-release.prop VERSION_ID=26
+assert_file_has_content os-release.prop VERSION_ID=${releasever}
 assert_not_file_has_content os-release.prop OSTREE_VERSION=
-assert_file_has_content os-release.prop 'VERSION="26 (Twenty Six)"'
+assert_file_has_content os-release.prop 'VERSION="'${releasever}' (Twenty '
 echo "ok mutate-os-release-none"
 
 # make sure --add-metadata-string has precedence and works with
 # mutate-os-release
 
 prepare_compose_test "mutate-os-release-cli"
-pysetjsonmember "automatic_version_prefix" '"26.555"'
-pysetjsonmember "mutate-os-release" '"26"'
-runcompose --add-metadata-string=version=26.444
+pysetjsonmember "automatic_version_prefix" '"'${releasever}'.555"'
+pysetjsonmember "mutate-os-release" '"'${releasever}'"'
+runcompose --add-metadata-string=version=${releasever}.444
 echo "ok compose (cli)"
 
 ostree --repo=${repobuild} cat ${treeref} \
@@ -35,16 +36,16 @@ ostree --repo=${repobuild} cat ${treeref} \
 
 # VERSION_ID *shouldn't* change
 # (https://github.com/projectatomic/rpm-ostree/pull/433)
-assert_file_has_content os-release.prop VERSION_ID=26
-assert_file_has_content os-release.prop OSTREE_VERSION=26.444
-assert_file_has_content os-release.prop 'VERSION="26\.444 (Twenty Six)"'
+assert_file_has_content os-release.prop VERSION_ID=${releasever}
+assert_file_has_content os-release.prop OSTREE_VERSION=${releasever}.444
+assert_file_has_content os-release.prop 'VERSION="'${releasever}'\.444 (Twenty '
 echo "ok mutate-os-release-cli"
 
 # make sure automatic_version_prefix works
 
 prepare_compose_test "mutate-os-release-auto"
-pysetjsonmember "automatic_version_prefix" '"26.555"'
-pysetjsonmember "mutate-os-release" '"26"'
+pysetjsonmember "automatic_version_prefix" '"'${releasever}'.555"'
+pysetjsonmember "mutate-os-release" '"'${releasever}'"'
 runcompose
 echo "ok compose (auto)"
 
@@ -53,7 +54,7 @@ ostree --repo=${repobuild} cat ${treeref} \
 
 # VERSION_ID *shouldn't* change
 # (https://github.com/projectatomic/rpm-ostree/pull/433)
-assert_file_has_content os-release.prop VERSION_ID=26
-assert_file_has_content os-release.prop OSTREE_VERSION=26.555
-assert_file_has_content os-release.prop 'VERSION="26\.555 (Twenty Six)"'
+assert_file_has_content os-release.prop VERSION_ID=${releasever}
+assert_file_has_content os-release.prop OSTREE_VERSION=${releasever}.555
+assert_file_has_content os-release.prop 'VERSION="'${releasever}'\.555 (Twenty '
 echo "ok mutate-os-release (auto)"

--- a/tests/composedata/fedora-base.json
+++ b/tests/composedata/fedora-base.json
@@ -1,5 +1,6 @@
 {
     "ref": "fedora/stable/${basearch}",
+    "releasever": "27",
 
     "repos": ["fedora", "updates"],
 

--- a/tests/ex-container
+++ b/tests/ex-container
@@ -25,8 +25,7 @@ trap cleanup_tmp EXIT
 
 cd ${tmpdir}
 rpm-ostree ex container init
-# Need 27 due to http://bugzilla.redhat.com/1478172 only built there
-setup_rpmmd_repos ${tmpdir}/rpmmd.repos.d 27
+setup_rpmmd_repos ${tmpdir}/rpmmd.repos.d
 
 echo "Results in ${LOGDIR}"
 rm ${LOGDIR} -rf

--- a/tests/ex-container-tests/test-bash.sh
+++ b/tests/ex-container-tests/test-bash.sh
@@ -11,6 +11,7 @@ cat >bash.conf <<EOF
 ref=bash
 packages=coreutils;bash;
 repos=fedora;
+releasever=27
 EOF
 
 rpm-ostree ex container assemble bash.conf
@@ -24,6 +25,7 @@ cat >bash-nodocs.conf <<EOF
 ref=bash-nodocs
 packages=coreutils;bash;
 repos=fedora;
+releasever=27
 documentation=false;
 EOF
 

--- a/tests/ex-container-tests/test-httpd.sh
+++ b/tests/ex-container-tests/test-httpd.sh
@@ -11,6 +11,7 @@ cat >httpd.conf <<EOF
 ref=httpd
 packages=httpd;
 repos=fedora;
+releasever=27
 EOF
 
 # This one has non-root ownership in some of the dependencies, but we shouldn't


### PR DESCRIPTION
In #875 AKA b46fc35901acb18a3cbf01fd10bce16acd727650 we
added support for the `releasever` option in treefiles.  I am
pretty sure it worked at the time...but I didn't add tests.

Either it never worked or some refactoring broke it. The whole chain of
`GKeyFile` → `GVariant` is so confusing. Anyways fix it by copying the string.
Now let's use it by default in the compose tests, and while we're here bump
those to F27.

I'm doing this patch now as I was playing with doing a compose from
the `/usr/share/rpm-ostree/treefile.json` and wanted to use the stock
`.repo` files.
