### PR TITLE
build-sys: Mark libpriv symbols as private

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -57,6 +57,7 @@ librpmostreed_la_CFLAGS = \
 	$(AM_CFLAGS) \
 	$(PKGDEP_RPMOSTREE_CFLAGS) \
 	-DG_LOG_DOMAIN=\"rpm-ostreed\" \
+	-fvisibility=hidden \
 	-D_RPMOSTREE_EXTERN= \
 	-I$(srcdir)/src/daemon \
 	-I$(srcdir)/src/lib \

--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -74,6 +74,7 @@ librpmostreepriv_la_CFLAGS = \
 	-I$(srcdir)/src/libpriv \
 	-I$(libglnx_srcpath) \
 	-DPKGLIBDIR=\"$(pkglibdir)\" \
+	-fvisibility=hidden \
 	$(PKGDEP_RPMOSTREE_CFLAGS) \
 	$(NULL)
 

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -68,7 +68,7 @@ endif
 
 rpm_ostree_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-I$(srcdir)/src/lib -I$(srcdir)/src/libpriv -I$(libglnx_srcpath) \
-  -DPKGLIBDIR=\"$(pkglibdir)\" $(PKGDEP_RPMOSTREE_CFLAGS)
+	-fvisibility=hidden -DPKGLIBDIR=\"$(pkglibdir)\" $(PKGDEP_RPMOSTREE_CFLAGS)
 rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la librpmostree-1.la librpmostreed.la
 
 privdatadir=$(pkglibdir)

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -21,7 +21,7 @@ endif
 GITIGNOREFILES += ssh-config ansible-inventory.yml vmcheck/ test-compose-logs/
 
 testbin_cppflags = $(AM_CPPFLAGS) -I $(srcdir)/src/lib -I $(srcdir)/src/libpriv -I $(srcdir)/libglnx -I $(srcdir)/tests/common
-testbin_cflags = $(AM_CFLAGS) $(PKGDEP_RPMOSTREE_CFLAGS)
+testbin_cflags = $(AM_CFLAGS) -fvisibility=hidden $(PKGDEP_RPMOSTREE_CFLAGS)
 testbin_ldadd = $(PKGDEP_RPMOSTREE_LIBS) librpmostree-1.la librpmostreepriv.la
 
 noinst_LTLIBRARIES += libtest.la


### PR DESCRIPTION
This was caught by the abicheck in Fedora; since we were building with default
visibility for `librpmostreepriv.la` which was linked statically into the public
library, we'd end up with lots of internals as public ABI.

Fix this by using `-fvisibility=private` for the libpriv build and for good
measure elsewhere so we remember to use it by default.
