### PR TITLE
daemon: Automatically reload sysroot before txn

### DIFF
--- a/src/daemon/rpmostreed-sysroot.h
+++ b/src/daemon/rpmostreed-sysroot.h
@@ -36,7 +36,6 @@ gboolean            rpmostreed_sysroot_populate         (RpmostreedSysroot *self
                                                          GCancellable *cancellable,
                                                          GError **error);
 gboolean            rpmostreed_sysroot_reload           (RpmostreedSysroot *self,
-                                                         gboolean *out_changed,
                                                          GError **error);
 
 OstreeSysroot *     rpmostreed_sysroot_get_root         (RpmostreedSysroot *self);

--- a/src/daemon/rpmostreed-transaction.c
+++ b/src/daemon/rpmostreed-transaction.c
@@ -335,7 +335,7 @@ transaction_execute_done_cb (GObject *source_object,
   success = g_task_propagate_boolean (G_TASK (result), &local_error);
   if (success)
     {
-      if (!rpmostreed_sysroot_reload (rpmostreed_sysroot_get (), NULL, &local_error))
+      if (!rpmostreed_sysroot_reload (rpmostreed_sysroot_get (), &local_error))
         success = FALSE;
     }
 

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -126,11 +126,9 @@ assert_not_file_has_content status.txt "Pinned: yes"
 echo "ok pinning"
 
 vm_cmd ostree admin pin 0
-vm_rpmostree reload  # Try to avoid reload races
 vm_rpmostree cleanup -p
 vm_assert_status_jq ".deployments|length == 2"
 vm_cmd ostree admin pin -u 0
-vm_rpmostree reload  # Try to avoid reload races
 vm_rpmostree cleanup -p
 vm_assert_status_jq ".deployments|length == 1"
 echo "ok pinned retained"


### PR DESCRIPTION
In this PR: https://github.com/projectatomic/rpm-ostree/pull/1309
I was hitting race conditions running `ostree admin pin` then
`rpm-ostree cleanup` as it was possible that the daemon hadn't handled
the inotify on the sysroot and reloaded the deployment state before
the txn request came in.

Close this race by doing an implicit `reload` before starting a txn.
This is a pretty efficient operation because for the sysroot we're
just doing a `stat()` and comparing mtime.

Implementation wise, change the external API to drop the "did change"
boolean as nothing outside of the `sysroot.c` file used it.

A followup to this would be changing the `status` CLI to call a
(new) DBus API like `RequestReload` that at least did the sysroot
reload if the daemon was otherwise idle or so?  And it'd be available
to unprivileged users.
