### PR TITLE
auto-updates: Redirect output to self if timer

### DIFF
--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -120,6 +120,8 @@ rpmostree_builtin_upgrade (int             argc,
       GVariantDict dict;
       g_variant_dict_init (&dict, NULL);
       g_variant_dict_insert (&dict, "mode", "s", check_or_preview ? "check" : "auto");
+      /* override default if we're actually on a tty and not e.g. timer triggered */
+      g_variant_dict_insert (&dict, "redirect-output", "b", !glnx_stdout_is_tty ());
       g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
       gboolean auto_updates_enabled;

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -120,8 +120,10 @@ rpmostree_builtin_upgrade (int             argc,
       GVariantDict dict;
       g_variant_dict_init (&dict, NULL);
       g_variant_dict_insert (&dict, "mode", "s", check_or_preview ? "check" : "auto");
-      /* override default if we're actually on a tty and not e.g. timer triggered */
-      g_variant_dict_insert (&dict, "redirect-output", "b", !glnx_stdout_is_tty ());
+      /* override default of TRUE if we're handling --check/--preview for backcompat,
+       * or we're *are* handling --trigger-automatic-update-policy, but on a tty */
+      if (check_or_preview || glnx_stdout_is_tty ())
+        g_variant_dict_insert (&dict, "redirect-output", "b", FALSE);
       g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
       gboolean auto_updates_enabled;

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -123,7 +123,7 @@ rpmostree_builtin_upgrade (int             argc,
       /* override default of TRUE if we're handling --check/--preview for backcompat,
        * or we're *are* handling --trigger-automatic-update-policy, but on a tty */
       if (check_or_preview || glnx_stdout_is_tty ())
-        g_variant_dict_insert (&dict, "redirect-output", "b", FALSE);
+        g_variant_dict_insert (&dict, "output-to-self", "b", FALSE);
       g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
       gboolean auto_updates_enabled;

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -96,7 +96,7 @@
          "mode" (type 's')
             One of auto, none, check. Defaults to auto, which follows configured
             policy (available in AutomaticUpdatePolicy property).
-         "redirect-output" (type 'b')
+         "output-to-self" (type 'b')
             Whether output should go to the daemon itself rather than the
             transaction. Defaults to TRUE.
 

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -96,6 +96,9 @@
          "mode" (type 's')
             One of auto, none, check. Defaults to auto, which follows configured
             policy (available in AutomaticUpdatePolicy property).
+         "redirect-output" (type 'b')
+            Whether output should go to the daemon itself rather than the
+            transaction. Defaults to TRUE.
 
          If automatic updates are not enabled, @enabled will be FALSE and
          @transaction_address will be the empty string.

--- a/src/daemon/rpm-ostreed-automatic.service.in
+++ b/src/daemon/rpm-ostreed-automatic.service.in
@@ -6,3 +6,4 @@ ConditionPathExists=/run/ostree-booted
 [Service]
 Type=simple
 ExecStart=@bindir@/rpm-ostree upgrade --trigger-automatic-update-policy
+StandardOutput=null

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -693,7 +693,7 @@ start_deployment_txn (GDBusMethodInvocation  *invocation,
     }
 
   const gboolean redirect_output =
-    vardict_lookup_bool (&options_dict, "redirect-output", FALSE);
+    vardict_lookup_bool (&options_dict, "output-to-self", FALSE);
   default_flags = deploy_flags_from_options (options, default_flags);
   return rpmostreed_transaction_new_deploy (invocation, ot_sysroot,
                                             default_flags,
@@ -971,11 +971,11 @@ os_handle_automatic_update_trigger (RPMOSTreeOS *interface,
       g_assert_not_reached ();
     }
 
-  /* if redirect-output is not explicitly set, default to TRUE */
+  /* if output-to-self is not explicitly set, default to TRUE */
   g_autoptr(GVariant) new_dict = NULL;
-  if (!g_variant_dict_contains (&dict, "redirect-output"))
+  if (!g_variant_dict_contains (&dict, "output-to-self"))
     {
-      g_variant_dict_insert (&dict, "redirect-output", "b", TRUE);
+      g_variant_dict_insert (&dict, "output-to-self", "b", TRUE);
       arg_options = new_dict = g_variant_ref_sink (g_variant_dict_end (&dict));
     }
 

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -781,15 +781,17 @@ os_merge_or_start_deployment_txn (RPMOSTreeOS            *interface,
                                           fd_list,
                                           &local_error);
       if (transaction)
-        rpmostreed_transaction_monitor_add (self->transaction_monitor, transaction);
+        {
+          rpmostreed_transaction_monitor_add (self->transaction_monitor, transaction);
 
-      /* For the AutomaticUpdateTrigger "check" and "download" cases, we want to make sure
-       * we refresh CachedUpdate after; "deploy" will do this through sysroot_changed */
-      const char *method_name = g_dbus_method_invocation_get_method_name (invocation);
-      if (g_str_equal (method_name, "AutomaticUpdateTrigger") &&
-          (default_flags & (RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_ONLY |
-                            RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_METADATA_ONLY)))
-        g_signal_connect (transaction, "closed", G_CALLBACK (on_auto_update_done), self);
+          /* For the AutomaticUpdateTrigger "check" case, we want to make sure we refresh
+           * the CachedUpdate property; "deploy" will do this through sysroot_changed */
+          const char *method_name = g_dbus_method_invocation_get_method_name (invocation);
+          if (g_str_equal (method_name, "AutomaticUpdateTrigger") &&
+              (default_flags & (RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_ONLY |
+                                RPMOSTREE_TRANSACTION_DEPLOY_FLAG_DOWNLOAD_METADATA_ONLY)))
+            g_signal_connect (transaction, "closed", G_CALLBACK (on_auto_update_done), self);
+        }
     }
 
   if (transaction)

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -971,6 +971,14 @@ os_handle_automatic_update_trigger (RPMOSTreeOS *interface,
       g_assert_not_reached ();
     }
 
+  /* if redirect-output is not explicitly set, default to TRUE */
+  g_autoptr(GVariant) new_dict = NULL;
+  if (!g_variant_dict_contains (&dict, "redirect-output"))
+    {
+      g_variant_dict_insert (&dict, "redirect-output", "b", TRUE);
+      arg_options = new_dict = g_variant_ref_sink (g_variant_dict_end (&dict));
+    }
+
   return os_merge_or_start_deployment_txn (
       interface,
       invocation,

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -692,9 +692,12 @@ start_deployment_txn (GDBusMethodInvocation  *invocation,
         return FALSE;
     }
 
+  const gboolean redirect_output =
+    vardict_lookup_bool (&options_dict, "redirect-output", FALSE);
   default_flags = deploy_flags_from_options (options, default_flags);
   return rpmostreed_transaction_new_deploy (invocation, ot_sysroot,
                                             default_flags,
+                                            redirect_output,
                                             osname,
                                             canon_refspec,
                                             revision,
@@ -972,7 +975,7 @@ os_handle_automatic_update_trigger (RPMOSTreeOS *interface,
       interface,
       invocation,
       dfault,
-      NULL,
+      arg_options,
       NULL,
       NULL,
       automatic_update_trigger_completer);

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -111,7 +111,7 @@ sysroot_output_cb (RpmOstreeOutputType type, void *data, void *opaque)
   transaction =
     rpmostreed_transaction_monitor_ref_active_transaction (self->transaction_monitor);
   if (transaction)
-    g_object_get (transaction, "redirect-output", &redirect, NULL);
+    g_object_get (transaction, "output-to-self", &redirect, NULL);
 
   if (!transaction || redirect)
     {

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -106,11 +106,14 @@ sysroot_output_cb (RpmOstreeOutputType type, void *data, void *opaque)
 {
   RpmostreedSysroot *self = RPMOSTREED_SYSROOT (opaque);
   glnx_unref_object RpmostreedTransaction *transaction = NULL;
+  gboolean redirect = FALSE;
 
   transaction =
     rpmostreed_transaction_monitor_ref_active_transaction (self->transaction_monitor);
+  if (transaction)
+    g_object_get (transaction, "redirect-output", &redirect, NULL);
 
-  if (!transaction)
+  if (!transaction || redirect)
     {
       rpmostree_output_default_handler (type, data, opaque);
       return;

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1133,6 +1133,7 @@ RpmostreedTransaction *
 rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
                                    OstreeSysroot *sysroot,
                                    RpmOstreeTransactionDeployFlags flags,
+                                   gboolean    redirect_output,
                                    const char *osname,
                                    const char *refspec,
                                    const char *revision,
@@ -1155,6 +1156,7 @@ rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
                     cancellable, error,
                     "invocation", invocation,
                     "sysroot-path", gs_file_get_path_cached (ostree_sysroot_get_path (sysroot)),
+                    "redirect-output", redirect_output,
                     NULL);
 
   if (self != NULL)

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1156,7 +1156,7 @@ rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
                     cancellable, error,
                     "invocation", invocation,
                     "sysroot-path", gs_file_get_path_cached (ostree_sysroot_get_path (sysroot)),
-                    "redirect-output", redirect_output,
+                    "output-to-self", redirect_output,
                     NULL);
 
   if (self != NULL)

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -65,6 +65,7 @@ RpmostreedTransaction *
 rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
                                    OstreeSysroot *sysroot,
                                    RpmOstreeTransactionDeployFlags flags,
+                                   gboolean    redirect_output,
                                    const char *osname,
                                    const char *refspec,
                                    const char *revision,

--- a/src/daemon/rpmostreed-transaction.c
+++ b/src/daemon/rpmostreed-transaction.c
@@ -37,6 +37,8 @@ struct _RpmostreedTransactionPrivate {
   char *sysroot_path;
   OstreeSysroot *sysroot;
 
+  gboolean redirect_output;
+
   GDBusServer *server;
   GHashTable *peer_connections;
 
@@ -50,7 +52,8 @@ enum {
   PROP_0,
   PROP_ACTIVE,
   PROP_INVOCATION,
-  PROP_SYSROOT_PATH
+  PROP_SYSROOT_PATH,
+  PROP_REDIRECT_OUTPUT
 };
 
 enum {
@@ -376,6 +379,9 @@ transaction_set_property (GObject *object,
       case PROP_SYSROOT_PATH:
         priv->sysroot_path = g_value_dup_string (value);
         break;
+      case PROP_REDIRECT_OUTPUT:
+        priv->redirect_output = g_value_get_boolean (value);
+        break;
       default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
         break;
@@ -398,6 +404,9 @@ transaction_get_property (GObject *object,
         break;
       case PROP_SYSROOT_PATH:
         g_value_set_string (value, priv->sysroot_path);
+        break;
+      case PROP_REDIRECT_OUTPUT:
+        g_value_set_boolean (value, priv->redirect_output);
         break;
       default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -673,6 +682,16 @@ rpmostreed_transaction_class_init (RpmostreedTransactionClass *class)
                                                         G_PARAM_READWRITE |
                                                         G_PARAM_CONSTRUCT_ONLY |
                                                         G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (object_class,
+                                   PROP_REDIRECT_OUTPUT,
+                                   g_param_spec_boolean ("redirect-output",
+                                                         "Redirect output",
+                                                         "Whether to redirect output to daemon",
+                                                         FALSE,
+                                                         G_PARAM_READWRITE |
+                                                         G_PARAM_CONSTRUCT_ONLY |
+                                                         G_PARAM_STATIC_STRINGS));
 
   signals[CLOSED] = g_signal_new ("closed",
                                   RPMOSTREED_TYPE_TRANSACTION,

--- a/src/daemon/rpmostreed-transaction.c
+++ b/src/daemon/rpmostreed-transaction.c
@@ -685,9 +685,9 @@ rpmostreed_transaction_class_init (RpmostreedTransactionClass *class)
 
   g_object_class_install_property (object_class,
                                    PROP_REDIRECT_OUTPUT,
-                                   g_param_spec_boolean ("redirect-output",
-                                                         "Redirect output",
-                                                         "Whether to redirect output to daemon",
+                                   g_param_spec_boolean ("output-to-self",
+                                                         "Output to self",
+                                                         "Whether to redirect output to daemon itself",
                                                          FALSE,
                                                          G_PARAM_READWRITE |
                                                          G_PARAM_CONSTRUCT_ONLY |

--- a/src/libpriv/rpmostree-output.c
+++ b/src/libpriv/rpmostree-output.c
@@ -50,9 +50,10 @@ rpmostree_output_default_handler (RpmOstreeOutputType type,
   case RPMOSTREE_OUTPUT_PROGRESS_PERCENT:
     if (!console.locked)
       glnx_console_lock (&console);
-    glnx_console_progress_text_percent (
-      ((RpmOstreeOutputProgressPercent*)data)->text,
-      ((RpmOstreeOutputProgressPercent*)data)->percentage);
+    RpmOstreeOutputProgressPercent *prog = data;
+    /* let's not spam stdout if it's not a tty; see dbus-helpers.c */
+    if (prog->percentage == 100 || console.is_tty)
+      glnx_console_progress_text_percent (prog->text, prog->percentage);
     break;
   case RPMOSTREE_OUTPUT_PROGRESS_N_ITEMS:
     {


### PR DESCRIPTION
As mentioned during code review, it feels odd to have our automatic
service collect output under its name rather than the main daemon. It
shouldn't be thought of as a daemon with its own logs, it's really just
a trigger.

We change this here so that for automatic updates, output is redirected
to the daemon stdout, which of course goes to the journal. This should
make logs in case of errors more discoverable as well since
`rpm-ostreed` is the well-known name.

I drilled down the notion directly into `RpmostreedTransaction` since I
think it's a useful property that might be handy at a more general
level.

Requires: https://github.com/projectatomic/rpm-ostree/pull/1277