### PR TITLE
 daemon: Add new Reload D-Bus method

### DIFF
--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -47,6 +47,12 @@
       <arg type="a{sv}" name="options" direction="in"/>
     </method>
 
+    <!-- Reload sysroot if changed. This can also be used as a way to sync with the daemon
+         to ensure e.g. D-Bus properties are updated before reading them. -->
+    <method name="Reload">
+    </method>
+
+    <!-- Like Reload, but also reload configuration files. -->
     <method name="ReloadConfig">
     </method>
 

--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -40,9 +40,9 @@
 #include <systemd/sd-journal.h>
 
 static gboolean
-sysroot_reload (RpmostreedSysroot *self,
-                gboolean *out_changed,
-                GError **error);
+sysroot_reload_ostree_configs_and_deployments (RpmostreedSysroot *self,
+                                               gboolean *out_changed,
+                                               GError **error);
 
 /**
  * SECTION: sysroot
@@ -448,7 +448,7 @@ handle_reload_config (RPMOSTreeSysroot *object,
     goto out;
 
   gboolean sysroot_changed;
-  if (!sysroot_reload (self, &sysroot_changed, error))
+  if (!sysroot_reload_ostree_configs_and_deployments (self, &sysroot_changed, error))
     goto out;
 
   /* also send an UPDATED signal if configs changed to cause OS interfaces to reload; we do
@@ -697,9 +697,9 @@ rpmostreed_sysroot_class_init (RpmostreedSysrootClass *klass)
 }
 
 static gboolean
-sysroot_reload (RpmostreedSysroot *self,
-                gboolean *out_changed,
-                GError **error)
+sysroot_reload_ostree_configs_and_deployments (RpmostreedSysroot *self,
+                                               gboolean *out_changed,
+                                               GError **error)
 {
   gboolean ret = FALSE;
   gboolean did_change;
@@ -722,7 +722,7 @@ sysroot_reload (RpmostreedSysroot *self,
 gboolean
 rpmostreed_sysroot_reload (RpmostreedSysroot *self, GError **error)
 {
-  return sysroot_reload (self, NULL, error);
+  return sysroot_reload_ostree_configs_and_deployments (self, NULL, error);
 }
 
 static void

--- a/src/daemon/rpmostreed-sysroot.h
+++ b/src/daemon/rpmostreed-sysroot.h
@@ -36,7 +36,6 @@ gboolean            rpmostreed_sysroot_populate         (RpmostreedSysroot *self
                                                          GCancellable *cancellable,
                                                          GError **error);
 gboolean            rpmostreed_sysroot_reload           (RpmostreedSysroot *self,
-                                                         gboolean *out_changed,
                                                          GError **error);
 
 OstreeSysroot *     rpmostreed_sysroot_get_root         (RpmostreedSysroot *self);

--- a/src/daemon/rpmostreed-transaction.c
+++ b/src/daemon/rpmostreed-transaction.c
@@ -335,7 +335,7 @@ transaction_execute_done_cb (GObject *source_object,
   success = g_task_propagate_boolean (G_TASK (result), &local_error);
   if (success)
     {
-      if (!rpmostreed_sysroot_reload (rpmostreed_sysroot_get (), NULL, &local_error))
+      if (!rpmostreed_sysroot_reload (rpmostreed_sysroot_get (), &local_error))
         success = FALSE;
     }
 

--- a/tests/vmcheck/test-autoupdate.sh
+++ b/tests/vmcheck/test-autoupdate.sh
@@ -218,6 +218,9 @@ assert_output
 echo "ok check mode layered only with advisories"
 
 # check we see the same output with --check/--preview
+# clear out cache first to make sure they start from scratch
+vm_rpmostree cleanup -m
+vm_cmd systemctl stop rpm-ostreed
 vm_rpmostree upgrade --check > out.txt
 vm_rpmostree upgrade --preview > out-verbose.txt
 assert_output

--- a/tests/vmcheck/test-basic.sh
+++ b/tests/vmcheck/test-basic.sh
@@ -126,11 +126,9 @@ assert_not_file_has_content status.txt "Pinned: yes"
 echo "ok pinning"
 
 vm_cmd ostree admin pin 0
-vm_rpmostree reload  # Try to avoid reload races
 vm_rpmostree cleanup -p
 vm_assert_status_jq ".deployments|length == 2"
 vm_cmd ostree admin pin -u 0
-vm_rpmostree reload  # Try to avoid reload races
 vm_rpmostree cleanup -p
 vm_assert_status_jq ".deployments|length == 1"
 echo "ok pinned retained"


### PR DESCRIPTION
Follow up to #1310. Adds a new `Reload()` D-Bus method to make it easier to sync state. See commit messages for details.