### PR TITLE
lib: Fix the library name to link to in the pkg-config file

### DIFF
--- a/src/lib/rpm-ostree-1.pc.in
+++ b/src/lib/rpm-ostree-1.pc.in
@@ -7,5 +7,5 @@ Name: RpmOstree
 Description: Hybrid package/OSTree system
 Version: @VERSION@
 Requires: ostree-1
-Libs: -L${libdir} -lrpm-ostree-1
+Libs: -L${libdir} -lrpmostree-1
 Cflags: -I${includedir}/rpm-ostree-1


### PR DESCRIPTION
This lets other programs actually link with the shared library.