### PR TITLE
Tests drop unit daemon

### DIFF
--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -303,6 +303,10 @@ vm_has_dormant_packages() {
     ! vm_has_layered_packages "$@"
 }
 
+vm_get_booted_stateroot() {
+    vm_get_booted_deployment_info osname
+}
+
 # retrieve the checksum of the currently booted deployment
 vm_get_booted_csum() {
   vm_get_booted_deployment_info checksum

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -448,3 +448,37 @@ vm_stop_httpd() {
   set +E
   trap - ERR
 }
+
+vm_ostreeupdate_prepare_repo() {
+  # Really testing this like a user requires a remote ostree server setup.
+  # Let's start by setting up the repo.
+  REMOTE_OSTREE=/ostree/repo/tmp/vmcheck-remote
+  vm_cmd mkdir -p $REMOTE_OSTREE
+  vm_cmd ostree init --repo=$REMOTE_OSTREE --mode=archive
+  vm_start_httpd ostree_server $REMOTE_OSTREE 8888
+}
+
+# APIs to build up a history on the server. Rather than wasting time
+# composing trees for real, we just use client package layering to create new
+# trees that we then "lift" into the server before cleaning them up client-side.
+
+# steal a commit from the system repo and make a branch out of it
+vm_ostreeupdate_lift_commit() {
+  checksum=$1; shift
+  branch=$1; shift
+  vm_cmd ostree pull-local --repo=$REMOTE_OSTREE --disable-fsync \
+    /ostree/repo $checksum
+  vm_cmd ostree --repo=$REMOTE_OSTREE refs $branch --delete
+  vm_cmd ostree --repo=$REMOTE_OSTREE refs $checksum --create=$branch
+}
+
+# use a previously stolen commit to create an update on our vmcheck branch,
+# complete with version string and pkglist metadata
+vm_ostreeupdate_create() {
+  branch=$1; shift
+  vm_cmd ostree commit --repo=$REMOTE_OSTREE -b vmcheck \
+    --tree=ref=$branch --add-metadata-string=version=$branch --fsync=no
+  # avoid libtool wrapper here since we're running on the VM and it would try to
+  # cd to topsrcdir/use gcc; libs are installed anyway
+  vm_cmd /var/roothome/sync/.libs/inject-pkglist $REMOTE_OSTREE vmcheck
+}

--- a/tests/vmcheck/test-misc-1.sh
+++ b/tests/vmcheck/test-misc-1.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+#
+# Copyright (C) 2017,2018 Red Hat, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -euo pipefail
+
+. ${commondir}/libtest.sh
+. ${commondir}/libvm.sh
+
+set -x
+
+# Miscellaneous basic tests; most are nondestructive
+
+# make sure that package-related entries are always present,
+# even when they're empty
+vm_assert_status_jq \
+  '.deployments[0]["packages"]' \
+  '.deployments[0]["requested-packages"]' \
+  '.deployments[0]["requested-local-packages"]' \
+  '.deployments[0]["base-removals"]' \
+  '.deployments[0]["requested-base-removals"]' \
+  '.deployments[0]["base-commit-meta"]["ostree.source-title"]|contains("overlay")' \
+  '.deployments[0]["layered-commit-meta"]|not'
+echo "ok empty pkg arrays, and commit meta correct in status json"
+
+vm_rpmostree status --jsonpath '$.deployments[0].booted' > jsonpath.txt
+assert_file_has_content_literal jsonpath.txt '[true]'
+echo "ok jsonpath"
+
+vm_rpmostree --version > version.yaml
+python -c 'import yaml; v=yaml.safe_load(open("version.yaml")); assert("Version" in v["rpm-ostree"])'
+echo "ok yaml version"
+
+# Ensure we return an error when passing a wrong option.
+vm_rpmostree --help | awk '/^$/ {in_commands=0} {if(in_commands==1){print $0}} /^Builtin Commands:/ {in_commands=1}' > commands
+while read command; do
+    if vm_rpmostree $command --n0t-3xisting-0ption &>/dev/null; then
+        assert_not_reached "command $command --n0t-3xisting-0ption was successful"
+    fi
+done < commands
+echo "ok error on unknown command options"
+
+if vm_rpmostree nosuchcommand --nosuchoption 2>err.txt; then
+    assert_not_reached "Expected an error for nosuchcommand"
+fi
+assert_file_has_content err.txt 'Unknown.*command'
+echo "ok error on unknown command"
+
+# Be sure an unprivileged user exists and that we can SSH into it. This is a bit
+# underhanded, but we need a bona fide user session to verify non-priv status,
+# and logging in through SSH is an easy way to achieve that.
+if ! vm_cmd getent passwd testuser; then
+  vm_ansible_inline <<EOF
+- shell: |
+    set -euo pipefail
+    useradd testuser
+    mkdir -pm 0700 /home/testuser/.ssh
+    cp -a /root/.ssh/authorized_keys /home/testuser/.ssh
+    chown -R testuser:testuser /home/testuser/.ssh
+EOF
+fi
+
+# Make sure we can't do various operations as non-root
+vm_build_rpm foo
+if vm_cmd_as testuser rpm-ostree pkg-add foo &> err.txt; then
+    assert_not_reached "Was able to install a package as non-root!"
+fi
+assert_file_has_content err.txt 'PkgChange not allowed for user'
+if vm_cmd_as testuser rpm-ostree reload &> err.txt; then
+    assert_not_reached "Was able to reload as non-root!"
+fi
+assert_file_has_content err.txt 'ReloadConfig not allowed for user'
+echo "ok auth"
+
+# Assert that we can do status as non-root
+vm_cmd_as testuser rpm-ostree status
+echo "ok status doesn't require root"
+
+# StateRoot is only in --verbose
+vm_rpmostree status > status.txt
+assert_not_file_has_content status.txt StateRoot:
+vm_rpmostree status -v > status.txt
+assert_file_has_content status.txt StateRoot:
+echo "ok status text"
+
+# Also check that we can do status as non-root non-active
+vm_cmd runuser -u bin rpm-ostree status
+echo "ok status doesn't require active PAM session"
+
+vm_rpmostree status -b > status.txt
+assert_streq $(grep -F -e 'ostree://' status.txt | wc -l) "1"
+echo "ok status -b"
+
+# Reload as root https://github.com/projectatomic/rpm-ostree/issues/976
+vm_cmd rpm-ostree reload
+echo "ok reload"
+
+stateroot=$(vm_get_booted_stateroot)
+stateroot_dbus=$(echo ${stateroot} | sed -e 's,-,_,')
+vm_cmd dbus-send --system --dest=org.projectatomic.rpmostree1 --print-reply=literal /org/projectatomic/rpmostree1/${stateroot_dbus} org.projectatomic.rpmostree1.OSExperimental.Moo boolean:true > moo.txt
+assert_file_has_content moo.txt '🐄'
+echo "ok moo"
+
+vm_rpmostree usroverlay
+vm_cmd test -w /usr/bin
+echo "ok usroverlay"
+
+vm_ansible_inline <<EOF
+- shell: |
+    set -xeuo pipefail
+    rpm-ostree cleanup -p
+    originpath=\$(ostree admin --print-current-dir).origin
+    cp -a \${originpath}{,.orig}
+    echo "unconfigured-state=Access to TestOS requires ONE BILLION DOLLARS" >> \${originpath}
+    rpm-ostree reload
+    rpm-ostree status
+    if rpm-ostree upgrade 2>err.txt; then
+       echo "Upgraded from unconfigured-state"
+       exit 1
+    fi
+    grep -qFe 'ONE BILLION DOLLARS' err.txt
+    mv \${originpath}{.orig,}
+    rpm-ostree reload
+EOF
+echo "ok unconfigured status"
+
+# https://github.com/projectatomic/rpm-ostree/issues/1301
+vm_cmd 'mv /etc/ostree/remotes.d{,.orig}'
+vm_cmd systemctl restart rpm-ostreed
+vm_cmd rpm-ostree status > status.txt
+assert_file_has_content status.txt 'Remote.*not found'
+vm_cmd 'mv /etc/ostree/remotes.d{.orig,}'
+vm_rpmostree reload
+echo "ok remote not found"

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -24,118 +24,7 @@ set -euo pipefail
 
 set -x
 
-# make sure that package-related entries are always present,
-# even when they're empty
-vm_assert_status_jq \
-  '.deployments[0]["packages"]' \
-  '.deployments[0]["requested-packages"]' \
-  '.deployments[0]["requested-local-packages"]' \
-  '.deployments[0]["base-removals"]' \
-  '.deployments[0]["requested-base-removals"]' \
-  '.deployments[0]["base-commit-meta"]["ostree.source-title"]|contains("overlay")' \
-  '.deployments[0]["layered-commit-meta"]|not'
-echo "ok empty pkg arrays, and commit meta correct in status json"
-
-vm_rpmostree status --jsonpath '$.deployments[0].booted' > jsonpath.txt
-assert_file_has_content_literal jsonpath.txt '[true]'
-echo "ok jsonpath"
-
-vm_rpmostree --version > version.yaml
-python -c 'import yaml; v=yaml.safe_load(open("version.yaml")); assert("Version" in v["rpm-ostree"])'
-echo "ok yaml version"
-
-# Ensure we return an error when passing a wrong option.
-vm_rpmostree --help | awk '/^$/ {in_commands=0} {if(in_commands==1){print $0}} /^Builtin Commands:/ {in_commands=1}' > commands
-while read command; do
-    if vm_rpmostree $command --n0t-3xisting-0ption &>/dev/null; then
-        assert_not_reached "command $command --n0t-3xisting-0ption was successful"
-    fi
-done < commands
-echo "ok error on unknown command options"
-
-if vm_rpmostree nosuchcommand --nosuchoption 2>err.txt; then
-    assert_not_reached "Expected an error for nosuchcommand"
-fi
-assert_file_has_content err.txt 'Unknown.*command'
-echo "ok error on unknown command"
-
-# Be sure an unprivileged user exists and that we can SSH into it. This is a bit
-# underhanded, but we need a bona fide user session to verify non-priv status,
-# and logging in through SSH is an easy way to achieve that.
-if ! vm_cmd getent passwd testuser; then
-  vm_ansible_inline <<EOF
-- shell: |
-    set -euo pipefail
-    useradd testuser
-    mkdir -pm 0700 /home/testuser/.ssh
-    cp -a /root/.ssh/authorized_keys /home/testuser/.ssh
-    chown -R testuser:testuser /home/testuser/.ssh
-EOF
-fi
-
-# Make sure we can't do various operations as non-root
-vm_build_rpm foo
-if vm_cmd_as testuser rpm-ostree pkg-add foo &> err.txt; then
-    assert_not_reached "Was able to install a package as non-root!"
-fi
-assert_file_has_content err.txt 'PkgChange not allowed for user'
-if vm_cmd_as testuser rpm-ostree reload &> err.txt; then
-    assert_not_reached "Was able to reload as non-root!"
-fi
-assert_file_has_content err.txt 'ReloadConfig not allowed for user'
-echo "ok auth"
-
-# Assert that we can do status as non-root
-vm_cmd_as testuser rpm-ostree status
-echo "ok status doesn't require root"
-
-# StateRoot is only in --verbose
-vm_rpmostree status > status.txt
-assert_not_file_has_content status.txt StateRoot:
-vm_rpmostree status -v > status.txt
-assert_file_has_content status.txt StateRoot:
-echo "ok status text"
-
-# Also check that we can do status as non-root non-active
-vm_cmd runuser -u bin rpm-ostree status
-echo "ok status doesn't require active PAM session"
-
-# Reload as root https://github.com/projectatomic/rpm-ostree/issues/976
-vm_cmd rpm-ostree reload
-echo "ok reload"
-
-stateroot=$(vm_get_booted_stateroot)
-stateroot_dbus=$(echo ${stateroot} | sed -e 's,-,_,')
-vm_cmd dbus-send --system --dest=org.projectatomic.rpmostree1 --print-reply=literal /org/projectatomic/rpmostree1/${stateroot_dbus} org.projectatomic.rpmostree1.OSExperimental.Moo boolean:true > moo.txt
-assert_file_has_content moo.txt '🐄'
-echo "ok moo"
-
-vm_ansible_inline <<EOF
-- shell: |
-    set -xeuo pipefail
-    rpm-ostree cleanup -p
-    originpath=\$(ostree admin --print-current-dir).origin
-    cp -a \${originpath}{,.orig}
-    echo "unconfigured-state=Access to TestOS requires ONE BILLION DOLLARS" >> \${originpath}
-    rpm-ostree reload
-    rpm-ostree status
-    if rpm-ostree upgrade 2>err.txt; then
-       echo "Upgraded from unconfigured-state"
-       exit 1
-    fi
-    grep -qFe 'ONE BILLION DOLLARS' err.txt
-    mv \${originpath}{.orig,}
-    rpm-ostree reload
-EOF
-echo "ok unconfigured status"
-
-# https://github.com/projectatomic/rpm-ostree/issues/1301
-vm_cmd 'mv /etc/ostree/remotes.d{,.orig}'
-vm_cmd systemctl restart rpm-ostreed
-vm_cmd rpm-ostree status > status.txt
-assert_file_has_content status.txt 'Remote.*not found'
-vm_cmd 'mv /etc/ostree/remotes.d{.orig,}'
-echo "ok remote not found"
+# More miscellaneous tests
 
 # Add metadata string containing EnfOfLife attribtue
 META_ENDOFLIFE_MESSAGE="this is a test for metadata message"
@@ -160,10 +49,6 @@ vm_rpmostree rollback
 vm_assert_status_jq ".deployments[0][\"booted\"] == false" \
                     ".deployments[1][\"booted\"] == true"
 echo "ok rollback"
-
-vm_rpmostree status -b > status.txt
-assert_streq $(grep -F -e 'ostree://' status.txt | wc -l) "1"
-echo "ok status -b"
 
 # Pinning
 vm_cmd ostree admin pin 0
@@ -274,7 +159,3 @@ if ! vm_rpmostree install refresh-md-new-pkg --dry-run; then
 fi
 vm_stop_httpd vmcheck
 echo "ok refresh-md"
-
-vm_rpmostree usroverlay
-vm_cmd test -w /usr/bin
-echo "ok usroverlay"


### PR DESCRIPTION
Some prep for dropping the `test-basic.sh` tests that start the daemon as non-roto.