### PR TITLE
core: Prefix error when loading commit for cache branch

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1406,6 +1406,10 @@ find_pkg_in_ostree (RpmOstreeContext *self,
   if (!cached_rev)
     return TRUE; /* Note early return */
 
+  /* Below here prefix with the branch */
+  const char *errprefix = glnx_strjoina ("Loading pkgcache branch ", cachebranch);
+  GLNX_AUTO_PREFIX_ERROR (errprefix, error);
+
   g_autoptr(GVariant) commit = NULL;
   if (!ostree_repo_load_commit (repo, cached_rev, &commit, NULL, error))
     return FALSE;


### PR DESCRIPTION
Somehow my dev container's pkgcache repo lost a commit.  Prefix
the error so this is easier to debug.
