### PR TITLE
client: Don't output progress bars on non-ttys

### DIFF
--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -428,9 +428,14 @@ add_status_line (TransactionProgress *self,
   self->in_status_line = TRUE;
   if (!self->console.locked)
     glnx_console_lock (&self->console);
+
+  /* Always render text, but we only show progress if we're on a tty, to be
+   * friendlier to e.g. Ansible and other tools that may just be seeing our
+   * output.
+   */
   if (percentage < 0)
     glnx_console_text (line);
-  else
+  else if (percentage == 100 || self->console.is_tty)
     glnx_console_progress_text_percent (line, percentage);
 }
 

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -84,6 +84,12 @@ vm_rpmostree db diff --format=diff \
 assert_file_has_content_literal 'db-diff.txt' "+foo-1.0-1.x86_64"
 echo "ok pkg-add foo"
 
+# Test that we don't do progress bars if on a tty (with the client)
+vm_rpmostree uninstall foo-1.0
+vm_rpmostree install foo-1.0 > foo-install.txt
+assert_file_has_content_literal foo-install.txt 'Building filesystem (1/1) 100%'
+echo "ok install not on a tty"
+
 vm_reboot
 vm_assert_status_jq \
   '.deployments[0]["base-checksum"]' \


### PR DESCRIPTION
This is what a lot of other tools do. It can get very verbose, with a
potentially huge amount of output if things are trickling in.  This way
we're at least more friendly to someone running `cmd: rpm-ostree upgrade`
via Ansible or equivalent.

The slight hack here is that we *do* output `100%` on non-ttys to ensure we
print the result of the task.

Closes: https://github.com/projectatomic/rpm-ostree/issues/1183
