### PR TITLE
Release 2018.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,13 @@
 AC_PREREQ([2.63])
 dnl To do a release, increment this number, commit, then submit it as a PR
 dnl to merge via homu.  After that, do `git pull origin && git reset --hard origin/master`.
-dnl Then use https://github.com/cgwalters/git-evtag to sign.
+dnl Then draft release notes highlighting changes and generate the shortlog using
+dnl <https://github.com/cgwalters/homegit/blob/master/bin/git-shortlog-with-prs>.
+dnl Then use <https://github.com/cgwalters/git-evtag> to create a signed tag with the
+dnl release notes as its content.
 dnl Then, git push origin v201X.XX
 m4_define([year_version], [2018])
-m4_define([release_version], [2])
+m4_define([release_version], [3])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [atomic-devel@projectatomic.io])
 AC_CONFIG_HEADER([config.h])


### PR DESCRIPTION
Bugfix release to fix minor performance regression from auto-updates
work. Plus a low-risk enhancement to `status` to print only the booted
deployment with `--booted`.

Also minor refresh of release workflow documentation.