### PR TITLE
auto-updates: Cache `cached-update` GVariant to disk

### DIFF
--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -81,7 +81,7 @@
        'signatures' (type 'av')
        'gpg-enabled' (type 'b')
        'ref-has-new-commit' (type 'b')
-          TRUE if 'checksum' refers to a new commit we're not booted in.
+          TRUE if 'checksum' refers to a new base commit we're not booted in.
        'rpm-diff' (type 'a{sv}')
           'upgraded' (type 'a(us(ss)(ss))')
           'downgraded' (type 'a(us(ss)(ss))')

--- a/src/daemon/rpmostreed-deployment-utils.h
+++ b/src/daemon/rpmostreed-deployment-utils.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <ostree.h>
+#include <libdnf/libdnf.h>
 
 #include "rpmostreed-types.h"
 
@@ -45,9 +46,11 @@ GVariant *      rpmostreed_commit_generate_cached_details_variant (OstreeDeploym
                                                                    const char       *refspec,
                                                                    const char       *checksum,
                                                                    GError          **error);
-gboolean
-rpmostreed_update_generate_variant (OstreeSysroot *sysroot,
-                                    OstreeDeployment *deployment,
-                                    OstreeRepo *repo,
-                                    GVariant **out_update,
-                                    GError **error);
+
+gboolean        rpmostreed_update_generate_variant (OstreeSysroot     *sysroot,
+                                                    OstreeDeployment  *deployment,
+                                                    OstreeRepo        *repo,
+                                                    DnfSack           *sack,
+                                                    GVariant         **out_update,
+                                                    GCancellable      *cancellable,
+                                                    GError           **error);

--- a/src/daemon/rpmostreed-deployment-utils.h
+++ b/src/daemon/rpmostreed-deployment-utils.h
@@ -47,8 +47,7 @@ GVariant *      rpmostreed_commit_generate_cached_details_variant (OstreeDeploym
                                                                    const char       *checksum,
                                                                    GError          **error);
 
-gboolean        rpmostreed_update_generate_variant (OstreeSysroot     *sysroot,
-                                                    OstreeDeployment  *deployment,
+gboolean        rpmostreed_update_generate_variant (OstreeDeployment  *deployment,
                                                     OstreeRepo        *repo,
                                                     DnfSack           *sack,
                                                     GVariant         **out_update,

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -914,14 +914,14 @@ os_handle_update_deployment (RPMOSTreeOS *interface,
 }
 
 /* compat shim for call completer */
-static void automatic_update_trigger_completer (RPMOSTreeOS            *os,
-                                                GDBusMethodInvocation  *invocation,
-                                                GUnixFDList            *dummy,
-                                                const gchar            *address)
+static void
+automatic_update_trigger_completer (RPMOSTreeOS            *os,
+                                    GDBusMethodInvocation  *invocation,
+                                    GUnixFDList            *dummy,
+                                    const gchar            *address)
 {                                                              /* enabled */
   rpmostree_os_complete_automatic_update_trigger (os, invocation, TRUE, address);
 }
-
 
 /* we make this a separate method to keep the D-Bus API clean, but the actual
  * implementation is done by our dear friend deploy_transaction_execute(). ❤️
@@ -932,11 +932,26 @@ os_handle_automatic_update_trigger (RPMOSTreeOS *interface,
                                     GDBusMethodInvocation *invocation,
                                     GVariant *arg_options)
 {
+  g_autoptr(GError) local_error = NULL;
+  GError **error = &local_error;
+
+  const char *osname = rpmostree_os_get_name (interface);
+  OstreeSysroot *sysroot = rpmostreed_sysroot_get_root (rpmostreed_sysroot_get ());
+  OstreeDeployment *booted = ostree_sysroot_get_booted_deployment (sysroot);
+  if (!booted || !g_str_equal (osname, ostree_deployment_get_osname (booted)))
+    {
+      /* We're not even booted in our osname; let's just not handle this case for now until
+       * someone shows up with a good use case for it. We only want the booted OS to use the
+       * current /var/cache, since it's per-OS. If we ever allow this, we'll want to
+       * invalidate the auto-update cache on the osname as well. */
+      glnx_throw (error, "Cannot trigger auto-update for offline OS '%s'", osname);
+      g_dbus_method_invocation_take_error (invocation, g_steal_pointer (&local_error));
+      return TRUE;
+    }
+
   g_auto(GVariantDict) dict;
   g_variant_dict_init (&dict, arg_options);
   const char *mode = vardict_lookup_ptr (&dict, "mode", "&s") ?: "auto";
-  g_autoptr(GError) local_error = NULL;
-  GError **error = &local_error;
 
   RpmostreedAutomaticUpdatePolicy autoupdate_policy;
   if (g_str_equal (mode, "auto"))
@@ -1696,44 +1711,69 @@ out:
   return TRUE;
 }
 
+/* split out for easier handling of the NULL case */
+static gboolean
+refresh_cached_update_impl (RpmostreedOS *self,
+                            GVariant    **out_cached_update,
+                            GError      **error)
+{
+  g_autoptr(GVariant) cached_update = NULL;
+
+  /* if we're not booted into our OS, don't look at cache; it's for another OS interface */
+  const char *osname = rpmostree_os_get_name (RPMOSTREE_OS (self));
+  OstreeSysroot *sysroot = rpmostreed_sysroot_get_root (rpmostreed_sysroot_get ());
+  OstreeDeployment *booted = ostree_sysroot_get_booted_deployment (sysroot);
+  if (!booted || !g_str_equal (osname, ostree_deployment_get_osname (booted)))
+    return TRUE; /* Note early return */
+
+  glnx_autofd int fd = -1;
+  g_autoptr(GError) local_error = NULL;
+  if (!glnx_openat_rdonly (AT_FDCWD, RPMOSTREE_AUTOUPDATES_CACHE_FILE, TRUE, &fd,
+                           &local_error))
+    {
+      if (!g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+        return g_propagate_error (error, g_steal_pointer (&local_error)), FALSE;
+      return TRUE; /* Note early return */
+    }
+
+  /* sanity check there isn't something fishy going on before even reading it in */
+  struct stat stbuf;
+  if (!glnx_fstat (fd, &stbuf, error))
+    return FALSE;
+
+  if (!rpmostree_check_size_within_limit (stbuf.st_size, OSTREE_MAX_METADATA_SIZE,
+                                          RPMOSTREE_AUTOUPDATES_CACHE_FILE, error))
+    return FALSE;
+
+  g_autoptr(GBytes) data = glnx_fd_readall_bytes (fd, NULL, error);
+  if (!data)
+    return FALSE;
+
+  cached_update =
+    g_variant_ref_sink (g_variant_new_from_bytes (G_VARIANT_TYPE_VARDICT, data, FALSE));
+
+  /* check if cache is still valid -- see rpmostreed_update_generate_variant() */
+  g_auto(GVariantDict) dict;
+  g_variant_dict_init (&dict, cached_update);
+  const char *state = vardict_lookup_ptr (&dict, "update-sha256", "&s");
+  if (g_strcmp0 (state, ostree_deployment_get_csum (booted)) != 0)
+    {
+      sd_journal_print (LOG_INFO, "Deleting outdated cached update for OS '%s'", osname);
+      g_clear_pointer (&cached_update, (GDestroyNotify)g_variant_unref);
+      if (!glnx_unlinkat (AT_FDCWD, RPMOSTREE_AUTOUPDATES_CACHE_FILE, 0, error))
+        return FALSE;
+    }
+
+  *out_cached_update = g_steal_pointer (&cached_update);
+  return TRUE;
+}
+
 static gboolean
 refresh_cached_update (RpmostreedOS *self, GError **error)
 {
   g_autoptr(GVariant) cached_update = NULL;
-
-  gsize n;
-  g_autofree char *contents = NULL;
-  g_autoptr(GError) local_error = NULL;
-  if (!g_file_get_contents (RPMOSTREE_AUTOUPDATES_CACHE_FILE, &contents, &n, &local_error))
-    {
-      if (!g_error_matches (local_error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
-        return g_propagate_error (error, g_steal_pointer (&local_error)), FALSE;
-    }
-  else
-    {
-      /* sanity check there isn't something fishy going on */
-      if (!rpmostree_check_size_within_limit (n, OSTREE_MAX_METADATA_SIZE,
-                                              RPMOSTREE_AUTOUPDATES_CACHE_FILE, error))
-        return FALSE;
-
-      char *contents_owned = g_steal_pointer (&contents);
-      cached_update =
-        g_variant_ref_sink (g_variant_new_from_data (G_VARIANT_TYPE_VARDICT, contents_owned, n,
-                                                     FALSE, g_free, contents_owned));
-
-      /* check if the cache is still valid -- see rpmostred_update_generate_variant() */
-      g_auto(GVariantDict) dict;
-      g_variant_dict_init (&dict, cached_update);
-      const char *state = vardict_lookup_ptr (&dict, "state-sha512", "&s");
-      OstreeSysroot *sysroot = rpmostreed_sysroot_get_root (rpmostreed_sysroot_get ());
-      OstreeDeployment *booted = ostree_sysroot_get_booted_deployment (sysroot);
-      if (!booted || g_strcmp0 (state, ostree_deployment_get_csum (booted)) != 0)
-        {
-          g_clear_pointer (&cached_update, (GDestroyNotify)g_variant_unref);
-          if (!glnx_unlinkat (AT_FDCWD, RPMOSTREE_AUTOUPDATES_CACHE_FILE, 0, error))
-            return FALSE;
-        }
-    }
+  if (!refresh_cached_update_impl (self, &cached_update, error))
+    return FALSE;
 
   rpmostree_os_set_cached_update (RPMOSTREE_OS (self), cached_update);
   rpmostree_os_set_has_cached_update_rpm_diff (RPMOSTREE_OS (self), cached_update != NULL);

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1528,7 +1528,9 @@ refresh_md_transaction_execute (RpmostreedTransaction *transaction,
   /* point libdnf to our repos dir */
   rpmostree_context_configure_from_deployment (ctx, sysroot, cfg_merge_deployment);
 
-  if (!rpmostree_context_download_metadata (ctx, cancellable, error))
+  /* don't even bother loading the rpmdb */
+  if (!rpmostree_context_download_metadata (ctx, DNF_CONTEXT_SETUP_SACK_FLAG_SKIP_RPMDB,
+                                            cancellable, error))
     return FALSE;
 
   return TRUE;

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1045,6 +1045,12 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
 {
   g_assert (!self->empty);
 
+  /* https://github.com/rpm-software-management/libdnf/pull/416
+   * https://github.com/projectatomic/rpm-ostree/issues/1127
+   */
+  if (self->rojig_pure)
+    dnf_context_set_enable_filelists (self->dnfctx, FALSE);
+
   g_autoptr(GPtrArray) rpmmd_repos =
     get_enabled_rpmmd_repos (self->dnfctx, DNF_REPO_ENABLED_PACKAGES);
 

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -153,8 +153,9 @@ rpmostree_get_nevra_from_pkgcache (OstreeRepo   *repo,
                                    GError  **error);
 
 gboolean rpmostree_context_download_metadata (RpmOstreeContext  *context,
-                                               GCancellable      *cancellable,
-                                               GError           **error);
+                                              DnfContextSetupSackFlags flags,
+                                              GCancellable      *cancellable,
+                                              GError           **error);
 
 /* This API allocates an install context, use with one of the later ones */
 gboolean rpmostree_context_prepare (RpmOstreeContext     *self,

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -36,6 +36,9 @@
 #define RPMOSTREE_SYSIMAGE_DIR "usr/lib/sysimage"
 #define RPMOSTREE_BASE_RPMDB RPMOSTREE_SYSIMAGE_DIR "/rpm-ostree-base-db"
 
+/* put it in cache dir so it gets destroyed naturally with a `cleanup -m` */
+#define RPMOSTREE_AUTOUPDATES_CACHE_FILE RPMOSTREE_CORE_CACHEDIR "cached-update.gv"
+
 #define RPMOSTREE_TYPE_CONTEXT (rpmostree_context_get_type ())
 G_DECLARE_FINAL_TYPE (RpmOstreeContext, rpmostree_context, RPMOSTREE, CONTEXT, GObject)
 

--- a/tests/check/test-basic.sh
+++ b/tests/check/test-basic.sh
@@ -71,13 +71,6 @@ rpm-ostree rebase --os=testos otheros:
 assert_status_jq '.deployments[0].version == "'$(date "+%Y%m%d.0")'"'
 echo "ok rebase onto newer version"
 
-# Test 'upgrade --check' w/ no upgrade
-# XXX Disabled this because source repo has no /usr/share/rpm
-#     Maybe that's too heavy a requirement to just check for an
-#     upgrade, but on the other hand this is *RPM*-ostree.
-#rpm-ostree upgrade --os=testos --check
-#test "$?" = "77" || (echo 1>&2 "Expected exit code 77, got $?"; exit 1)
-
 # Jump backward to 1.0.9
 rpm-ostree deploy --os=testos 1.0.9
 assert_status_jq '.deployments[0].version == "1.0.9"'


### PR DESCRIPTION
Rather than recalculating `cached-update` as part of transaction
cleanups and RpmostreedOS internal reloads, write it directly to a file
from `deploy_transaction_execute`. This gives two major benefits:

1. Auto-updates now has virtually zero impact to daemon startup time.
2. We get to directly use the `DnfSack` created during metadata refresh
   rather than reconstructing it later on. This greatly simplifies code.

This makes use of new APIs in libdnf to skip filelists and load
updateinfo metadata right from the start.

Requires: https://github.com/rpm-software-management/libdnf/pull/420