### PR TITLE
 app/db-list: Use pkglist metadata when possible

### DIFF
--- a/tests/vmcheck/test-db.sh
+++ b/tests/vmcheck/test-db.sh
@@ -146,3 +146,17 @@ check_diff $pending_csum $pending_layered_csum \
   !pkg-to-replace-archtrans-1.0 \
   =pkg-to-replace-archtrans-2.0
 echo "ok db from pkglist.metadata"
+
+# check that db list also works fine from pkglist.metadata
+vm_rpmostree db list $pending_layered_csum > out.txt
+assert_not_file_has_content out.txt \
+  pkg-to-remove \
+  pkg-to-replace-1.0 \
+  pkg-to-replace-archtrans-1.0
+assert_file_has_content out.txt \
+  pkg-to-overlay-1.0-1.x86_64 \
+  pkg-to-overlay-1.0-1.i686 \
+  glibc-1.0-1.i686 \
+  pkg-to-replace-2.0 \
+  pkg-to-replace-archtrans-2.0
+echo "ok list from pkglist.metadata"

--- a/tests/vmcheck/test-db.sh
+++ b/tests/vmcheck/test-db.sh
@@ -74,6 +74,9 @@ check_diff "$pending_csum" "" \
   +pkg-to-replace \
   +pkg-to-replace-archtrans
 
+# check that diff'ing with --base yields 0 diffs
+check_not_diff "--base" "" pkg-to-
+
 # now let's make the pending csum become an update
 vm_cmd ostree commit -b vmcheck --tree=ref=$pending_csum
 vm_rpmostree cleanup -p


### PR DESCRIPTION
This patch teaches `db list` to also use the pkglist metadata when it
can, just like we did for `db diff`. To spell it out: this then allows
`db list` to work on commits for which we only have the commit object.

I went for the surgical incision here and didn't try to support
invocations which use fnmatch patterns for now. Definitely possible,
though it didn't feel like it was worth the effort given that the common
case is just a raw `db list` (I'd wager most people are probably
hard-wired to pipe to `grep` anyway for filtering).

Also fix the usage string, which had the arguments flipped.