### PR TITLE
app/usroverlay: Do a root check and fix typo

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -65,8 +65,8 @@ static RpmOstreeCommand commands[] = {
   { "reload", 0,
     "Reload configuration",
     rpmostree_builtin_reload },
-  { "usroverlay", 0,
-    "Apply a transient overlayfs to /urs",
+  { "usroverlay", RPM_OSTREE_BUILTIN_FLAG_REQUIRES_ROOT,
+    "Apply a transient overlayfs to /usr",
     rpmostree_builtin_usroverlay },
   /* Let's be "cognitively" compatible with `ostree admin unlock` */
   { "unlock", RPM_OSTREE_BUILTIN_FLAG_HIDDEN,


### PR DESCRIPTION
Let's give a nicer error than 'Permission denied' if users try to run
this as non-root. Kinda overkill to set up polkit auth for this command.
Feels like something only uid 0 should be able to do anyway.

Also fix `/usr` typo.