### PR TITLE
app/override: allow removing and replacing atomically

### DIFF
--- a/src/app/rpmostree-override-builtins.c
+++ b/src/app/rpmostree-override-builtins.c
@@ -29,6 +29,8 @@ static char *opt_osname;
 static gboolean opt_reboot;
 static gboolean opt_dry_run;
 static gboolean opt_reset_all;
+static const char *const *opt_remove_pkgs;
+static const char *const *opt_replace_pkgs;
 static const char *const *install_pkgs;
 static const char *const *uninstall_pkgs;
 
@@ -41,6 +43,16 @@ static GOptionEntry option_entries[] = {
 
 static GOptionEntry reset_option_entries[] = {
   { "all", 'a', 0, G_OPTION_ARG_NONE, &opt_reset_all, "Reset all active overrides", NULL },
+  { NULL }
+};
+
+static GOptionEntry replace_option_entries[] = {
+  { "remove", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_remove_pkgs, "Remove a package", "PKG" },
+  { NULL }
+};
+
+static GOptionEntry remove_option_entries[] = {
+  { "replace", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_replace_pkgs, "Replace a package", "RPM" },
   { NULL }
 };
 
@@ -124,6 +136,8 @@ rpmostree_override_builtin_replace (int argc, char **argv,
 
   context = g_option_context_new ("PACKAGE [PACKAGE...]");
 
+  g_option_context_add_main_entries (context, replace_option_entries, NULL);
+
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
                                        &argc, &argv,
@@ -149,7 +163,7 @@ rpmostree_override_builtin_replace (int argc, char **argv,
   argv[argc] = NULL;
 
   return handle_override (sysroot_proxy,
-                          NULL, (const char *const*)argv, NULL,
+                          opt_remove_pkgs, (const char *const*)argv, NULL,
                           cancellable, error);
 }
 
@@ -165,6 +179,8 @@ rpmostree_override_builtin_remove (int argc, char **argv,
 
   context = g_option_context_new ("PACKAGE [PACKAGE...]");
 
+  g_option_context_add_main_entries (context, remove_option_entries, NULL);
+
   if (!rpmostree_option_context_parse (context,
                                        option_entries,
                                        &argc, &argv,
@@ -190,7 +206,7 @@ rpmostree_override_builtin_remove (int argc, char **argv,
   argv[argc] = NULL;
 
   return handle_override (sysroot_proxy,
-                          (const char *const*)argv, NULL, NULL,
+                          (const char *const*)argv, opt_replace_pkgs, NULL,
                           cancellable, error);
 }
 

--- a/tests/vmcheck/test-override-local-replace.sh
+++ b/tests/vmcheck/test-override-local-replace.sh
@@ -171,15 +171,15 @@ vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo_and_bar
 vm_rpmostree upgrade
 vm_rpmostree override replace $YUMREPO/bar-0.9-1.x86_64.rpm \
                        --install $YUMREPO/baz-1.0-1.x86_64.rpm \
-                       --remove foo
+                       --remove foo --remove fooext
 vm_assert_status_jq \
   '.deployments[0]["base-local-replacements"]|length == 1' \
   '.deployments[0]["requested-base-local-replacements"]|length == 1' \
   '.deployments[0]["requested-local-packages"]|length == 1' \
   '.deployments[0]["requested-local-packages"]|index("baz-1.0-1.x86_64") >= 0' \
-  '.deployments[0]["base-removals"]|length == 1' \
+  '.deployments[0]["base-removals"]|length == 2' \
   '[.deployments[0]["base-removals"][][.0]]|index("foo-1.0-1.x86_64") >= 0' \
-  '.deployments[0]["requested-base-removals"]|length == 1' \
+  '.deployments[0]["requested-base-removals"]|length == 2' \
   '.deployments[0]["requested-base-removals"]|index("foo") >= 0'
 assert_replaced_local_pkg bar-1.0-1.x86_64 bar-0.9-1.x86_64
 echo "ok local replace and local layering"


### PR DESCRIPTION
This is an essential functionality rather than a nicety. Some
replacements can *only* be done without conflicts if we can remove
packages at the same time.

I do like that this has to be done explicitly, though OTOH, I can
definitely see folks wanting an `--allow-removals` type of switch in the
future.

Closes: #1255