### PR TITLE
daemon: Complete output-to-self rename

### DIFF
--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -692,12 +692,12 @@ start_deployment_txn (GDBusMethodInvocation  *invocation,
         return FALSE;
     }
 
-  const gboolean redirect_output =
+  const gboolean output_to_self =
     vardict_lookup_bool (&options_dict, "output-to-self", FALSE);
   default_flags = deploy_flags_from_options (options, default_flags);
   return rpmostreed_transaction_new_deploy (invocation, ot_sysroot,
                                             default_flags,
-                                            redirect_output,
+                                            output_to_self,
                                             osname,
                                             canon_refspec,
                                             revision,

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -106,14 +106,14 @@ sysroot_output_cb (RpmOstreeOutputType type, void *data, void *opaque)
 {
   RpmostreedSysroot *self = RPMOSTREED_SYSROOT (opaque);
   glnx_unref_object RpmostreedTransaction *transaction = NULL;
-  gboolean redirect = FALSE;
+  gboolean output_to_self = FALSE;
 
   transaction =
     rpmostreed_transaction_monitor_ref_active_transaction (self->transaction_monitor);
   if (transaction)
-    g_object_get (transaction, "output-to-self", &redirect, NULL);
+    g_object_get (transaction, "output-to-self", &output_to_self, NULL);
 
-  if (!transaction || redirect)
+  if (!transaction || output_to_self)
     {
       rpmostree_output_default_handler (type, data, opaque);
       return;

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1133,7 +1133,7 @@ RpmostreedTransaction *
 rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
                                    OstreeSysroot *sysroot,
                                    RpmOstreeTransactionDeployFlags flags,
-                                   gboolean    redirect_output,
+                                   gboolean    output_to_self,
                                    const char *osname,
                                    const char *refspec,
                                    const char *revision,
@@ -1156,7 +1156,7 @@ rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
                     cancellable, error,
                     "invocation", invocation,
                     "sysroot-path", gs_file_get_path_cached (ostree_sysroot_get_path (sysroot)),
-                    "output-to-self", redirect_output,
+                    "output-to-self", output_to_self,
                     NULL);
 
   if (self != NULL)

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -65,7 +65,7 @@ RpmostreedTransaction *
 rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
                                    OstreeSysroot *sysroot,
                                    RpmOstreeTransactionDeployFlags flags,
-                                   gboolean    redirect_output,
+                                   gboolean    output_to_self,
                                    const char *osname,
                                    const char *refspec,
                                    const char *revision,


### PR DESCRIPTION
To reduce confusion in future versions of myself and other readers,
complete the suggested rename from "redirect-output" to "output-to-self"
to internal variable names as well.