### PR TITLE
Second renaming pass for "rojig"

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -483,11 +483,11 @@ print_deployments (RPMOSTreeSysroot *sysroot_proxy,
               break;
             case RPMOSTREE_REFSPEC_TYPE_ROJIG:
               {
-                g_autoptr(GVariant) jigdo_description = NULL;
-                g_variant_dict_lookup (dict, "jigdo-description", "@a{sv}", &jigdo_description);
-                if (jigdo_description)
+                g_autoptr(GVariant) rojig_description = NULL;
+                g_variant_dict_lookup (dict, "rojig-description", "@a{sv}", &rojig_description);
+                if (rojig_description)
                   {
-                    g_autoptr(GVariantDict) dict = g_variant_dict_new (jigdo_description);
+                    g_autoptr(GVariantDict) dict = g_variant_dict_new (rojig_description);
                     const char *repo = NULL;
                     g_variant_dict_lookup (dict, "repo", "&s", &repo);
                     const char *name = NULL;

--- a/src/app/rpmostree-ex-builtin-jigdo2commit.c
+++ b/src/app/rpmostree-ex-builtin-jigdo2commit.c
@@ -103,15 +103,15 @@ rpm_ostree_jigdo2commit_context_new (RpmOstreeJigdo2CommitContext **out_context,
 
 static gboolean
 impl_rojig2commit (RpmOstreeJigdo2CommitContext *self,
-                   const char                   *jigdo_id,
+                   const char                   *rojig_id,
                    GCancellable                 *cancellable,
                    GError                      **error)
 {
   g_autoptr(GKeyFile) tsk = g_key_file_new ();
 
-  g_key_file_set_string (tsk, "tree", "jigdo", jigdo_id);
+  g_key_file_set_string (tsk, "tree", "rojig", rojig_id);
   if (opt_oirpm_version)
-    g_key_file_set_string (tsk, "tree", "jigdo-version", opt_oirpm_version);
+    g_key_file_set_string (tsk, "tree", "rojig-version", opt_oirpm_version);
   if (opt_releasever)
     g_key_file_set_string (tsk, "tree", "releasever", opt_releasever);
   if (opt_enable_rpmmdrepo)
@@ -122,13 +122,13 @@ impl_rojig2commit (RpmOstreeJigdo2CommitContext *self,
   if (!treespec)
     return FALSE;
 
-  /* We're also "pure" jigdo - this adds assertions that we don't depsolve for example */
+  /* We're also "pure" rojig - this adds assertions that we don't depsolve for example */
   if (!rpmostree_context_setup (self->ctx, NULL, NULL, treespec, cancellable, error))
     return FALSE;
   if (!rpmostree_context_prepare_jigdo (self->ctx, cancellable, error))
     return FALSE;
-  gboolean jigdo_changed;
-  if (!rpmostree_context_execute_jigdo (self->ctx, &jigdo_changed, cancellable, error))
+  gboolean rojig_changed;
+  if (!rpmostree_context_execute_jigdo (self->ctx, &rojig_changed, cancellable, error))
     return FALSE;
 
   return TRUE;

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -443,10 +443,10 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
           return glnx_throw (error, "Specifying commit overrides for rojig:// is not implemented yet");
 
         g_autoptr(GKeyFile) tsk = g_key_file_new ();
-        g_key_file_set_string (tsk, "tree", "jigdo", refspec);
-        const char *jigdo_version = rpmostree_origin_get_jigdo_version (self->origin);
-        if (jigdo_version)
-          g_key_file_set_string (tsk, "tree", "jigdo-version", jigdo_version);
+        g_key_file_set_string (tsk, "tree", "rojig", refspec);
+        const char *rojig_version = rpmostree_origin_get_jigdo_version (self->origin);
+        if (rojig_version)
+          g_key_file_set_string (tsk, "tree", "rojig-version", rojig_version);
 
         g_autoptr(RpmOstreeTreespec) treespec = rpmostree_treespec_new_from_keyfile (tsk, error);
         if (!treespec)
@@ -455,7 +455,7 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
         /* This context is currently different from one that may be created later
          * for e.g. package layering. I can't think why we couldn't unify them,
          * but for now it seems a lot simpler to keep the symmetry that
-         * rpm-ostree jigdo == ostree pull.
+         * rojig == ostree pull.
          */
         g_autoptr(RpmOstreeContext) ctx =
           rpmostree_context_new_system (self->repo, cancellable, error);
@@ -469,17 +469,17 @@ rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
          */
         if (!rpmostree_context_setup (ctx, NULL, "/", treespec, cancellable, error))
           return FALSE;
-        /* We're also "pure" rpm-ostree jigdo - this adds assertions that we don't depsolve for example */
+        /* We're also "pure" rojig - this adds assertions that we don't depsolve for example */
         if (!rpmostree_context_prepare_jigdo (ctx, cancellable, error))
           return FALSE;
-        DnfPackage *jigdo_pkg = rpmostree_context_get_jigdo_pkg (ctx);
+        DnfPackage *rojig_pkg = rpmostree_context_get_jigdo_pkg (ctx);
         new_base_rev = g_strdup (rpmostree_context_get_jigdo_checksum (ctx));
-        gboolean jigdo_changed;  /* Currently unused */
-        if (!rpmostree_context_execute_jigdo (ctx, &jigdo_changed, cancellable, error))
+        gboolean rojig_changed;  /* Currently unused */
+        if (!rpmostree_context_execute_jigdo (ctx, &rojig_changed, cancellable, error))
           return FALSE;
 
-        if (jigdo_changed)
-          rpmostree_origin_set_jigdo_description (self->origin, jigdo_pkg);
+        if (rojig_changed)
+          rpmostree_origin_set_jigdo_description (self->origin, rojig_pkg);
       }
     }
 

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -329,7 +329,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
       break;
     case RPMOSTREE_REFSPEC_TYPE_ROJIG:
       {
-        g_variant_dict_insert (&dict, "jigdo-description", "@a{sv}",
+        g_variant_dict_insert (&dict, "rojig-description", "@a{sv}",
                                rpmostree_origin_get_jigdo_description (origin));
       }
       break;
@@ -985,7 +985,7 @@ rpmostreed_update_generate_variant (OstreeSysroot *sysroot,
     if (!rpmostree_refspec_classify (refspec, &refspectype, &refspec_data, error))
       return FALSE;
 
-    /* we don't support jigdo-based origins yet */
+    /* we don't support rojig-based origins yet */
     if (refspectype != RPMOSTREE_REFSPEC_TYPE_OSTREE)
       {
         *out_update = NULL;

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -30,12 +30,12 @@ struct _RpmOstreeContext {
   RpmOstreeTreespec *spec;
   gboolean empty;
 
-  /* jigdo-mode data */
-  const char *jigdo_spec; /* The jigdo spec like: repoid:package */
-  const char *jigdo_version; /* Optional */
-  gboolean jigdo_pure; /* There is only jigdo */
-  DnfPackage *jigdo_pkg;
-  char *jigdo_checksum;
+  /* rojig-mode data */
+  const char *rojig_spec; /* The rojig spec like: repoid:package */
+  const char *rojig_version; /* Optional */
+  gboolean rojig_pure; /* There is only rojig */
+  DnfPackage *rojig_pkg;
+  char *rojig_checksum;
 
   gboolean pkgcache_only;
   DnfContext *dnfctx;

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -33,15 +33,15 @@ struct RpmOstreeOrigin {
   /* this is the single source of truth */
   GKeyFile *kf;
 
-  /* An origin can have either a refspec or a jigdospec */
+  /* An origin can have either a refspec or a rojigspec */
   RpmOstreeRefspecType refspec_type;
   char *cached_refspec;
 
   /* Version data that goes along with the refspec */
   char *cached_override_commit;
-  char *cached_jigdo_version;
-  /* The NEVRA of the jigdoRPM */
-  char *cached_jigdo_description;
+  char *cached_rojig_version;
+  /* The NEVRA of the rojigRPM */
+  char *cached_rojig_description;
 
   char *cached_unconfigured_state;
   char **cached_initramfs_args;
@@ -117,14 +117,14 @@ rpmostree_origin_parse_keyfile (GKeyFile         *origin,
   ret->cached_unconfigured_state = g_key_file_get_string (ret->kf, "origin", "unconfigured-state", NULL);
 
   g_autofree char *refspec = g_key_file_get_string (ret->kf, "origin", "refspec", NULL);
-  g_autofree char *jigdo_spec = g_key_file_get_string (ret->kf, "origin", "rojig", NULL);
+  g_autofree char *rojig_spec = g_key_file_get_string (ret->kf, "origin", "rojig", NULL);
   if (!refspec)
     {
       refspec = g_key_file_get_string (ret->kf, "origin", "baserefspec", NULL);
-      if (!refspec && !jigdo_spec)
+      if (!refspec && !rojig_spec)
         return glnx_null_throw (error, "No origin/refspec, origin/rojig, or origin/baserefspec in current deployment origin; cannot handle via rpm-ostree");
     }
-  if (refspec && jigdo_spec)
+  if (refspec && rojig_spec)
     return glnx_null_throw (error, "Duplicate origin/refspec and origin/rojig in deployment origin");
   else if (refspec)
     {
@@ -139,11 +139,11 @@ rpmostree_origin_parse_keyfile (GKeyFile         *origin,
     }
   else
     {
-      g_assert (jigdo_spec);
+      g_assert (rojig_spec);
       ret->refspec_type = RPMOSTREE_REFSPEC_TYPE_ROJIG;
-      ret->cached_refspec = g_steal_pointer (&jigdo_spec);
-      ret->cached_jigdo_version = g_key_file_get_string (ret->kf, "origin", "jigdo-override-version", NULL);
-      ret->cached_jigdo_description = g_key_file_get_string (ret->kf, "origin", "jigdo-description", NULL);
+      ret->cached_refspec = g_steal_pointer (&rojig_spec);
+      ret->cached_rojig_version = g_key_file_get_string (ret->kf, "origin", "rojig-override-version", NULL);
+      ret->cached_rojig_description = g_key_file_get_string (ret->kf, "origin", "rojig-description", NULL);
     }
 
   if (!parse_packages_strv (ret->kf, "packages", "requested", FALSE,
@@ -201,7 +201,7 @@ rpmostree_origin_get_full_refspec (RpmOstreeOrigin *origin,
   return NULL;
 }
 
-/* Returns: TRUE iff the origin type is rpm-ostree jigdo */
+/* Returns: TRUE iff the origin type is rpm-ostree rojig */
 gboolean
 rpmostree_origin_is_rojig (RpmOstreeOrigin *origin)
 {
@@ -221,7 +221,7 @@ rpmostree_origin_classify_refspec (RpmOstreeOrigin      *origin,
 const char *
 rpmostree_origin_get_jigdo_version (RpmOstreeOrigin *origin)
 {
-  return origin->cached_jigdo_version;
+  return origin->cached_rojig_version;
 }
 
 /* Returns a new (floating) variant of type a{sv} with fields:
@@ -237,15 +237,15 @@ rpmostree_origin_get_jigdo_description (RpmOstreeOrigin *origin)
   const char *colon = strchr (origin->cached_refspec, ':');
   g_assert (colon);
   const char *repo = strndupa (origin->cached_refspec, colon - origin->cached_refspec);
-  g_autofree char *jigdo_evr = g_key_file_get_string (origin->kf, "origin", "jigdo-imported-evr", NULL);
-  g_autofree char *jigdo_arch = g_key_file_get_string (origin->kf, "origin", "jigdo-imported-arch", NULL);
+  g_autofree char *rojig_evr = g_key_file_get_string (origin->kf, "origin", "rojig-imported-evr", NULL);
+  g_autofree char *rojig_arch = g_key_file_get_string (origin->kf, "origin", "rojig-imported-arch", NULL);
   g_autoptr(GVariantBuilder) builder = g_variant_builder_new (G_VARIANT_TYPE_VARDICT);
   g_variant_builder_add (builder, "{sv}", "repo", g_variant_new_string (repo));
   g_variant_builder_add (builder, "{sv}", "name", g_variant_new_string (colon + 1));
-  if (jigdo_evr)
-    g_variant_builder_add (builder, "{sv}", "evr", g_variant_new_string (jigdo_evr));
-  if (jigdo_arch)
-    g_variant_builder_add (builder, "{sv}", "arch", g_variant_new_string (jigdo_arch));
+  if (rojig_evr)
+    g_variant_builder_add (builder, "{sv}", "evr", g_variant_new_string (rojig_evr));
+  if (rojig_arch)
+    g_variant_builder_add (builder, "{sv}", "arch", g_variant_new_string (rojig_arch));
   return g_variant_builder_end (builder);
 }
 
@@ -353,7 +353,7 @@ rpmostree_origin_unref (RpmOstreeOrigin *origin)
     return;
   g_key_file_unref (origin->kf);
   g_free (origin->cached_refspec);
-  g_free (origin->cached_jigdo_version);
+  g_free (origin->cached_rojig_version);
   g_free (origin->cached_unconfigured_state);
   g_strfreev (origin->cached_initramfs_args);
   g_clear_pointer (&origin->cached_packages, g_hash_table_unref);
@@ -428,14 +428,14 @@ rpmostree_origin_set_jigdo_version (RpmOstreeOrigin *origin,
                                     const char      *version)
 {
   if (version)
-    g_key_file_set_string (origin->kf, "origin", "jigdo-override-version", version);
+    g_key_file_set_string (origin->kf, "origin", "rojig-override-version", version);
   else
-    g_key_file_remove_key (origin->kf, "origin", "jigdo-override-version", NULL);
-  g_free (origin->cached_jigdo_version);
-  origin->cached_jigdo_version = g_strdup (version);
+    g_key_file_remove_key (origin->kf, "origin", "rojig-override-version", NULL);
+  g_free (origin->cached_rojig_version);
+  origin->cached_rojig_version = g_strdup (version);
 }
 
-/* The jigdoRPM is highly special; it doesn't live in the rpmdb for example, as
+/* The rojigRPM is highly special; it doesn't live in the rpmdb for example, as
  * that would be fully circular. Yet, it's of critical importance to the whole
  * system; we want to render it on the client. For now, what we do is stick the
  * EVR+A in the origin. That's the only data we really care about.
@@ -449,8 +449,8 @@ rpmostree_origin_set_jigdo_description (RpmOstreeOrigin *origin,
                                         DnfPackage      *package)
 {
   g_assert_cmpint (origin->refspec_type, ==, RPMOSTREE_REFSPEC_TYPE_ROJIG);
-  g_key_file_set_string (origin->kf, "origin", "jigdo-imported-evr", dnf_package_get_evr (package));
-  g_key_file_set_string (origin->kf, "origin", "jigdo-imported-arch", dnf_package_get_arch (package));
+  g_key_file_set_string (origin->kf, "origin", "rojig-imported-evr", dnf_package_get_evr (package));
+  g_key_file_set_string (origin->kf, "origin", "rojig-imported-arch", dnf_package_get_arch (package));
 }
 
 gboolean
@@ -462,7 +462,7 @@ rpmostree_origin_set_rebase (RpmOstreeOrigin *origin,
    * rebase by default.
    */
   rpmostree_origin_set_override_commit (origin, NULL, NULL);
-  g_key_file_remove_key (origin->kf, "origin", "jigdo-override-version", NULL);
+  g_key_file_remove_key (origin->kf, "origin", "rojig-override-version", NULL);
 
   /* See related code in rpmostree_origin_parse_keyfile() */
   const char *refspecdata;
@@ -475,8 +475,8 @@ rpmostree_origin_set_rebase (RpmOstreeOrigin *origin,
     case RPMOSTREE_REFSPEC_TYPE_OSTREE:
       {
         g_key_file_remove_key (origin->kf, "origin", "rojig", NULL);
-        g_key_file_remove_key (origin->kf, "origin", "jigdo-imported-evr", NULL);
-        g_key_file_remove_key (origin->kf, "origin", "jigdo-imported-arch", NULL);
+        g_key_file_remove_key (origin->kf, "origin", "rojig-imported-evr", NULL);
+        g_key_file_remove_key (origin->kf, "origin", "rojig-imported-arch", NULL);
         const char *refspec_key =
           g_key_file_has_key (origin->kf, "origin", "baserefspec", NULL) ?
           "baserefspec" : "refspec";

--- a/tests/compose-tests/test-jigdo-e2e.sh
+++ b/tests/compose-tests/test-jigdo-e2e.sh
@@ -54,10 +54,10 @@ do_rojig2commit
 assert_file_has_content jigdo2commit-out.txt ${npkgs}/${npkgs}' packages to import'
 ostree --repo=jigdo-unpack-repo rev-parse ${rev}
 ostree --repo=jigdo-unpack-repo fsck
-ostree --repo=jigdo-unpack-repo refs > jigdo-refs.txt
-assert_file_has_content jigdo-refs.txt 'rpmostree/jigdo/test-pkg/1.0-1.x86__64'
+ostree --repo=jigdo-unpack-repo refs > rojig-refs.txt
+assert_file_has_content rojig-refs.txt 'rpmostree/rojig/test-pkg/1.0-1.x86__64'
 
-echo "ok jigdo ♲📦 fresh assembly"
+echo "ok rojig ♲📦 fresh assembly"
 
 origrev=${rev}
 unset rev
@@ -94,13 +94,13 @@ for x in ${origrev} ${newrev}; do
     ostree --repo=jigdo-unpack-repo rev-parse ${x}
 done
 ostree --repo=jigdo-unpack-repo fsck
-ostree --repo=jigdo-unpack-repo refs > jigdo-refs.txt
+ostree --repo=jigdo-unpack-repo refs > rojig-refs.txt
 # We should have both refs; GC will be handled by the sysroot upgrader
 # via deployments, same way it is for pkg layering.
-assert_file_has_content jigdo-refs.txt 'rpmostree/jigdo/test-pkg/1.0-1.x86__64'
-assert_file_has_content jigdo-refs.txt 'rpmostree/jigdo/test-pkg/1.1-1.x86__64'
+assert_file_has_content rojig-refs.txt 'rpmostree/rojig/test-pkg/1.0-1.x86__64'
+assert_file_has_content rojig-refs.txt 'rpmostree/rojig/test-pkg/1.1-1.x86__64'
 
-echo "ok jigdo ♲📦 update!"
+echo "ok rojig ♲📦 update!"
 
 # Add all docs to test https://github.com/projectatomic/rpm-ostree/issues/1197
 pysetjsonmember "documentation" 'True'
@@ -113,4 +113,4 @@ do_rojig2commit
 # Not every package has docs, but there are going to need to be changes
 assert_file_has_content jigdo2commit-out.txt '[1-9][0-9]*/[1-9][0-9]* packages to import ([1-9][0-9]* changed)'
 ostree --repo=jigdo-unpack-repo ls -R ${newrev} >/dev/null
-echo "ok jigdo ♲📦 updated docs"
+echo "ok rojig ♲📦 updated docs"

--- a/tests/vmcheck/test-jigdo-client.sh
+++ b/tests/vmcheck/test-jigdo-client.sh
@@ -40,7 +40,7 @@ assert_file_has_content_literal err.txt 'rojig:// refspec requires --experimenta
 vm_rpmostree rebase --experimental rojig://fahc:fedora-atomic-host
 vm_assert_status_jq '.deployments[0].origin|startswith("rojig://fahc:fedora-atomic-host")'
 vm_cmd ostree refs > refs.txt
-assert_file_has_content refs.txt '^rpmostree/jigdo/kernel-core/'
+assert_file_has_content refs.txt '^rpmostree/rojig/kernel-core/'
 echo "ok jigdo client rebase "
 
 version=$(vm_get_deployment_info 0 version)


### PR DESCRIPTION
We're continuing an incremental renaming process; previously we changed
the most user-visible strings.  Now we're doing some internal variables,
and notably the cached refs and the origin files - the latter set is
things that end up on disk.

This leaves the biggest items; renaming APIs, files, and tests.
