### PR TITLE
core: Finish implementing `override replace ./kernel*.x86_64.rpm

### DIFF
--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -67,6 +67,8 @@ struct _RpmOstreeContext {
 
   GLnxTmpDir tmpdir;
 
+  gboolean kernel_changed;
+
   int tmprootfs_dfd; /* Borrowed */
   GHashTable *rootfs_usrlinks;
   GLnxTmpDir repo_tmpdir; /* Used to assemble+commit if no base rootfs provided */

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -3881,7 +3881,8 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
           self->kernel_changed = TRUE;
           /* Remove all of our kernel data first, to ensure it's done
            * consistently. For example, in some of the rpmostree kernel handling code we
-           * won't look for an initramfs if the vmlinuz binary isn't found.
+           * won't look for an initramfs if the vmlinuz binary isn't found.  This
+           * is also taking over the role of running the kernel.spec's `%preun`.
            */
           if (!rpmostree_kernel_remove (tmprootfs_dfd, cancellable, error))
             return FALSE;

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -220,6 +220,8 @@ void rpmostree_context_set_tmprootfs_dfd (RpmOstreeContext *self,
                                           int               dfd);
 int rpmostree_context_get_tmprootfs_dfd  (RpmOstreeContext *self);
 
+gboolean rpmostree_context_get_kernel_changed (RpmOstreeContext *self);
+
 /* NB: tmprootfs_dfd is allowed to have pre-existing data */
 /* devino_cache can be NULL if no previous cache established */
 gboolean rpmostree_context_assemble (RpmOstreeContext      *self,

--- a/src/libpriv/rpmostree-kernel.c
+++ b/src/libpriv/rpmostree-kernel.c
@@ -451,7 +451,6 @@ rpmostree_run_dracut (int     rootfs_dfd,
 
   if (rebuild_from_initramfs)
     {
-      g_assert (argv == NULL);
       rebuild_argv = g_ptr_array_new ();
       g_ptr_array_add (rebuild_argv, "--rebuild");
       g_ptr_array_add (rebuild_argv, (char*)rebuild_from_initramfs);

--- a/src/libpriv/rpmostree-kernel.h
+++ b/src/libpriv/rpmostree-kernel.h
@@ -35,6 +35,11 @@ rpmostree_find_kernel (int rootfs_dfd,
                        GError **error);
 
 gboolean
+rpmostree_kernel_remove (int rootfs_dfd,
+                         GCancellable *cancellable,
+                         GError **error);
+
+gboolean
 rpmostree_finalize_kernel (int rootfs_dfd,
                            const char *bootdir,
                            const char *kver,

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -250,7 +250,7 @@ rpmostree_postprocess_run_depmod (int           rootfs_dfd,
                                   GCancellable *cancellable,
                                   GError      **error)
 {
-  char *child_argv[] = { "depmod", (char*)kver, NULL };
+  char *child_argv[] = { "depmod", "-a", (char*)kver, NULL };
   if (!run_bwrap_mutably (rootfs_dfd, "depmod", child_argv, unified_core_mode, cancellable, error))
     return FALSE;
   return TRUE;

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -243,6 +243,19 @@ hardlink_recurse (int                src_dfd,
   return TRUE;
 }
 
+gboolean
+rpmostree_postprocess_run_depmod (int           rootfs_dfd,
+                                  const char   *kver,
+                                  gboolean      unified_core_mode,
+                                  GCancellable *cancellable,
+                                  GError      **error)
+{
+  char *child_argv[] = { "depmod", (char*)kver, NULL };
+  if (!run_bwrap_mutably (rootfs_dfd, "depmod", child_argv, unified_core_mode, cancellable, error))
+    return FALSE;
+  return TRUE;
+}
+
 /* Handle the kernel/initramfs, which can be in at least 2 different places:
  *  - /boot (CentOS, Fedora treecompose before we suppressed kernel.spec's %posttrans)
  *  - /usr/lib/modules (Fedora treecompose without kernel.spec's %posttrans)
@@ -328,11 +341,9 @@ process_kernel_and_initramfs (int            rootfs_dfd,
   /* Ensure depmod (kernel modules index) is up to date; because on Fedora we
    * suppress the kernel %posttrans we need to take care of this.
    */
-  {
-    char *child_argv[] = { "depmod", (char*)kver, NULL };
-    if (!run_bwrap_mutably (rootfs_dfd, "depmod", child_argv, unified_core_mode, cancellable, error))
-      return FALSE;
-  }
+  if (!rpmostree_postprocess_run_depmod (rootfs_dfd, kver, unified_core_mode,
+                                         cancellable, error))
+    return FALSE;
 
   RpmOstreePostprocessBootLocation boot_location =
     RPMOSTREE_POSTPROCESS_BOOT_LOCATION_BOTH;

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -60,6 +60,13 @@ rpmostree_rootfs_postprocess_common (int           rootfs_fd,
                                      GError       **error);
 
 gboolean
+rpmostree_postprocess_run_depmod (int           rootfs_fd,
+                                  const char   *kver,
+                                  gboolean      unified_core_mode,
+                                  GCancellable *cancellable,
+                                  GError      **error);
+
+gboolean
 rpmostree_prepare_rootfs_get_sepolicy (int            dfd,
                                        OstreeSePolicy **out_sepolicy,
                                        GCancellable  *cancellable,

--- a/tests/vmcheck/test-override-kernel.sh
+++ b/tests/vmcheck/test-override-kernel.sh
@@ -50,8 +50,8 @@ if grep -q -F -e "${orig_kernel}" new-dblist.txt; then
     fatal "Found kernel: ${line}"
 fi
 newroot=$(vm_get_deployment_root 0)
-find ${newroot}/usr/lib/modules -maxdepth 1 -type d > modules-dirs.txt
-assert_streq $(wc -l modules-dirs.txt) "2"
+vm_cmd find ${newroot}/usr/lib/modules -maxdepth 1 -type d > modules-dirs.txt
+assert_streq "$(wc -l < modules-dirs.txt)" "2"
 assert_file_has_content_literal modules-dirs.txt '4.13.9-300.fc27'
 
 echo "ok override kernel"

--- a/tests/vmcheck/test-override-kernel.sh
+++ b/tests/vmcheck/test-override-kernel.sh
@@ -49,4 +49,9 @@ assert_file_has_content_literal new-dblist.txt 'kernel-4.13.9-300.fc27'
 if grep -q -F -e "${orig_kernel}" new-dblist.txt; then
     fatal "Found kernel: ${line}"
 fi
+newroot=$(vm_get_deployment_root 0)
+find ${newroot}/usr/lib/modules -maxdepth 1 -type d > modules-dirs.txt
+assert_streq $(wc -l modules-dirs.txt) "2"
+assert_file_has_content_literal modules-dirs.txt '4.13.9-300.fc27'
+
 echo "ok override kernel"


### PR DESCRIPTION
Previously we merged: #1228 AKA 12dc565b00638182664bc21cd90ff12d49ac2e5a
My recollection is that was working on it the background, while doing
something else, and I clearly didn't get to the point of testing it "for real".

There are many interlocking issues here to make this work.  For example,
the "remove RPM" logic needs special handling for the kernel, because
we also inject content into `/usr/lib/ostree-boot` and also generate
the initramfs, etc.

The architecture I chose is to have the core *detect* when a kernel
is changed, and also call into the kernel processing code when removing
a kernel package.  But the logic for doing kernel reinstallation client-side
is best alongside the initramfs generation logic which already existed
in the sysroot upgrader.

I extended the test suite to cover what was failing before, and I
tested this interactively.  But I'm uncertain about adding a test
for actually *booting* into the GA kernel as it's quite possible
some bits in userspace rely on a newer kernel.  Fixing this properly
really wants some infrastructure to better "re-version" an existing
package without changing its content.

Closes: https://github.com/projectatomic/rpm-ostree/issues/1334
