### PR TITLE
daemon/os: Check deployment before using it

### DIFF
--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -1716,23 +1716,26 @@ refresh_cached_update (RpmostreedOS *self, GError **error)
     ostree_sysroot_get_merge_deployment (sysroot, name);
 
   g_autoptr(GVariant) cached_update = NULL;
-  RpmostreedAutomaticUpdatePolicy autoupdate_policy =
-    rpmostreed_get_automatic_update_policy (rpmostreed_daemon_get ());
+  if (merge_deployment)
+    {
+      RpmostreedAutomaticUpdatePolicy autoupdate_policy =
+        rpmostreed_get_automatic_update_policy (rpmostreed_daemon_get ());
 
-  /* if auto-updates is off, just fill in the backcompat stuff */
-  if (autoupdate_policy == RPMOSTREED_AUTOMATIC_UPDATE_POLICY_NONE)
-    {
-      cached_update = rpmostreed_commit_generate_cached_details_variant (merge_deployment,
-                                                                         repo, NULL, NULL,
-                                                                         error);
-      if (!cached_update)
-        return FALSE;
-    }
-  else
-    {
-      if (!rpmostreed_update_generate_variant (sysroot, merge_deployment, repo,
-                                               &cached_update, error))
-        return FALSE;
+      /* if auto-updates is off, just fill in the backcompat stuff */
+      if (autoupdate_policy == RPMOSTREED_AUTOMATIC_UPDATE_POLICY_NONE)
+        {
+          cached_update = rpmostreed_commit_generate_cached_details_variant (merge_deployment,
+                                                                             repo, NULL, NULL,
+                                                                             error);
+          if (!cached_update)
+            return FALSE;
+        }
+      else
+        {
+          if (!rpmostreed_update_generate_variant (sysroot, merge_deployment, repo,
+                                                   &cached_update, error))
+            return FALSE;
+        }
     }
 
   rpmostree_os_set_cached_update (RPMOSTREE_OS (self), cached_update);


### PR DESCRIPTION
If one isn't actually booted in a deployment, we'd get `NULL` from
libostree. Check for it before trying to use it. Something something
Rust.

This will all go away soon with #1268, though this quick fix should
allow anyone hitting this to use FAHC RPMs to move forward.