### PR TITLE
daemon: Retain pinned deployments

### DIFF
--- a/src/daemon/rpmostree-sysroot-core.c
+++ b/src/daemon/rpmostree-sysroot-core.c
@@ -404,8 +404,10 @@ rpmostree_syscore_filter_deployments (OstreeSysroot      *sysroot,
           continue;
         }
 
-      /* Is this deployment for a different osname?  Keep it. */
-      if (strcmp (ostree_deployment_get_osname (deployment), osname) != 0)
+      const gboolean osname_matches =
+        strcmp (ostree_deployment_get_osname (deployment), osname) == 0;
+      /* Retain deployments for other osnames, as well as pinned ones */
+      if (!osname_matches || ostree_deployment_is_pinned (deployment))
         {
           g_ptr_array_add (new_deployments, g_object_ref (deployment));
           continue;

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -125,6 +125,16 @@ vm_rpmostree status > status.txt
 assert_not_file_has_content status.txt "Pinned: yes"
 echo "ok pinning"
 
+vm_cmd ostree admin pin 0
+vm_rpmostree reload  # Try to avoid reload races
+vm_rpmostree cleanup -p
+vm_assert_status_jq ".deployments|length == 2"
+vm_cmd ostree admin pin -u 0
+vm_rpmostree reload  # Try to avoid reload races
+vm_rpmostree cleanup -p
+vm_assert_status_jq ".deployments|length == 1"
+echo "ok pinned retained"
+
 # https://github.com/ostreedev/ostree/pull/1055
 vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck --timestamp=\"October 25 1985\"
 if vm_rpmostree upgrade 2>err.txt; then


### PR DESCRIPTION
Followup to: https://github.com/ostreedev/ostree/pull/1464

Ideally, we'd delegate more logic around these things to libostree, but we're
not there yet.

This means e.g. `rpm-ostree cleanup -r` for a pinned rollback will just silently
skip it.  It'd be nicer to emit an error probably, but that'd be quite a bit
more work.

Closes: https://github.com/projectatomic/rpm-ostree/issues/1293
