### PR TITLE
Jigdo import coherency

### DIFF
--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -122,7 +122,9 @@ gboolean rpmostree_context_get_state_sha512 (RpmOstreeContext *self,
 
 char * rpmostree_get_cache_branch_for_n_evr_a (const char *name, const char *evr, const char *arch);
 char *rpmostree_get_cache_branch_header (Header hdr);
+char *rpmostree_get_jigdo_branch_header (Header hdr);
 char *rpmostree_get_cache_branch_pkg (DnfPackage *pkg);
+char *rpmostree_get_jigdo_branch_pkg (DnfPackage *pkg);
 
 gboolean
 rpmostree_find_cache_branch_by_nevra (OstreeRepo    *pkgcache,

--- a/src/libpriv/rpmostree-importer.c
+++ b/src/libpriv/rpmostree-importer.c
@@ -327,7 +327,12 @@ const char *
 rpmostree_importer_get_ostree_branch (RpmOstreeImporter *self)
 {
   if (!self->ostree_branch)
-    self->ostree_branch = rpmostree_get_cache_branch_header (self->hdr);
+    {
+      if (self->jigdo_mode)
+        self->ostree_branch = rpmostree_get_jigdo_branch_header (self->hdr);
+      else
+        self->ostree_branch = rpmostree_get_cache_branch_header (self->hdr);
+    }
 
   return self->ostree_branch;
 }

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -809,7 +809,7 @@ get_sack_for_root (int               dfd,
   g_autoptr(DnfSack) sack = dnf_sack_new ();
   dnf_sack_set_rootdir (sack, fullpath);
 
-  if (!dnf_sack_setup (sack, DNF_SACK_LOAD_FLAG_BUILD_CACHE, error))
+  if (!dnf_sack_setup (sack, 0, error))
     return FALSE;
 
   if (!dnf_sack_load_system_repo (sack, NULL, 0, error))

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -766,6 +766,7 @@ rpmrev_free (struct RpmRevisionData *ptr)
 static gboolean
 checkout_only_rpmdb (OstreeRepo       *repo,
                      const char       *ref,
+                     const char       *rpmdb,
                      GLnxTmpDir       *tmpdir,
                      GCancellable     *cancellable,
                      GError          **error)
@@ -781,7 +782,8 @@ checkout_only_rpmdb (OstreeRepo       *repo,
   /* Check out the database (via copy) */
   OstreeRepoCheckoutAtOptions checkout_options = { 0, };
   checkout_options.mode = OSTREE_REPO_CHECKOUT_MODE_USER;
-  checkout_options.subpath = RPMOSTREE_RPMDB_LOCATION;
+  const char *subpath = glnx_strjoina ("/", rpmdb);
+  checkout_options.subpath = subpath;
   if (!ostree_repo_checkout_at (repo, &checkout_options, tmpdir->fd,
                                 RPMOSTREE_RPMDB_LOCATION, commit,
                                 cancellable, error))
@@ -845,7 +847,37 @@ rpmostree_get_refsack_for_commit (OstreeRepo                *repo,
   if (!glnx_mkdtemp ("rpmostree-dbquery-XXXXXX", 0700, &tmpdir, error))
     return NULL;
 
-  if (!checkout_only_rpmdb (repo, ref, &tmpdir, cancellable, error))
+  if (!checkout_only_rpmdb (repo, ref, RPMOSTREE_RPMDB_LOCATION,
+                            &tmpdir, cancellable, error))
+    return NULL;
+
+  g_autoptr(DnfSack) hsack = NULL; /* NB: refsack adds a ref to it */
+  if (!get_sack_for_root (tmpdir.fd, ".", &hsack, error))
+    return NULL;
+
+  /* Ownership of tmpdir is transferred */
+  return rpmostree_refsack_new (hsack, &tmpdir);
+}
+
+/* Return a sack for the "base" rpmdb without any layering/overrides/etc.
+ * involved.
+ */
+RpmOstreeRefSack *
+rpmostree_get_base_refsack_for_commit (OstreeRepo                *repo,
+                                       const char                *ref,
+                                       GCancellable              *cancellable,
+                                       GError                   **error)
+{
+  g_auto(GLnxTmpDir) tmpdir = { 0, };
+  if (!glnx_mkdtemp ("rpmostree-dbquery-XXXXXX", 0700, &tmpdir, error))
+    return NULL;
+
+  /* This is a bit of a hack; we checkout the "base" dbpath as /usr/share/rpm in
+   * a temporary root. Fixing this would require patching through new APIs into
+   * libdnf → libsolv to teach it about a way to find a user-specified dbpath.
+   */
+  if (!checkout_only_rpmdb (repo, ref, RPMOSTREE_BASE_RPMDB,
+                            &tmpdir, cancellable, error))
     return NULL;
 
   g_autoptr(DnfSack) hsack = NULL; /* NB: refsack adds a ref to it */
@@ -885,7 +917,8 @@ rpmostree_get_refts_for_commit (OstreeRepo                *repo,
   if (!glnx_mkdtemp ("rpmostree-dbquery-XXXXXX", 0700, &tmpdir, error))
     return FALSE;
 
-  if (!checkout_only_rpmdb (repo, ref, &tmpdir, cancellable, error))
+  if (!checkout_only_rpmdb (repo, ref, RPMOSTREE_RPMDB_LOCATION,
+                            &tmpdir, cancellable, error))
     return FALSE;
 
   /* Ownership of tmpdir is transferred */

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -107,6 +107,12 @@ rpmostree_get_refsack_for_root (int              dfd,
                                 const char      *path,
                                 GError         **error);
 
+RpmOstreeRefSack *
+rpmostree_get_base_refsack_for_commit (OstreeRepo                *repo,
+                                       const char                *ref,
+                                       GCancellable              *cancellable,
+                                       GError                   **error);
+
 gboolean
 rpmostree_get_refts_for_commit (OstreeRepo                *repo,
                                 const char                *ref,

--- a/tests/compose-tests/test-jigdo-e2e.sh
+++ b/tests/compose-tests/test-jigdo-e2e.sh
@@ -54,7 +54,7 @@ assert_file_has_content jigdo2commit-out.txt '[1-9][0-9]* packages to import'
 ostree --repo=jigdo-unpack-repo rev-parse ${rev}
 ostree --repo=jigdo-unpack-repo fsck
 ostree --repo=jigdo-unpack-repo refs > jigdo-refs.txt
-assert_file_has_content jigdo-refs.txt 'rpmostree/pkg/test-pkg/1.0-1.x86__64'
+assert_file_has_content jigdo-refs.txt 'rpmostree/jigdo/test-pkg/1.0-1.x86__64'
 
 echo "ok jigdo ♲📦 fresh assembly"
 
@@ -96,7 +96,7 @@ ostree --repo=jigdo-unpack-repo fsck
 ostree --repo=jigdo-unpack-repo refs > jigdo-refs.txt
 # We should have both refs; GC will be handled by the sysroot upgrader
 # via deployments, same way it is for pkg layering.
-assert_file_has_content jigdo-refs.txt 'rpmostree/pkg/test-pkg/1.0-1.x86__64'
-assert_file_has_content jigdo-refs.txt 'rpmostree/pkg/test-pkg/1.1-1.x86__64'
+assert_file_has_content jigdo-refs.txt 'rpmostree/jigdo/test-pkg/1.0-1.x86__64'
+assert_file_has_content jigdo-refs.txt 'rpmostree/jigdo/test-pkg/1.1-1.x86__64'
 
 echo "ok jigdo ♲📦 update!"

--- a/tests/vmcheck/test-jigdo-client.sh
+++ b/tests/vmcheck/test-jigdo-client.sh
@@ -40,5 +40,5 @@ assert_file_has_content_literal err.txt 'rojig:// refspec requires --experimenta
 vm_rpmostree rebase --experimental rojig://fahc:fedora-atomic-host
 vm_assert_status_jq '.deployments[0].origin|startswith("rojig://fahc:fedora-atomic-host")'
 vm_cmd ostree refs > refs.txt
-assert_file_has_content refs.txt '^rpmostree/pkg/kernel-core/'
+assert_file_has_content refs.txt '^rpmostree/jigdo/kernel-core/'
 echo "ok jigdo client"


### PR DESCRIPTION
https://github.com/projectatomic/rpm-ostree/issues/1197

Currently just splits off the jigdo refs.

TODO:

 - Add + test ostree checksum as invalidation mechanism
 - Tests