### PR TITLE
tests: Add RPMOSTREE_TEST_NO_OVERLAY to skip overlay

### DIFF
--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -32,7 +32,7 @@ EOF
     fi
     # ✀✀✀ END selinux-policy hack ✀✀✀
 
-    vm_cmd env INSIDE_VM=1 /var/roothome/sync/tests/vmcheck/overlay.sh
+    vm_cmd env RPMOSTREE_TEST_NO_OVERLAY="${RPMOSTREE_TEST_NO_OVERLAY:-}" INSIDE_VM=1 /var/roothome/sync/tests/vmcheck/overlay.sh
     vm_reboot
     exit 0
 fi
@@ -69,10 +69,16 @@ rm vmcheck -rf
 ostree checkout $commit vmcheck --fsync=0
 rm vmcheck/etc -rf
 
-# Now, overlay our built binaries & config files
-INSTTREE=/var/roothome/sync/insttree
-rsync -rlv $INSTTREE/usr/ vmcheck/usr/
-rsync -rlv $INSTTREE/etc/ vmcheck/usr/etc/
+# Now, overlay our built binaries & config files, unless
+# explicitly requested not to (with the goal of testing the
+# tree shipped as is with our existing tests).
+if test -z "${RPMOSTREE_TEST_NO_OVERLAY}"; then
+    INSTTREE=/var/roothome/sync/insttree
+    rsync -rlv $INSTTREE/usr/ vmcheck/usr/
+    rsync -rlv $INSTTREE/etc/ vmcheck/usr/etc/
+else
+    echo "Skipping overlay of built rpm-ostree"
+fi
 
 ## ✀✀✀ BEGIN selinux-policy hack (part 2) for
 ## https://github.com/fedora-selinux/selinux-policy-contrib/pull/45

--- a/tests/vmcheck/test.sh
+++ b/tests/vmcheck/test.sh
@@ -74,7 +74,9 @@ fi
 if vm_cmd test -f /etc/rpm-ostreed.conf; then
   vm_cmd mv -f /etc/rpm-ostreed.conf{,.bak}
 fi
-vm_cmd cp -f /usr/etc/rpm-ostreed.conf /etc
+if vm_cmd test -f /usr/etc/rpm-ostreed.conf; then
+    vm_cmd cp -f /usr/etc/rpm-ostreed.conf /etc
+fi
 
 vm_cmd ostree remote delete --if-exists vmcheckmote
 


### PR DESCRIPTION
The use case here is to run our tests against the shipped tree;
this could be used by a-h-t for example:
https://github.com/projectatomic/atomic-host-tests/issues/74

I tried this with just `TESTS=basic` and it failed for `usroverlay`. So we'd
have to start adding feature detection to the test suite to make this truly
useful, but let's at least start with the basic bits now to play with it.
