### PR TITLE
core: Add rpmostree.rpmmd-repos metadata to client layers too

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -4090,6 +4090,11 @@ rpmostree_context_commit (RpmOstreeContext      *self,
         g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.clientlayer",
                                g_variant_new_boolean (TRUE));
 
+
+        /* Record the rpm-md information on the client just like we do on the server side */
+        g_autoptr(GVariant) rpmmd_meta = rpmostree_context_get_rpmmd_repo_commit_metadata (self);
+        g_variant_builder_add (&metadata_builder, "{sv}", "rpmostree.rpmmd-repos", rpmmd_meta);
+
         /* embed packages (really, "patterns") layered */
         g_autoptr(GVariant) pkgs =
           g_variant_dict_lookup_value (self->spec->dict, "packages", G_VARIANT_TYPE ("as"));

--- a/src/libpriv/rpmostree-importer.c
+++ b/src/libpriv/rpmostree-importer.c
@@ -378,6 +378,8 @@ get_lead_sig_header_as_bytes (RpmOstreeImporter *self,
  * https://github.com/rpm-software-management/libdnf/pull/199/
  * https://github.com/projectatomic/rpm-ostree/issues/774
  * https://github.com/projectatomic/rpm-ostree/pull/1072
+ *
+ * Note overlap with rpmostree_context_get_rpmmd_repo_commit_metadata()
  */
 static GVariant *
 repo_metadata_for_package (DnfRepo *repo)

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -70,6 +70,12 @@ vm_cmd ostree show --print-metadata-key rpmostree.repo ${pkgref} >refdata.txt
 assert_file_has_content refdata.txt 'id.*test-repo'
 assert_file_has_content refdata.txt 'timestamp'
 rm -f refs.txt refdata.txt
+# And that we have rpmmd-repos on the layered commit
+vm_cmd ostree show --print-metadata-key rpmostree.rpmmd-repos $(vm_get_deployment_info 0 checksum) > rpmmd-meta.txt
+assert_file_has_content rpmmd-meta.txt 'id.*test-repo'
+assert_file_has_content rpmmd-meta.txt 'timestamp'
+rm -f rpmmd-meta.txt
+
 # This will cover things like us failing to break hardlinks for the rpmdb,
 # as well as rofiles-fuse
 vm_cmd ostree fsck


### PR DESCRIPTION
This is a logical followup to:

 - "core: Add rpmostree.repo metadata to imported packages" AKA a52cb7d78e304b088be29188a237ec034880e6f7
 - "compose: Add rpmostree.rpmmd-repo metadata to commits by default" AKA e7a42f70a9e119f5211665f8ed036e8f82fd34e2

Basically I'd like to display this in `status` at least, though how we render it
gets...interesting when there is layering in play. For now though let's just
capture the data the same way we do server side.

Theoretically we could reconstruct this data by walking all of the pkgrefs in
the tree but...ugh. It's just a lot simpler to have it in this form too just
like the server-side path.
