### PR TITLE
status: Render jigdo mode using package NEVRA

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -472,10 +472,14 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
         /* We're also "pure" rpm-ostree jigdo - this adds assertions that we don't depsolve for example */
         if (!rpmostree_context_prepare_jigdo (ctx, cancellable, error))
           return FALSE;
+        DnfPackage *jigdo_pkg = rpmostree_context_get_jigdo_pkg (ctx);
         new_base_rev = g_strdup (rpmostree_context_get_jigdo_checksum (ctx));
         gboolean jigdo_changed;  /* Currently unused */
         if (!rpmostree_context_execute_jigdo (ctx, &jigdo_changed, cancellable, error))
           return FALSE;
+
+        if (jigdo_changed)
+          rpmostree_origin_set_jigdo_description (self->origin, jigdo_pkg);
       }
     }
 

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -142,7 +142,7 @@ rpmostree_origin_parse_keyfile (GKeyFile         *origin,
       g_assert (jigdo_spec);
       ret->refspec_type = RPMOSTREE_REFSPEC_TYPE_ROJIG;
       ret->cached_refspec = g_steal_pointer (&jigdo_spec);
-      ret->cached_jigdo_version = g_key_file_get_string (ret->kf, "origin", "jigdo-version", NULL);
+      ret->cached_jigdo_version = g_key_file_get_string (ret->kf, "origin", "jigdo-override-version", NULL);
       ret->cached_jigdo_description = g_key_file_get_string (ret->kf, "origin", "jigdo-description", NULL);
     }
 
@@ -428,9 +428,9 @@ rpmostree_origin_set_jigdo_version (RpmOstreeOrigin *origin,
                                     const char      *version)
 {
   if (version)
-    g_key_file_set_string (origin->kf, "origin", "jigdo-version", version);
+    g_key_file_set_string (origin->kf, "origin", "jigdo-override-version", version);
   else
-    g_key_file_remove_key (origin->kf, "origin", "jigdo-version", NULL);
+    g_key_file_remove_key (origin->kf, "origin", "jigdo-override-version", NULL);
   g_free (origin->cached_jigdo_version);
   origin->cached_jigdo_version = g_strdup (version);
 }
@@ -462,7 +462,7 @@ rpmostree_origin_set_rebase (RpmOstreeOrigin *origin,
    * rebase by default.
    */
   rpmostree_origin_set_override_commit (origin, NULL, NULL);
-  g_key_file_remove_key (origin->kf, "origin", "jigdo-version", NULL);
+  g_key_file_remove_key (origin->kf, "origin", "jigdo-override-version", NULL);
 
   /* See related code in rpmostree_origin_parse_keyfile() */
   const char *refspecdata;

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -69,6 +69,9 @@ gboolean rpmostree_origin_is_rojig (RpmOstreeOrigin *origin);
 const char *
 rpmostree_origin_get_jigdo_version (RpmOstreeOrigin *origin);
 
+GVariant *
+rpmostree_origin_get_jigdo_description (RpmOstreeOrigin *origin);
+
 GHashTable *
 rpmostree_origin_get_packages (RpmOstreeOrigin *origin);
 
@@ -118,6 +121,9 @@ void
 rpmostree_origin_set_override_commit (RpmOstreeOrigin *origin,
                                       const char      *checksum,
                                       const char      *version);
+void
+rpmostree_origin_set_jigdo_description (RpmOstreeOrigin *origin,
+                                        DnfPackage      *package);
 
 void
 rpmostree_origin_set_jigdo_version (RpmOstreeOrigin *origin,

--- a/tests/vmcheck/test-jigdo-client.sh
+++ b/tests/vmcheck/test-jigdo-client.sh
@@ -53,3 +53,8 @@ vm_assert_status_jq '.deployments[0].origin|startswith("rojig://fahc:fedora-atom
                     '.deployments[0].version == "'${prev_version}'"'
 
 echo "ok jigdo client deploy"
+
+vm_cmd rpm-ostree status > status.txt
+assert_file_has_content_literal status.txt  'fahc:fedora-atomic-host-'${prev_version}'-1.fc27.x86_64'
+
+echo "ok jigdo status"


### PR DESCRIPTION
What's happened up till now is supporting `rojig://` in the same way as
`ostree://`.  However, part of the high level goal here is to reduce
the need for system administrators to understand ostree.

This patch set starts to introduce some of the ideas for client-side
changes as part of jigdo ♲📦:
https://github.com/projectatomic/rpm-ostree/issues/1081#issuecomment-348540604

Basically, we can use the `NEVRA` of the jigdoRPM instead of displaying
`Version`. Also, let's be opinionated here and entirely drop the `Commit`
checksum by default. I believe the Cockpit guys were right here - versions are
for humans. The fact that we have a checksum is powerful; and we still show it
with `status -v`. The way I think of it is: the checksum shows we're really an
image system. But we don't need to show it by default.
