### PR TITLE
core: Fix override-remove from UsrMove compat paths /lib,/bin etc

### DIFF
--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -62,6 +62,7 @@ struct _RpmOstreeContext {
   GLnxTmpDir tmpdir;
 
   int tmprootfs_dfd; /* Borrowed */
+  GHashTable *rootfs_usrlinks;
   GLnxTmpDir repo_tmpdir; /* Used to assemble+commit if no base rootfs provided */
 };
 


### PR DESCRIPTION
I'm working on supporting `override replace ./kernel-*.rpm`:
https://github.com/projectatomic/rpm-ostree/issues/946

But after battling the "installonly" logic in libdnf, I was confused why we
still had the files in `/usr/lib/modules`. It turned out to be because we only
remove files in `/usr`, but the code didn't handle UsrMove compat links.

There are a variety of approaches to fix this.  Obviously a lot
of things get nicer in jigdo mode as we do UsrMove canonicalization
on import, and we could change this code to walk the imported pkg
ostree ref.

Another approach would be to walk the initial symlink, and check whether or not
it's the same as `/usr` (i.e. let the kernel do it).

For now though, what I chose to do was to scan the rootfs and find the UsrMove
compat links (i.e. we avoid hardcoding them again here).  This is
fewer syscalls than the above and works well in practice.
