### PR TITLE
scripts: Support RPMOSTREE_SCRIPT_DEBUG

### DIFF
--- a/src/libpriv/rpmostree-bwrap.c
+++ b/src/libpriv/rpmostree-bwrap.c
@@ -104,6 +104,13 @@ rpmostree_bwrap_unref (RpmOstreeBwrap *bwrap)
   g_free (bwrap);
 }
 
+/* Configure the process to inherit stdin */
+void
+rpmostree_bwrap_set_inherit_stdin (RpmOstreeBwrap *bwrap)
+{
+  g_subprocess_launcher_set_flags (bwrap->launcher, G_SUBPROCESS_FLAGS_STDIN_INHERIT);
+}
+
 void
 rpmostree_bwrap_append_bwrap_argv (RpmOstreeBwrap *bwrap, ...)
 {

--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -43,6 +43,7 @@ RpmOstreeBwrap *rpmostree_bwrap_new (int rootfs,
                                      GError **error,
                                      ...) G_GNUC_NULL_TERMINATED;
 
+void rpmostree_bwrap_set_inherit_stdin (RpmOstreeBwrap *bwrap);
 void rpmostree_bwrap_append_bwrap_argv (RpmOstreeBwrap *bwrap, ...) G_GNUC_NULL_TERMINATED;
 void rpmostree_bwrap_append_child_argv (RpmOstreeBwrap *bwrap, ...) G_GNUC_NULL_TERMINATED;
 


### PR DESCRIPTION
This makes it easy to get an interactive shell instead of executing a specific
script. I used this while debugging `build-locale-archive`. This is better than
`bwrap-script-shell.sh` as we'll get the real rofiles-fuse etc., and
additionally have the root filesystem at the exact same point.
