### PR TITLE
lib/package: Handle arch pkg transitions

### DIFF
--- a/src/lib/rpmostree-package.c
+++ b/src/lib/rpmostree-package.c
@@ -349,17 +349,7 @@ _rpm_ostree_diff_package_lists (GPtrArray  *a,
       else
         {
           cmp = strcmp (pkg_a->arch, pkg_b->arch);
-          if (cmp < 0)
-            {
-              g_ptr_array_add (unique_a, g_object_ref (pkg_a));
-              cur_a++;
-            }
-          else if (cmp > 0)
-            {
-              g_ptr_array_add (unique_b, g_object_ref (pkg_b));
-              cur_b++;
-            }
-          else
+          if (cmp == 0)
             {
               cmp = dnf_sack_evr_cmp (sack, pkg_a->evr, pkg_b->evr);
               if (cmp == 0)
@@ -373,6 +363,19 @@ _rpm_ostree_diff_package_lists (GPtrArray  *a,
                 }
               cur_a++;
               cur_b++;
+            }
+          else
+            {
+              if (cmp < 0)
+                {
+                  g_ptr_array_add (unique_a, g_object_ref (pkg_a));
+                  cur_a++;
+                }
+              else if (cmp > 0)
+                {
+                  g_ptr_array_add (unique_b, g_object_ref (pkg_b));
+                  cur_b++;
+                }
             }
         }
     }

--- a/src/lib/rpmostree-package.c
+++ b/src/lib/rpmostree-package.c
@@ -371,9 +371,9 @@ _rpm_ostree_diff_package_lists (GPtrArray  *a,
                   g_ptr_array_add (modified_a, g_object_ref (pkg_a));
                   g_ptr_array_add (modified_b, g_object_ref (pkg_b));
                 }
+              cur_a++;
+              cur_b++;
             }
-          cur_a++;
-          cur_b++;
         }
     }
 


### PR DESCRIPTION
Let's try to match expectations a bit from the dnf/yum world and
describe e.g. a `noarch` package become archful as an upgrade rather
than a removal and an addition. This was originally implicitly supported
(before PR #1230) by the fact that we didn't compare arches at all (and
in fact, arches don't even show up in a `db diff` output for modified
packages).

We bring this back here, but only in the simple case that it's a single
package. We still don't try to do any fancy handling for packages of the
same name.

Closes: #1272