### PR TITLE
daemon: Don't error out if a remote isn't found

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -525,7 +525,7 @@ print_deployments (RPMOSTreeSysroot *sysroot_proxy,
       g_print ("\n");
 
       const char *remote_not_found = NULL;
-      g_variant_dict_lookup (dict, "remote-not-found", "s", &remote_not_found);
+      g_variant_dict_lookup (dict, "remote-error", "s", &remote_not_found);
       if (remote_not_found)
         {
           g_print ("%s%s", get_red_start (), get_bold_start ());

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -524,6 +524,15 @@ print_deployments (RPMOSTreeSysroot *sysroot_proxy,
         g_print ("%s", checksum);
       g_print ("\n");
 
+      const char *remote_not_found = NULL;
+      g_variant_dict_lookup (dict, "remote-not-found", "s", &remote_not_found);
+      if (remote_not_found)
+        {
+          g_print ("%s%s", get_red_start (), get_bold_start ());
+          rpmostree_print_kv ("OstreeRemoteStatus", max_key_len, remote_not_found);
+          g_print ("%s%s", get_bold_end (), get_red_end ());
+        }
+
       const char *base_checksum = NULL;
       g_variant_dict_lookup (dict, "base-checksum", "&s", &base_checksum);
       gboolean is_locally_assembled = FALSE;

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -111,7 +111,7 @@ rpmostreed_deployment_get_for_index (OstreeSysroot *sysroot,
 }
 
 static gboolean
-variant_add_origin_status (OstreeRepo  *repo,
+variant_add_remote_status (OstreeRepo  *repo,
                            const gchar *origin_refspec,
                            const gchar *checksum,
                            GVariantDict *dict,
@@ -305,7 +305,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
     {
     case RPMOSTREE_REFSPEC_TYPE_OSTREE:
       {
-        if (!variant_add_origin_status (repo, refspec, base_checksum, &dict, error))
+        if (!variant_add_remote_status (repo, refspec, base_checksum, &dict, error))
           return NULL;
 
         g_autofree char *pending_base_commitrev = NULL;
@@ -450,7 +450,7 @@ add_all_commit_details_to_vardict (OstreeDeployment *deployment,
 
   if (refspec_is_ostree)
     {
-      if (!variant_add_origin_status (repo, refspec, checksum, dict, error))
+      if (!variant_add_remote_status (repo, refspec, checksum, dict, error))
         return FALSE;
     }
 

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -134,7 +134,7 @@ variant_add_remote_status (OstreeRepo  *repo,
            */
           if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
             {
-              g_variant_dict_insert (dict, "remote-not-found", "s", local_error->message);
+              g_variant_dict_insert (dict, "remote-error", "s", local_error->message);
               return TRUE;
             }
           g_propagate_error (error, g_steal_pointer (&local_error));

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -111,31 +111,42 @@ rpmostreed_deployment_get_for_index (OstreeSysroot *sysroot,
 }
 
 static gboolean
-variant_add_gpg_results (OstreeRepo  *repo,
-                         const gchar *origin_refspec,
-                         const gchar *checksum,
-                         GVariantDict *dict,
-                         GError     **error)
+variant_add_origin_status (OstreeRepo  *repo,
+                           const gchar *origin_refspec,
+                           const gchar *checksum,
+                           GVariantDict *dict,
+                           GError     **error)
 {
-  GLNX_AUTO_PREFIX_ERROR ("GPG verification error", error);
+  GLNX_AUTO_PREFIX_ERROR ("Loading origin status", error);
 
   g_autofree gchar *remote = NULL;
   if (!ostree_parse_refspec (origin_refspec, &remote, NULL, error))
     return FALSE;
 
+  g_autoptr(GError) local_error = NULL;
   gboolean gpg_verify = FALSE;
   if (remote)
     {
-      if (!ostree_repo_remote_get_gpg_verify (repo, remote, &gpg_verify, error))
-        return FALSE;
+      if (!ostree_repo_remote_get_gpg_verify (repo, remote, &gpg_verify, &local_error))
+        {
+          /* If the remote doesn't exist, let's note that so that status can
+           * render it specially.
+           */
+          if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+            {
+              g_variant_dict_insert (dict, "remote-not-found", "s", local_error->message);
+              return TRUE;
+            }
+          g_propagate_error (error, g_steal_pointer (&local_error));
+          return FALSE;
+        }
     }
   g_variant_dict_insert (dict, "gpg-enabled", "b", gpg_verify);
   if (!gpg_verify)
     return TRUE; /* Note early return; no need to verify signatures! */
 
-  g_autoptr(GError) local_error = NULL;
   g_autoptr(OstreeGpgVerifyResult) verify_result =
-    ostree_repo_verify_commit_for_remote (repo, checksum, remote, NULL, &local_error);
+    ostree_repo_verify_commit_for_remote (repo, checksum, remote, NULL, NULL);
   if (!verify_result)
     {
       /* Somehow, we have a deployment which has gpg-verify=true, but *doesn't* have a valid
@@ -294,7 +305,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
     {
     case RPMOSTREE_REFSPEC_TYPE_OSTREE:
       {
-        if (!variant_add_gpg_results (repo, refspec, base_checksum, &dict, error))
+        if (!variant_add_origin_status (repo, refspec, base_checksum, &dict, error))
           return NULL;
 
         g_autofree char *pending_base_commitrev = NULL;
@@ -439,7 +450,7 @@ add_all_commit_details_to_vardict (OstreeDeployment *deployment,
 
   if (refspec_is_ostree)
     {
-      if (!variant_add_gpg_results (repo, refspec, checksum, dict, error))
+      if (!variant_add_origin_status (repo, refspec, checksum, dict, error))
         return FALSE;
     }
 

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -77,6 +77,14 @@ echo "ok status doesn't require active PAM session"
 vm_cmd rpm-ostree reload
 echo "ok reload"
 
+# Reload as root https://github.com/projectatomic/rpm-ostree/issues/976
+vm_cmd 'mv /etc/ostree/remotes.d{,.orig}'
+vm_cmd systemctl restart rpm-ostreed
+vm_cmd rpm-ostree status > status.txt
+assert_file_has_content status.txt 'Remote.*not found'
+vm_cmd 'mv /etc/ostree/remotes.d{.orig,}'
+echo "ok remote not found"
+
 # Add metadata string containing EnfOfLife attribtue
 META_ENDOFLIFE_MESSAGE="this is a test for metadata message"
 commit=$(vm_cmd ostree commit -b vmcheck \

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -77,7 +77,7 @@ echo "ok status doesn't require active PAM session"
 vm_cmd rpm-ostree reload
 echo "ok reload"
 
-# Reload as root https://github.com/projectatomic/rpm-ostree/issues/976
+# https://github.com/projectatomic/rpm-ostree/issues/1301
 vm_cmd 'mv /etc/ostree/remotes.d{,.orig}'
 vm_cmd systemctl restart rpm-ostreed
 vm_cmd rpm-ostree status > status.txt


### PR DESCRIPTION
This came up in a few places recently; it happens for RHEL in some
cases, and in general we don't want to completely fail the daemon
start if someone messes up their remote config.

Closes: https://github.com/projectatomic/rpm-ostree/issues/1301