### PR TITLE
status: Show deployment pinned 📌 state

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -737,6 +737,10 @@ print_deployments (RPMOSTreeSysroot *sysroot_proxy,
             g_string_append (buf, "regenerate");
           rpmostree_print_kv ("Initramfs", max_key_len, buf->str);
         }
+      gboolean pinned = FALSE;
+      g_variant_dict_lookup (dict, "pinned", "b", &pinned);
+      if (pinned)
+        rpmostree_print_kv ("Pinned", max_key_len, "yes");
 
       if (unlocked && g_strcmp0 (unlocked, "none") != 0)
         {

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -366,6 +366,8 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
     g_variant_dict_insert_value (&dict, "signatures", sigs);
   g_variant_dict_insert (&dict, "gpg-enabled", "b", gpg_enabled);
 
+  g_variant_dict_insert (&dict, "pinned", "b",
+                         ostree_deployment_is_pinned (deployment));
   g_variant_dict_insert (&dict, "unlocked", "s",
                          ostree_deployment_unlocked_state_to_string (ostree_deployment_get_unlocked (deployment)));
 

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -102,6 +102,17 @@ vm_rpmostree status -b > status.txt
 assert_streq $(grep -F -e 'ostree://' status.txt | wc -l) "1"
 echo "ok status -b"
 
+# Pinning
+vm_cmd ostree admin pin 0
+vm_rpmostree reload  # Try to avoid reload races
+vm_rpmostree status > status.txt
+assert_file_has_content_literal status.txt "Pinned: yes"
+vm_cmd ostree admin pin -u 0
+vm_rpmostree reload  # Try to avoid reload races
+vm_rpmostree status > status.txt
+assert_not_file_has_content status.txt "Pinned: yes"
+echo "ok pinning"
+
 # https://github.com/ostreedev/ostree/pull/1055
 vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --timestamp=\"October 25 1985\"
 if vm_rpmostree upgrade 2>err.txt; then


### PR DESCRIPTION
Implemented in libostree in https://github.com/ostreedev/ostree/pull/1464
Let's display it - wrapping the command will come later.

I also just noticed `rpmostree_syscore_filter_deployments()` at least is
going to have to learn about pinning; will need to improve the test suite
around this too.
