### PR TITLE
Add support for `deploy <version>` in `rojig://` mode

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -439,7 +439,8 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
     case RPMOSTREE_REFSPEC_TYPE_ROJIG:
       {
         // Not implemented yet, though we could do a query for the provides
-        g_assert (!override_commit);
+        if (override_commit)
+          return glnx_throw (error, "Specifying commit overrides for rojig:// is not implemented yet");
 
         g_autoptr(GKeyFile) tsk = g_key_file_new ();
         g_key_file_set_string (tsk, "tree", "jigdo", refspec);

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -156,6 +156,8 @@ apply_revision_override (RpmostreedTransaction    *transaction,
                                                  version, progress,
                                                  cancellable, &checksum, error))
               return FALSE;
+
+            rpmostree_origin_set_override_commit (origin, checksum, version);
           }
           break;
         case RPMOSTREE_REFSPEC_TYPE_ROJIG:

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -250,6 +250,7 @@ rpmostree_treespec_new_from_keyfile (GKeyFile   *keyfile,
   }
 
   BIND_STRING("jigdo");
+  BIND_STRING("jigdo-version");
   BIND_STRING("releasever");
 
   add_canonicalized_string_array (&builder, "packages", NULL, keyfile);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -252,6 +252,7 @@ rpmostree_treespec_new_from_keyfile (GKeyFile   *keyfile,
   BIND_STRING("jigdo");
   BIND_STRING("jigdo-version");
   BIND_STRING("releasever");
+#undef BIND_STRING
 
   add_canonicalized_string_array (&builder, "packages", NULL, keyfile);
   add_canonicalized_string_array (&builder, "cached-packages", NULL, keyfile);

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -392,7 +392,10 @@ void
 rpmostree_origin_set_jigdo_version (RpmOstreeOrigin *origin,
                                     const char      *version)
 {
-  g_key_file_set_string (origin->kf, "origin", "jigdo-version", version);
+  if (version)
+    g_key_file_set_string (origin->kf, "origin", "jigdo-version", version);
+  else
+    g_key_file_remove_key (origin->kf, "origin", "jigdo-version", NULL);
   g_free (origin->cached_jigdo_version);
   origin->cached_jigdo_version = g_strdup (version);
 }

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -388,6 +388,15 @@ rpmostree_origin_set_override_commit (RpmOstreeOrigin *origin,
   origin->cached_override_commit = g_strdup (checksum);
 }
 
+void
+rpmostree_origin_set_jigdo_version (RpmOstreeOrigin *origin,
+                                    const char      *version)
+{
+  g_key_file_set_string (origin->kf, "origin", "jigdo-version", version);
+  g_free (origin->cached_jigdo_version);
+  origin->cached_jigdo_version = g_strdup (version);
+}
+
 gboolean
 rpmostree_origin_set_rebase (RpmOstreeOrigin *origin,
                              const char      *new_refspec,

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -117,6 +117,10 @@ rpmostree_origin_set_override_commit (RpmOstreeOrigin *origin,
                                       const char      *checksum,
                                       const char      *version);
 
+void
+rpmostree_origin_set_jigdo_version (RpmOstreeOrigin *origin,
+                                    const char      *version);
+
 gboolean
 rpmostree_origin_set_rebase (RpmOstreeOrigin *origin,
                              const char      *new_refspec,

--- a/tests/vmcheck/test-jigdo-client.sh
+++ b/tests/vmcheck/test-jigdo-client.sh
@@ -41,4 +41,15 @@ vm_rpmostree rebase --experimental rojig://fahc:fedora-atomic-host
 vm_assert_status_jq '.deployments[0].origin|startswith("rojig://fahc:fedora-atomic-host")'
 vm_cmd ostree refs > refs.txt
 assert_file_has_content refs.txt '^rpmostree/jigdo/kernel-core/'
-echo "ok jigdo client"
+echo "ok jigdo client rebase "
+
+version=$(vm_get_deployment_info 0 version)
+version_major=$(echo ${version} | cut -f 1 -d '.')
+version_minor=$(echo ${version} | cut -f 2 -d '.')
+prev_version=${version_major}.$((${version_minor} - 1))
+assert_not_streq "${version}" "${prev_version}"
+vm_rpmostree deploy ${prev_version}
+vm_assert_status_jq '.deployments[0].origin|startswith("rojig://fahc:fedora-atomic-host")' \
+                    '.deployments[0].version == "'${prev_version}'"'
+
+echo "ok jigdo client deploy"


### PR DESCRIPTION
This fleshes out an important piece of the story, showing that
we can support history versioning the same way that we did with
ostree.

Also it's very useful for testing; I'm going to extend the suite after this to
deploy the previous version, clean everything up, then upgrade and verify we
only download changed RPMs.
