### PR TITLE
daemon/api: fix legacy D-Bus API and add coverage

### DIFF
--- a/src/daemon/rpmostreed-deployment-utils.h
+++ b/src/daemon/rpmostreed-deployment-utils.h
@@ -42,7 +42,8 @@ GVariant *      rpmostreed_deployment_generate_variant (OstreeSysroot    *sysroo
 
 GVariant *      rpmostreed_commit_generate_cached_details_variant (OstreeDeployment *deployment,
                                                                    OstreeRepo       *repo,
-                                                                   const gchar      *refspec,
+                                                                   const char       *refspec,
+                                                                   const char       *checksum,
                                                                    GError          **error);
 gboolean
 rpmostreed_update_generate_variant (OstreeSysroot *sysroot,

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -427,6 +427,7 @@ os_handle_get_cached_update_rpm_diff (RPMOSTreeOS *interface,
 
   details = rpmostreed_commit_generate_cached_details_variant (base_deployment, ot_repo,
                                                                rpmostree_origin_get_refspec (origin),
+                                                               NULL,
                                                                &local_error);
   if (!details)
     goto out;
@@ -1471,6 +1472,7 @@ os_handle_get_cached_rebase_rpm_diff (RPMOSTreeOS *interface,
   details = rpmostreed_commit_generate_cached_details_variant (base_deployment,
                                                                ot_repo,
                                                                comp_ref,
+                                                               NULL,
                                                                &local_error);
   if (!details)
     goto out;
@@ -1606,7 +1608,8 @@ os_handle_get_cached_deploy_rpm_diff (RPMOSTreeOS *interface,
 
   details = rpmostreed_commit_generate_cached_details_variant (base_deployment,
                                                                ot_repo,
-                                                               NULL,
+                                                               rpmostree_origin_get_refspec (origin),
+                                                               checksum,
                                                                &local_error);
   if (!details)
     goto out;

--- a/tests/vmcheck/test-cached-rpm-diffs.sh
+++ b/tests/vmcheck/test-cached-rpm-diffs.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# Test some of the legacy D-Bus APIs that Cockpit still uses. This is also
+# useful for making sure we don't break anything when we move those APIs over to
+# use the new pkglist data.
+
+# the usual update synthesis trickery
+vm_build_rpm pkg1
+vm_rpmostree install pkg1
+deploy_csum=$(vm_cmd ostree commit -b vmcheck --fsync=no \
+                --tree=ref=$(vm_get_pending_csum) \
+                --add-metadata-string=version=vDeploy)
+# put a pin on it so it doesn't get blown away
+vm_cmd ostree refs $deploy_csum --create vmcheck_tmp/pinned
+vm_build_rpm pkg2
+vm_rpmostree install pkg2
+update_csum=$(vm_cmd ostree commit -b vmcheck --fsync=no \
+                --tree=ref=$(vm_get_pending_csum) \
+                --add-metadata-string=version=vUpdate)
+vm_build_rpm pkg3
+vm_rpmostree install pkg3
+rebase_csum=$(vm_cmd ostree commit -b vmcheck_tmp/other_branch --fsync=no \
+                --tree=ref=$(vm_get_pending_csum) \
+                --add-metadata-string=version=vRebase)
+vm_rpmostree cleanup -p
+echo "ok setup"
+
+osname=$(vm_get_booted_deployment_info osname)
+ospath=/org/projectatomic/rpmostree1/${osname/-/_}
+
+call_dbus() {
+  method=$1; shift
+  vm_cmd gdbus call -y -d org.projectatomic.rpmostree1 -o $ospath \
+    -m org.projectatomic.rpmostree1.OS.$method "$@"
+}
+
+call_dbus GetCachedDeployRpmDiff "vDeploy" [] > out.txt
+assert_file_has_content out.txt "<'vmcheck'>"
+assert_file_has_content out.txt "$deploy_csum"
+assert_file_has_content out.txt "vDeploy"
+assert_file_has_content out.txt "pkg1"
+assert_not_file_has_content out.txt "pkg2"
+assert_not_file_has_content out.txt "pkg3"
+echo "ok GetCachedDeployRpmDiff"
+
+# extra quotes for hungry ssh
+call_dbus GetCachedUpdateRpmDiff '""' > out.txt
+assert_file_has_content out.txt "<'vmcheck'>"
+assert_file_has_content out.txt "$update_csum"
+assert_file_has_content out.txt "vUpdate"
+assert_file_has_content out.txt "pkg1"
+assert_file_has_content out.txt "pkg2"
+assert_not_file_has_content out.txt "pkg3"
+echo "ok GetCachedUpdateRpmDiff"
+
+call_dbus GetCachedRebaseRpmDiff "vmcheck_tmp/other_branch" [] > out.txt
+assert_file_has_content out.txt "<'vmcheck_tmp/other_branch'>"
+assert_file_has_content out.txt "$rebase_csum"
+assert_file_has_content out.txt "vRebase"
+assert_file_has_content out.txt "pkg1"
+assert_file_has_content out.txt "pkg2"
+assert_file_has_content out.txt "pkg3"
+echo "ok GetCachedRebaseRpmDiff"

--- a/tests/vmcheck/test-cached-rpm-diffs.sh
+++ b/tests/vmcheck/test-cached-rpm-diffs.sh
@@ -50,7 +50,7 @@ vm_rpmostree cleanup -p
 echo "ok setup"
 
 osname=$(vm_get_booted_deployment_info osname)
-ospath=/org/projectatomic/rpmostree1/${osname/-/_}
+ospath=/org/projectatomic/rpmostree1/${osname//-/_}
 
 call_dbus() {
   method=$1; shift


### PR DESCRIPTION
Fix logic to make sure we check if the refspec is of type `ostree://`
even when it's explicitly specified. Also fix `Deploy` in the case where
we didn't just `Download` the RPM diff by adding a new `@checksum`
parameter to the higher-level API.

Finally, add a basic test for the `GetCached*RpmDiff` APIs so we have at
least *some* coverage. This is also good prep for making sure we don't
break anything when we convert those APIs to use the more efficient
pkglist metadata. The tests completely ignore the `DownloadRpmDiff`
paths for now though.

Closes: #1250