### PR TITLE
fix "make tags"

### DIFF
--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -42,7 +42,6 @@ librpmostreepriv_la_SOURCES = \
 	src/libpriv/rpmostree-scripts.h \
 	src/libpriv/rpmostree-refsack.h \
 	src/libpriv/rpmostree-refsack.c \
-	src/libpriv/rpmostree-cleanup.h \
 	src/libpriv/rpmostree-rpm-util.c \
 	src/libpriv/rpmostree-rpm-util.h \
 	src/libpriv/rpmostree-importer.c \


### PR DESCRIPTION
src/libpriv/rpmostree-cleanup.h was removed in commit f14d1a3536418ad9a277e328641776a4d0b5b50e and its presence in Makefile causes "make tags" to fail.