### PR TITLE
tests/jigdo-client: Re-enable

### DIFF
--- a/tests/vmcheck/test-jigdo-client.sh
+++ b/tests/vmcheck/test-jigdo-client.sh
@@ -24,9 +24,6 @@ set -euo pipefail
 
 set -x
 
-echo "ok SKIP for v5 bump; remove after FAHC is rebuilt"
-exit 0
-
 # Test rebasing to https://pagure.io/fedora-atomic-host-continuous
 # in rojig:// mode.
 


### PR DESCRIPTION
FAHC is rebuilt now with v5.
