### PR TITLE
tests/compose: `f` is valid in a hex checksum

### DIFF
--- a/tests/compose-tests/test-boot-location-new.sh
+++ b/tests/compose-tests/test-boot-location-new.sh
@@ -19,7 +19,7 @@ diff -u bootls{-expected,}.txt
 ostree --repo=${repobuild} ls -R ${treeref} /usr/lib/ostree-boot > bootls.txt
 assert_file_has_content bootls.txt vmlinuz-
 assert_file_has_content bootls.txt initramfs-
-kver=$(grep /vmlinuz bootls.txt | sed -e 's,.*/vmlinuz-\(.*\)-[0-9a-e].*$,\1,')
+kver=$(grep /vmlinuz bootls.txt | sed -e 's,.*/vmlinuz-\(.*\)-[0-9a-f].*$,\1,')
 # And use the kver to find the kernel in /usr/lib/modules
 ostree --repo=${repobuild} ls ${treeref} /usr/lib/modules/${kver}/{vmlinuz,initramfs.img} >/dev/null
 echo "ok boot location new"


### PR DESCRIPTION
I *think* this is why our tests started failing recently. It seems somehow very
unlikely to me though that we'd somehow managed to avoid `f` in the boot
checksums until now, but without doing some math...it seems plausible.
