### PR TITLE
 daemon: Also generate CachedUpdate in DownloadUpdateRpmDiff

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -330,6 +330,17 @@ package_diff_transaction_execute (RpmostreedTransaction *transaction,
         rpmostree_output_message ("No change.");
     }
 
+  if (upgrading)
+    {
+      /* For backwards compatibility, we still need to make sure the CachedUpdate property
+       * is updated here. To do this, we cache to disk in libostree mode (no DnfSack), since
+       * that's all we updated here. This conflicts with auto-updates for now, though we
+       * need better test coverage before uniting those two paths. */
+      OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);
+      if (!generate_update_variant (repo, booted_deployment, NULL, cancellable, error))
+        return FALSE;
+    }
+
   return TRUE;
 }
 

--- a/src/daemon/rpmostreed-transaction.c
+++ b/src/daemon/rpmostreed-transaction.c
@@ -303,13 +303,19 @@ transaction_execute_thread (GTask *task,
       /* Also log to journal in addition to the client, so it's recorded
        * consistently.
        */
-      sd_journal_print (LOG_ERR, "Txn %s failed: %s",
+      sd_journal_print (LOG_ERR, "Txn %s on %s failed: %s",
+                        g_dbus_method_invocation_get_method_name (priv->invocation),
                         g_dbus_method_invocation_get_object_path (priv->invocation),
                         local_error->message);
       g_task_return_error (task, local_error);
     }
   else
-    g_task_return_boolean (task, success);
+    {
+      sd_journal_print (LOG_INFO, "Txn %s on %s successful",
+                        g_dbus_method_invocation_get_method_name (priv->invocation),
+                        g_dbus_method_invocation_get_object_path (priv->invocation));
+      g_task_return_boolean (task, success);
+    }
 
   /* Clean up context */
   g_main_context_pop_thread_default (mctx);

--- a/tests/vmcheck/test-cached-rpm-diffs.sh
+++ b/tests/vmcheck/test-cached-rpm-diffs.sh
@@ -58,10 +58,10 @@ call_dbus() {
     -m org.projectatomic.rpmostree1.OS.$method "$@"
 }
 
-if vm_cmd grep -q 'ID=.*centos' /etc/os-release; then
-  py=python
-else
+if vm_cmd test -x /usr/bin/python3; then
   py=python3
+else
+  py=python
 fi
 
 run_transaction() {


### PR DESCRIPTION
Moving to caching the GVariant to disk rather than during RPMOSTreeOS
reloads broke the legacy `DownloadUpdateRpmDiff` path because it relied
on the implied recalculations that occur on reloads to update
`CachedUpdate`.

This patch series was initially going to be about just migrating all the
legacy APIs to make use of the new metadata, which would have fixed this
properly. But we first need some real coverage in that aread, which is
very poor right now. I'd like to investigate integrating the Cockpit
tests (at least the ostree-specific parts) into our CI to remedy this.

Anyways, for now at least, let's fix Cockpit.

Closes: #1300