### PR TITLE
overrides: Allow resetting inactive overrides

### DIFF
--- a/buildutil/.gitignore
+++ b/buildutil/.gitignore
@@ -4,3 +4,4 @@ ltoptions.m4
 ltsugar.m4
 ltversion.m4
 lt~obsolete.m4
+libglnx.m4

--- a/tests/vmcheck/test-override-local-replace.sh
+++ b/tests/vmcheck/test-override-local-replace.sh
@@ -162,6 +162,19 @@ vm_assert_status_jq \
 assert_replaced_local_pkg bar-1.0-1.x86_64 bar-0.9-1.x86_64
 echo "ok active -> inactive -> active override replace"
 
+# make sure we can reset it while it's inactive
+vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/without_foo_and_bar
+vm_rpmostree upgrade
+vm_assert_status_jq \
+  '.deployments[0]["base-local-replacements"]|length == 0' \
+  '.deployments[0]["requested-base-local-replacements"]|length == 1' \
+  '.deployments[0]["requested-base-local-replacements"]|index("bar-0.9-1.x86_64") >= 0'
+vm_rpmostree override reset bar-0.9-1.x86_64
+vm_assert_status_jq \
+  '.deployments[0]["base-local-replacements"]|length == 0' \
+  '.deployments[0]["requested-base-local-replacements"]|length == 0'
+echo "ok reset inactive override replace"
+
 vm_rpmostree cleanup -p
 
 # try both local package layering and local replacements to make sure fd sending

--- a/tests/vmcheck/test-override-local-replace.sh
+++ b/tests/vmcheck/test-override-local-replace.sh
@@ -135,7 +135,9 @@ echo "ok override reset foo and fooext using name and nevra"
 vm_rpmostree override reset --all
 vm_assert_status_jq \
   '.deployments[0]["base-removals"]|length == 0' \
-  '.deployments[0]["requested-base-removals"]|length == 0'
+  '.deployments[0]["requested-base-removals"]|length == 0' \
+  '.deployments[0]["base-local-replacements"]|length == 0' \
+  '.deployments[0]["requested-base-local-replacements"]|length == 0'
 echo "ok override reset --all"
 
 vm_rpmostree cleanup -p


### PR DESCRIPTION
This fixes a small regression from #852 which prevented inactive
overrides to be reset. Which is funny, because that's exactly the most
likely time when you would want to reset an override.

Basically, the `!is_layered --> no overrides` doesn't make sense for
inactive overrides. I suspect most people worked around this by just
using `reset --all`.