### PR TITLE
app/db-diff: assume booted deployment if less args

### DIFF
--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -137,7 +137,10 @@ Boston, MA 02111-1307, USA.
 
           <para>
             <command>diff</command> to see how the packages are
-            different between the trees in two commits.  The
+            different between the trees in two revs. If no revs are
+            provided, the booted commit is compared to the pending
+            commit. If only a single rev is provided, the booted commit
+            is compared to that rev. The
             <option>--format=diff</option> option uses
             <literal>-</literal> for removed packages,
             <literal>+</literal> for added packages, and finally

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -305,7 +305,7 @@ rpmostree_subcommand_parse (int *inout_argc,
   return command_name;
 }
 
-int
+gboolean
 rpmostree_handle_subcommand (int argc, char **argv,
                              RpmOstreeCommand *subcommands,
                              RpmOstreeCommandInvocation *invocation,

--- a/src/app/rpmostree-builtin-kargs.c
+++ b/src/app/rpmostree-builtin-kargs.c
@@ -168,7 +168,7 @@ kernel_arg_handle_editor (const char     *input_kernel_arg,
 }
 
 
-int
+gboolean
 rpmostree_ex_builtin_kargs (int            argc,
                             char         **argv,
                             RpmOstreeCommandInvocation *invocation,

--- a/src/app/rpmostree-builtin-livefs.c
+++ b/src/app/rpmostree-builtin-livefs.c
@@ -50,7 +50,7 @@ get_args_variant (void)
   return g_variant_dict_end (&dict);
 }
 
-int
+gboolean
 rpmostree_ex_builtin_livefs (int             argc,
                              char          **argv,
                              RpmOstreeCommandInvocation *invocation,

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -98,7 +98,7 @@ rpmostree_builtin_rebase (int             argc,
 
   if (argc < 2 && !(opt_branch || opt_remote))
     {
-      return rpmostree_usage_error (context, "Must specify refspec, or -b branch or -r remote", error), EXIT_FAILURE;
+      return rpmostree_usage_error (context, "Must specify refspec, or -b branch or -r remote", error), FALSE;
     }
   else if (argc >= 2)
     {

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1346,7 +1346,7 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
   return TRUE;
 }
 
-int
+gboolean
 rpmostree_compose_builtin_install (int             argc,
                                    char          **argv,
                                    RpmOstreeCommandInvocation *invocation,
@@ -1399,7 +1399,7 @@ rpmostree_compose_builtin_install (int             argc,
   return TRUE;
 }
 
-int
+gboolean
 rpmostree_compose_builtin_postprocess (int             argc,
                                        char          **argv,
                                        RpmOstreeCommandInvocation *invocation,
@@ -1439,7 +1439,7 @@ rpmostree_compose_builtin_postprocess (int             argc,
 
       JsonNode *treefile_rootval = json_parser_get_root (treefile_parser);
       if (!JSON_NODE_HOLDS_OBJECT (treefile_rootval))
-        return glnx_throw (error, "Treefile root is not an object"), EXIT_FAILURE;
+        return glnx_throw (error, "Treefile root is not an object");
       treefile = json_node_get_object (treefile_rootval);
     }
 
@@ -1454,7 +1454,7 @@ rpmostree_compose_builtin_postprocess (int             argc,
   return TRUE;
 }
 
-int
+gboolean
 rpmostree_compose_builtin_commit (int             argc,
                                   char          **argv,
                                   RpmOstreeCommandInvocation *invocation,
@@ -1498,7 +1498,7 @@ rpmostree_compose_builtin_commit (int             argc,
   return TRUE;
 }
 
-int
+gboolean
 rpmostree_compose_builtin_tree (int             argc,
                                 char          **argv,
                                 RpmOstreeCommandInvocation *invocation,

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -36,7 +36,7 @@ static GOptionEntry option_entries[] = {
   { NULL }
 };
 
-gboolean
+static gboolean
 print_diff (OstreeRepo   *repo,
             const char   *old_desc,
             const char   *old_checksum,

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -34,7 +34,7 @@ static GOptionEntry option_entries[] = {
   { NULL }
 };
 
-int
+gboolean
 rpmostree_db_builtin_diff (int argc, char **argv,
                            RpmOstreeCommandInvocation *invocation,
                            GCancellable *cancellable, GError **error)
@@ -84,10 +84,10 @@ rpmostree_db_builtin_diff (int argc, char **argv,
     {
       g_autoptr(RpmRevisionData) rpmrev1 = rpmrev_new (repo, old_ref, NULL, cancellable, error);
       if (!rpmrev1)
-        return EXIT_FAILURE;
+        return FALSE;
       g_autoptr(RpmRevisionData) rpmrev2 = rpmrev_new (repo, new_ref, NULL, cancellable, error);
       if (!rpmrev2)
-        return EXIT_FAILURE;
+        return FALSE;
 
       rpmhdrs_diff_prnt_block (TRUE, rpmhdrs_diff (rpmrev_get_headers (rpmrev1),
                                                    rpmrev_get_headers (rpmrev2)));

--- a/src/app/rpmostree-db-builtin-list.c
+++ b/src/app/rpmostree-db-builtin-list.c
@@ -78,7 +78,7 @@ _builtin_db_list (OstreeRepo *repo,
   return TRUE;
 }
 
-int
+gboolean
 rpmostree_db_builtin_list (int argc, char **argv,
                            RpmOstreeCommandInvocation *invocation,
                            GCancellable *cancellable, GError **error)
@@ -123,4 +123,3 @@ rpmostree_db_builtin_list (int argc, char **argv,
 
   return TRUE;
 }
-

--- a/src/app/rpmostree-db-builtin-version.c
+++ b/src/app/rpmostree-db-builtin-version.c
@@ -83,7 +83,7 @@ _builtin_db_version (OstreeRepo *repo, GPtrArray *revs,
   return TRUE;
 }
 
-int
+gboolean
 rpmostree_db_builtin_version (int argc, char **argv,
                               RpmOstreeCommandInvocation *invocation,
                               GCancellable *cancellable, GError **error)

--- a/src/app/rpmostree-ex-builtin-commit2rojig.c
+++ b/src/app/rpmostree-ex-builtin-commit2rojig.c
@@ -52,7 +52,7 @@ static GOptionEntry commit2rojig_option_entries[] = {
   { NULL }
 };
 
-int
+gboolean
 rpmostree_ex_builtin_commit2rojig (int             argc,
                                    char          **argv,
                                    RpmOstreeCommandInvocation *invocation,
@@ -85,7 +85,7 @@ rpmostree_ex_builtin_commit2rojig (int             argc,
   const char *oirpm_spec = argv[2];
   const char *outputdir = argv[3];
   if (!g_str_has_prefix (outputdir, "/"))
-    return glnx_throw (error, "outputdir must be absolute"), EXIT_FAILURE;
+    return glnx_throw (error, "outputdir must be absolute");
 
   g_autoptr(OstreeRepo) repo = ostree_repo_open_at (AT_FDCWD, opt_repo, cancellable, error);
   if (!repo)

--- a/src/app/rpmostree-ex-builtin-rojig2commit.c
+++ b/src/app/rpmostree-ex-builtin-rojig2commit.c
@@ -134,7 +134,7 @@ impl_rojig2commit (RpmOstreeRojig2CommitContext *self,
   return TRUE;
 }
 
-int
+gboolean
 rpmostree_ex_builtin_rojig2commit (int             argc,
                                    char          **argv,
                                    RpmOstreeCommandInvocation *invocation,

--- a/tests/vmcheck/test-db.sh
+++ b/tests/vmcheck/test-db.sh
@@ -30,9 +30,16 @@ set -x
 YUMREPO=/tmp/vmcheck/yumrepo/packages/x86_64
 
 check_diff() {
-  from=$1; shift
-  to=$1; shift
-  vm_rpmostree db diff --format=diff $from $to > diff.txt
+  arg1=$1; shift
+  arg2=$1; shift
+  cmd="vm_rpmostree db diff --format=diff"
+  if [ -n "$arg1" ]; then
+    cmd="$cmd $arg1"
+  fi
+  if [ -n "$arg2" ]; then
+    cmd="$cmd $arg2"
+  fi
+  $cmd > diff.txt
   assert_file_has_content diff.txt "$@"
 }
 
@@ -51,6 +58,18 @@ vm_rpmostree install pkg-to-remove pkg-to-replace pkg-to-replace-archtrans
 booted_csum=$(vm_get_booted_csum)
 pending_csum=$(vm_get_pending_csum)
 check_diff $booted_csum $pending_csum \
+  +pkg-to-remove \
+  +pkg-to-replace \
+  +pkg-to-replace-archtrans
+
+# check that it's the default behaviour without both args
+check_diff "" "" \
+  +pkg-to-remove \
+  +pkg-to-replace \
+  +pkg-to-replace-archtrans
+
+# check that it's the default behaviour without one arg
+check_diff "$pending_csum" "" \
   +pkg-to-remove \
   +pkg-to-replace \
   +pkg-to-replace-archtrans


### PR DESCRIPTION
Very often when I have a pending deployment, I just want to find out
what the diff is before rebooting. We do print it after whatever
transaction laid down the new deployment, though we may not reboot right
away. It seems like a common enough operation to warrant some shortcuts.

This makes `db diff` more useful by automatically subbing in the booted
deployment if less arguments are given:

    rpm-ostree db diff
      <diff booted and pending deployment>
    rpm-ostree db diff $csum
      <diff booted and $csum>
    rpm-ostree db diff $csum1 $csum2
      <as before, diff $csum1 and $csum2>

As before, we never try to even load the sysroot in the last invocation,
so it still works equally well on non-OSTree systems/unprivileged.