### PR TITLE
tests: Dip our toes into using Ansible

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -71,6 +71,7 @@ extra-repos:
 tests:
   # we're still on devmapper here; we need to expand rootfs for tests
   - for vm in vmcheck{1..3}; do ssh $vm lvresize -r -L +5G atomicos/root; done
+  - ci/vmcheck-provision.sh
   - yum install -y epel-release
   - ci/build-check.sh
   - make vmcheck

--- a/.papr.yml
+++ b/.papr.yml
@@ -29,6 +29,7 @@ tests:
   - ci/ci-commitmessage-submodules.sh
   - ci/codestyle.sh
   - ci/build-check.sh
+  - ci/vmcheck-provision.sh
   - make vmcheck
 
 timeout: 60m

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -18,6 +18,8 @@ if BUILDOPT_ASAN
 AM_TESTS_ENVIRONMENT += BUILDOPT_ASAN=yes ASAN_OPTIONS=detect_leaks=false
 endif
 
+GITIGNOREFILES += ssh-config ansible-inventory.yml vmcheck/ test-compose-logs/
+
 testbin_cppflags = $(AM_CPPFLAGS) -I $(srcdir)/src/lib -I $(srcdir)/src/libpriv -I $(srcdir)/libglnx -I $(srcdir)/tests/common
 testbin_cflags = $(AM_CFLAGS) $(PKGDEP_RPMOSTREE_CFLAGS)
 testbin_ldadd = $(PKGDEP_RPMOSTREE_LIBS) librpmostree-1.la librpmostreepriv.la

--- a/ci/vmcheck-provision.sh
+++ b/ci/vmcheck-provision.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+# Install build dependencies, run unit tests and installed tests.
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libbuild.sh
+pkg_install openssh-clients ansible

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -38,7 +38,7 @@ vm_setup() {
   cat >${topsrcdir}/ansible-inventory.yml <<EOF
 all:
   hosts:
-    vmcheck:
+    ${VM}:
       ansible_ssh_common_args: "${sshopts}"
 EOF
 }
@@ -47,7 +47,7 @@ vm_ansible_inline() {
     playbook=$(mktemp -p /tmp 'libvm-ansible.XXXXXX')
     cat > ${playbook} <<EOF
 ---
-- hosts: vmcheck
+- hosts: ${VM}
   tasks:
 EOF
     sed -e 's,^,  ,' >> ${playbook}

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -34,6 +34,25 @@ vm_setup() {
 
   export SSH="ssh $sshopts $VM"
   export SCP="scp $sshopts"
+
+  cat >${topsrcdir}/ansible-inventory.yml <<EOF
+all:
+  hosts:
+    vmcheck:
+      ansible_ssh_common_args: "${sshopts}"
+EOF
+}
+
+vm_ansible_inline() {
+    playbook=$(mktemp -p /tmp 'libvm-ansible.XXXXXX')
+    cat > ${playbook} <<EOF
+---
+- hosts: vmcheck
+  tasks:
+EOF
+    sed -e 's,^,  ,' >> ${playbook}
+    ansible-playbook -i ${topsrcdir}/ansible-inventory.yml ${playbook}
+    rm -f ${playbook}
 }
 
 # rsync wrapper that sets up authentication

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -35,12 +35,15 @@ vm_setup() {
   export SSH="ssh $sshopts $VM"
   export SCP="scp $sshopts"
 
-  cat >${topsrcdir}/ansible-inventory.yml <<EOF
-all:
-  hosts:
-    ${VM}:
-      ansible_ssh_common_args: "${sshopts}"
-EOF
+  local HOSTS="${HOSTS:-${VM}}"
+  inventory=${topsrcdir}/ansible-inventory.ini
+  (echo '[vmcheck]' &&
+   for host in "${HOSTS}"; do
+       echo "${host}"
+   done &&
+   echo '[vmcheck:vars]' &&
+   echo 'ansible_ssh_common_args: "'${sshopts}'"'
+  ) > ${inventory}.new && mv ${inventory}{.new,}
 }
 
 vm_ansible_inline() {

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -44,10 +44,13 @@ echo "ok jsonpath"
 # underhanded, but we need a bona fide user session to verify non-priv status,
 # and logging in through SSH is an easy way to achieve that.
 if ! vm_cmd getent passwd testuser; then
-  vm_cmd useradd testuser
-  vm_cmd mkdir -pm 0700 /home/testuser/.ssh
-  vm_cmd cp -a /root/.ssh/authorized_keys /home/testuser/.ssh
-  vm_cmd chown -R testuser:testuser /home/testuser/.ssh
+  vm_ansible_inline <<EOF
+- shell: >
+    useradd testuser &&
+    mkdir -pm 0700 /home/testuser/.ssh &&
+    cp -a /root/.ssh/authorized_keys /home/testuser/.ssh &&
+    chown -R testuser:testuser /home/testuser/.ssh
+EOF
 fi
 
 # Make sure we can't do various operations as non-root


### PR DESCRIPTION
This adds a shell primitive to make it easy to execute a playbook
task list.

The big picture idea is to sync with https://github.com/ostreedev/ostree/pull/1462
and rewrite some of the libvm shell stuff as playbooks, allowing easier
code sharing with a-h-t and just in general being a better library for
talking ssh and executing commnads.
