### PR TITLE
core: Set installonly to ensure we only have one kernel

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1172,6 +1172,12 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
                      NULL);
   }
 
+  /* Don't try to keep multiple kernels per root; that's a traditional thing,
+   * ostree binds kernel + userspace.
+   */
+  dnf_sack_set_installonly (dnf_context_get_sack (self->dnfctx), NULL);
+  dnf_sack_set_installonly_limit (dnf_context_get_sack (self->dnfctx), 0);
+
   return TRUE;
 }
 

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1172,12 +1172,6 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
                      NULL);
   }
 
-  /* Don't try to keep multiple kernels per root; that's a traditional thing,
-   * ostree binds kernel + userspace.
-   */
-  dnf_sack_set_installonly (dnf_context_get_sack (self->dnfctx), NULL);
-  dnf_sack_set_installonly_limit (dnf_context_get_sack (self->dnfctx), 0);
-
   return TRUE;
 }
 
@@ -1860,6 +1854,12 @@ rpmostree_context_prepare (RpmOstreeContext *self,
       if (!rpmostree_context_download_metadata (self, cancellable, error))
         return FALSE;
     }
+
+  /* Don't try to keep multiple kernels per root; that's a traditional thing,
+   * ostree binds kernel + userspace.
+   */
+  dnf_sack_set_installonly (dnf_context_get_sack (self->dnfctx), NULL);
+  dnf_sack_set_installonly_limit (dnf_context_get_sack (self->dnfctx), 0);
 
   if (self->jigdo_pure)
     {

--- a/tests/vmcheck/test-override-kernel.sh
+++ b/tests/vmcheck/test-override-kernel.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# Test that we can override the kernel.  For ease of testing
+# I just picked the "gold" F27 kernel.
+vm_cmd 'curl -sS -L -O https://dl.fedoraproject.org/pub/fedora/linux/releases/27/Everything/x86_64/os/Packages/k/kernel-4.13.9-300.fc27.x86_64.rpm \
+                -O https://dl.fedoraproject.org/pub/fedora/linux/releases/27/Everything/x86_64/os/Packages/k/kernel-core-4.13.9-300.fc27.x86_64.rpm \
+                -O https://dl.fedoraproject.org/pub/fedora/linux/releases/27/Everything/x86_64/os/Packages/k/kernel-modules-4.13.9-300.fc27.x86_64.rpm \
+                -O https://dl.fedoraproject.org/pub/fedora/linux/releases/27/Everything/x86_64/os/Packages/k/kernel-modules-extra-4.13.9-300.fc27.x86_64.rpm'
+current=$(vm_get_booted_csum)
+vm_cmd rpm-ostree db list "${current}" > current-dblist.txt
+assert_not_file_has_content current-dblist.txt 'kernel-4.13.9-300.fc27'
+grep -E '^ kernel-' current-dblist.txt  | sed -e 's,^ *,,' > current-kernel.txt
+vm_rpmostree override replace ./kernel*4.13.9*.rpm
+new=$(vm_get_deployment_info 0 checksum)
+vm_cmd rpm-ostree db list "${new}" > new-dblist.txt
+assert_file_has_content_literal new-dblist.txt 'kernel-4.13.9-300.fc27'
+cat current-kernel.txt | while read line; do
+    if grep -q -F -e "${line}" new-dblist.txt; then
+        fatal "Found kernel: ${line}"
+    fi
+done
+echo "ok override kernel"

--- a/tests/vmcheck/test-override-kernel.sh
+++ b/tests/vmcheck/test-override-kernel.sh
@@ -24,6 +24,12 @@ set -euo pipefail
 
 set -x
 
+osid=$(vm_cmd grep -E '^ID=' /etc/os-release)
+if test "${osid}" != 'ID=fedora'; then
+    echo "ok skip on OS ID=${osid}"
+    exit 0
+fi
+
 # Test that we can override the kernel.  For ease of testing
 # I just picked the "gold" F27 kernel.
 vm_cmd 'curl -sS -L -O https://dl.fedoraproject.org/pub/fedora/linux/releases/27/Everything/x86_64/os/Packages/k/kernel-4.13.9-300.fc27.x86_64.rpm \
@@ -34,7 +40,7 @@ current=$(vm_get_booted_csum)
 vm_cmd rpm-ostree db list "${current}" > current-dblist.txt
 assert_not_file_has_content current-dblist.txt 'kernel-4.13.9-300.fc27'
 grep -E '^ kernel-4' current-dblist.txt  | sed -e 's,^ *,,' > orig-kernel.txt
-assert_streq "$(wc -l orig-kernel.txt | cut -f 1 -d ' ')" "1"
+assert_streq "$(wc -l < orig-kernel.txt)" "1"
 orig_kernel=$(cat orig-kernel.txt)
 vm_rpmostree override replace ./kernel*4.13.9*.rpm
 new=$(vm_get_pending_csum)


### PR DESCRIPTION
The goal here is to support `override replace kernel.x86_64.rpm`.

There's a whole lot of logic in libdnf to support having multiple
kernel packages installed.  AIUI, that was implemented because:

1) The kernel is the biggest source of regressions
2) It'd be quite noticeable if all of your kernel modules were deleted

Of course point 2) applies to a lot of userspace too...that's something
rpm-ostree fixes of course.

Anyways, in some testing all we need to do really is just turn that
logic off unconditionally.

Closes: https://github.com/projectatomic/rpm-ostree/issues/946
