### PR TITLE
status: Show rpmmd-repo data in verbose mode

### DIFF
--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -296,7 +296,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
   /* We used to bridge individual keys, but that was annoying; just pass through all
    * of the commit metadata.
    */
-  { g_autoptr(GVariant) base_meta = g_variant_get_child_value (commit, 0);
+  { g_autoptr(GVariant) base_meta = g_variant_get_child_value (base_commit, 0);
     g_variant_dict_insert (&dict, "base-commit-meta", "@a{sv}", base_meta);
   }
   variant_add_commit_details (&dict, NULL, commit);

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -102,6 +102,8 @@ vm_assert_status_jq \
   '.deployments[0]["pending-base-checksum"]|not' \
   '.deployments[0]["base-commit-meta"]' \
   '.deployments[0]["layered-commit-meta"]["rpmostree.clientlayer_version"] > 1'
+vm_rpmostree status --verbose > verbose-status.txt
+assert_file_has_content_literal '└─ test-repo'
 
 vm_assert_layered_pkg foo-1.0 present
 echo "ok pkg foo added"


### PR DESCRIPTION
Building on:

 - 9cbec27d4c69b27afdaf895f84b64a4f0a3de3d6
 - e7a42f70a9e119f5211665f8ed036e8f82fd34e2

I was looking at a rpm-ostree run that imports a variety of rpmmd-repos,
and information about the source repositories is really useful for determining
the up-to-dateness.  We've been capturing this data for a while, it's
about time we started showing it somewhere.

This does make `status --verbose` notably more verbose, but eh, that
seems fine for now.

See also https://github.com/projectatomic/rpm-ostree/issues/774
