### PR TITLE
configure.ac: Bump ostree build dep to v2018.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ LIBS="$save_LIBS"
 # Remember to update AM_CPPFLAGS in Makefile.am when bumping GIO req.
 PKG_CHECK_MODULES(PKGDEP_GIO_UNIX, [gio-unix-2.0])
 PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0
-				     ostree-1 >= 2017.14
+				     ostree-1 >= 2018.2
 				     libsystemd
 				     polkit-gobject-1
 				     rpm librepo libsolv


### PR DESCRIPTION
We make use of the new `OstreeRepoCheckoutFilterResult` type.