### PR TITLE
core/assemble: clean up rpmdb leftover files

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -68,6 +68,8 @@ extra-repos:
     gpgcheck: 0
 
 tests:
+  # we're still on devmapper here; we need to expand rootfs for tests
+  - for vm in vmcheck{1..3}; do ssh $vm lvresize -r -L +5G atomicos/root; done
   - yum install -y epel-release
   - ci/build-check.sh
   - make vmcheck

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -4010,6 +4010,10 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
         return FALSE;
     }
 
+  /* And finally, make sure we clean up rpmdb left over files */
+  if (!rpmostree_cleanup_leftover_rpmdb_files (tmprootfs_dfd, cancellable, error))
+    return FALSE;
+
   rpmostree_output_task_end ("done");
 
   return TRUE;

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -4010,10 +4010,6 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
         return FALSE;
     }
 
-  /* And finally, make sure we clean up rpmdb left over files */
-  if (!rpmostree_cleanup_leftover_rpmdb_files (tmprootfs_dfd, cancellable, error))
-    return FALSE;
-
   rpmostree_output_task_end ("done");
 
   return TRUE;
@@ -4130,6 +4126,10 @@ rpmostree_context_commit (RpmOstreeContext      *self,
     g_variant_builder_add (&metadata_builder, "{sv}",
                            "rpmostree.state-sha512",
                            g_variant_new_string (state_checksum));
+
+    /* And finally, make sure we clean up rpmdb left over files */
+    if (!rpmostree_cleanup_leftover_rpmdb_files (self->tmprootfs_dfd, cancellable, error))
+      return FALSE;
 
     OstreeRepoCommitModifierFlags modflags = OSTREE_REPO_COMMIT_MODIFIER_FLAGS_NONE;
     /* For ex-container (bare-user-only), we always need canonical permissions */

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1211,6 +1211,15 @@ cleanup_selinux_lockfiles (int            rootfs_fd,
   return TRUE;
 }
 
+gboolean
+rpmostree_cleanup_leftover_rpmdb_files (int            rootfs_fd,
+                                        GCancellable  *cancellable,
+                                        GError       **error)
+{
+  return cleanup_leftover_files (rootfs_fd, RPMOSTREE_RPMDB_LOCATION, rpmdb_leftover_files,
+                                 rpmdb_leftover_prefixes, cancellable, error);
+}
+
 /**
  * rpmostree_rootfs_postprocess_common:
  *
@@ -1253,8 +1262,7 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
         }
     }
 
-  if (!cleanup_leftover_files (rootfs_fd, RPMOSTREE_RPMDB_LOCATION, rpmdb_leftover_files,
-                               rpmdb_leftover_prefixes, cancellable, error))
+  if (!rpmostree_cleanup_leftover_rpmdb_files (rootfs_fd, cancellable, error))
     return FALSE;
 
   /* If we do have an rpmdb, hardlink it into the base path */

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -48,6 +48,12 @@ gboolean
 rpmostree_rootfs_prepare_links (int           rootfs_fd,
                                 GCancellable *cancellable,
                                 GError       **error);
+
+gboolean
+rpmostree_cleanup_leftover_rpmdb_files (int            rootfs_fd,
+                                        GCancellable  *cancellable,
+                                        GError       **error);
+
 gboolean
 rpmostree_rootfs_postprocess_common (int           rootfs_fd,
                                      GCancellable *cancellable,

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -107,12 +107,13 @@ fi
 echo "ok correct output"
 
 # check that there are no leftover rpmdb files
-vm_cmd ls -la /usr/share/rpm > out.txt
+booted_csum=$(vm_get_booted_csum)
+vm_cmd ostree ls $booted_csum /usr/share/rpm > out.txt
 assert_not_file_has_content out.txt __db
 echo "ok no leftover rpmdb files"
 
 # upgrade to a layer with foo already builtin
-vm_cmd ostree commit -b vmcheck --tree=ref=$(vm_get_booted_csum)
+vm_cmd ostree commit -b vmcheck --tree=ref=$booted_csum
 vm_rpmostree upgrade
 vm_build_rpm bar conflicts foo
 if vm_rpmostree install bar &> err.txt; then

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -106,6 +106,11 @@ if [[ $output != foo-1.0-1.x86_64 ]]; then
 fi
 echo "ok correct output"
 
+# check that there are no leftover rpmdb files
+ls -la /usr/share/rpm > out.txt
+assert_not_file_has_content out.txt __db
+echo "ok no leftover rpmdb files"
+
 # upgrade to a layer with foo already builtin
 vm_cmd ostree commit -b vmcheck --tree=ref=$(vm_get_booted_csum)
 vm_rpmostree upgrade

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -107,7 +107,7 @@ fi
 echo "ok correct output"
 
 # check that there are no leftover rpmdb files
-ls -la /usr/share/rpm > out.txt
+vm_cmd ls -la /usr/share/rpm > out.txt
 assert_not_file_has_content out.txt __db
 echo "ok no leftover rpmdb files"
 


### PR DESCRIPTION
While debugging the recent `BDB0087 DB_RUNRECOVERY` issues that cropped
up recently, I came upon the fact that we're leaving leftover rpmdb
files in the rootfs on client-side assemblies. Let's clean those up too.