### PR TITLE
tests: Split unit test-basic.sh into introspection + upgrade-rebase

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -54,7 +54,8 @@ uninstalled_test_programs = \
 	$(NULL)
 
 uninstalled_test_scripts = \
-	tests/check/test-basic.sh \
+	tests/check/test-upgrade-rebase.sh \
+	tests/check/test-lib-introspection.sh \
 	tests/check/test-ucontainer.sh \
 	$(NULL)
 

--- a/tests/check/test-lib-introspection.sh
+++ b/tests/check/test-lib-introspection.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Copyright (C) 2014 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+set -e
+
+. ${commondir}/libtest.sh
+echo "1..2"
+
+set -x
+
+if ! skip_one_with_asan; then
+    cat >test-rpmostree-gi-arch <<EOF
+#!/usr/bin/python2
+import gi
+gi.require_version("RpmOstree", "1.0")
+from gi.repository import RpmOstree
+assert RpmOstree.get_basearch() == 'x86_64'
+assert RpmOstree.varsubst_basearch('http://example.com/foo/\${basearch}/bar') == 'http://example.com/foo/x86_64/bar'
+EOF
+    chmod a+x test-rpmostree-gi-arch
+    case $(arch) in
+        x86_64) ./test-rpmostree-gi-arch
+                echo "ok rpmostree arch"
+                ;;
+        *) echo "ok # SKIP Skipping RPM architecture test on $(arch)"
+    esac
+fi
+
+if ! skip_one_with_asan; then
+    cat >test-rpmostree-gi <<EOF
+#!/usr/bin/python2
+import gi
+gi.require_version("RpmOstree", "1.0")
+from gi.repository import RpmOstree
+assert RpmOstree.check_version(2017, 6)
+# If this fails for you, please come back in a time machine and say hi
+assert not RpmOstree.check_version(3000, 1)
+EOF
+    chmod a+x test-rpmostree-gi
+    ./test-rpmostree-gi
+    echo "ok rpmostree version"
+fi

--- a/tests/check/test-upgrade-rebase.sh
+++ b/tests/check/test-upgrade-rebase.sh
@@ -24,7 +24,7 @@ export RPMOSTREE_SUPPRESS_REQUIRES_ROOT_CHECK=yes
 
 ensure_dbus
 
-echo "1..20"
+echo "1..18"
 
 setup_os_repository "archive-z2" "syslinux"
 
@@ -160,36 +160,3 @@ assert_status_jq '.deployments[0].origin == "testos:testos/buildmaster/x86_64-ru
 echo "ok rebase refspec syntax"
 
 rpm-ostree rebase --os=testos :another-branch
-
-if ! skip_one_with_asan; then
-    cat >test-rpmostree-gi-arch <<EOF
-#!/usr/bin/python2
-import gi
-gi.require_version("RpmOstree", "1.0")
-from gi.repository import RpmOstree
-assert RpmOstree.get_basearch() == 'x86_64'
-assert RpmOstree.varsubst_basearch('http://example.com/foo/\${basearch}/bar') == 'http://example.com/foo/x86_64/bar'
-EOF
-    chmod a+x test-rpmostree-gi-arch
-    case $(arch) in
-        x86_64) ./test-rpmostree-gi-arch
-                echo "ok rpmostree arch"
-                ;;
-        *) echo "ok # SKIP Skipping RPM architecture test on $(arch)"
-    esac
-fi
-
-if ! skip_one_with_asan; then
-    cat >test-rpmostree-gi <<EOF
-#!/usr/bin/python2
-import gi
-gi.require_version("RpmOstree", "1.0")
-from gi.repository import RpmOstree
-assert RpmOstree.check_version(2017, 6)
-# If this fails for you, please come back in a time machine and say hi
-assert not RpmOstree.check_version(3000, 1)
-EOF
-    chmod a+x test-rpmostree-gi
-    ./test-rpmostree-gi
-    echo "ok rpmostree version"
-fi


### PR DESCRIPTION
Following up to: https://github.com/projectatomic/rpm-ostree/pull/1336

It makes sense to keep the library tests as unit tests (although
we should also support doing them installed).

The upgrade-rebase tests will move into vmcheck/ soon.
