### PR TITLE
app/status: Print diff/advisories with pending deployment

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -46,13 +46,15 @@
 
 static gboolean opt_pretty;
 static gboolean opt_verbose;
+static gboolean opt_verbose_advisories;
 static gboolean opt_json;
 static gboolean opt_only_booted;
 static const char *opt_jsonpath;
 
 static GOptionEntry option_entries[] = {
   { "pretty", 'p', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_pretty, "This option is deprecated and no longer has any effect", NULL },
-  { "verbose", 'v', 0, G_OPTION_ARG_NONE, &opt_verbose, "Print additional fields (e.g. StateRoot)", NULL },
+  { "verbose", 'v', 0, G_OPTION_ARG_NONE, &opt_verbose, "Print additional fields (e.g. StateRoot); implies -a", NULL },
+  { "advisories", 'a', 0, G_OPTION_ARG_NONE, &opt_verbose_advisories, "Expand advisories listing", NULL },
   { "json", 0, 0, G_OPTION_ARG_NONE, &opt_json, "Output JSON", NULL },
   { "jsonpath", 'J', 0, G_OPTION_ARG_STRING, &opt_jsonpath, "Filter JSONPath expression", "EXPRESSION" },
   { "booted", 'b', 0, G_OPTION_ARG_NONE, &opt_only_booted, "Only print the booted deployment", NULL },
@@ -636,8 +638,8 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
         g_variant_dict_lookup_value (&dict, "rpm-diff", G_VARIANT_TYPE ("a{sv}"));
       g_autoptr(GVariant) advisories =
         g_variant_dict_lookup_value (&dict, "advisories", G_VARIANT_TYPE ("a(suuasa{sv})"));
-      if (!rpmostree_print_diff_advisories (rpm_diff, advisories,
-                                            opt_verbose, max_key_len, error))
+      if (!rpmostree_print_diff_advisories (rpm_diff, advisories, opt_verbose,
+                                            opt_verbose_advisories, max_key_len, error))
         return FALSE;
       *out_printed_cached_update = TRUE;
     }
@@ -988,7 +990,7 @@ rpmostree_builtin_status (int             argc,
         {
           g_print ("\n");
           if (!rpmostree_print_cached_update (cached_update, opt_verbose,
-                                              cancellable, error))
+                                              opt_verbose_advisories, cancellable, error))
             return FALSE;
         }
     }

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -204,7 +204,7 @@ rpmostree_builtin_upgrade (int             argc,
       else
         {
           /* preview --> verbose (i.e. we want the diff) */
-          if (!rpmostree_print_cached_update (cached_update, opt_preview,
+          if (!rpmostree_print_cached_update (cached_update, opt_preview, FALSE,
                                               cancellable, error))
             return FALSE;
         }

--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -1357,11 +1357,12 @@ gboolean
 rpmostree_print_diff_advisories (GVariant         *rpm_diff,
                                  GVariant         *advisories,
                                  gboolean          verbose,
+                                 gboolean          verbose_advisories,
                                  guint             max_key_len,
                                  GError          **error)
 {
   if (advisories)
-    print_advisories (advisories, verbose, max_key_len);
+    print_advisories (advisories, verbose || verbose_advisories, max_key_len);
 
   g_auto(GVariantDict) rpm_diff_dict;
   g_variant_dict_init (&rpm_diff_dict, rpm_diff);
@@ -1415,6 +1416,7 @@ rpmostree_print_diff_advisories (GVariant         *rpm_diff,
 gboolean
 rpmostree_print_cached_update (GVariant         *cached_update,
                                gboolean          verbose,
+                               gboolean          verbose_advisories,
                                GCancellable     *cancellable,
                                GError          **error)
 {
@@ -1475,7 +1477,7 @@ rpmostree_print_cached_update (GVariant         *cached_update,
   if (rpm_diff)
     {
       if (!rpmostree_print_diff_advisories (rpm_diff, advisories, verbose,
-                                            max_key_len, error))
+                                            verbose_advisories, max_key_len, error))
         return FALSE;
     }
 

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -127,11 +127,13 @@ gboolean
 rpmostree_print_diff_advisories (GVariant         *rpm_diff,
                                  GVariant         *advisories,
                                  gboolean          verbose,
+                                 gboolean          verbose_advisories,
                                  guint             max_key_len,
                                  GError          **error);
 
 gboolean
 rpmostree_print_cached_update (GVariant         *cached_update,
                                gboolean          verbose,
+                               gboolean          verbose_advisories,
                                GCancellable     *cancellable,
                                GError          **error);

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -1116,7 +1116,11 @@ rpmostreed_update_generate_variant (OstreeDeployment  *booted_deployment,
         g_variant_dict_insert (&dict, "advisories", "@a(suuasa{sv})", advisories);
     }
 
-  g_variant_dict_insert (&dict, "staged", "b", staged_deployment != NULL);
+  if (staged_deployment)
+    {
+      g_autofree char *id = rpmostreed_deployment_generate_id (staged_deployment);
+      g_variant_dict_insert (&dict, "deployment", "s", id);
+    }
 
   /* but if there are no updates, then just ditch the whole thing and return NULL */
   if (is_new_checksum || rpmmd_modified_new)

--- a/tests/vmcheck/test-autoupdate.sh
+++ b/tests/vmcheck/test-autoupdate.sh
@@ -136,6 +136,9 @@ assert_output() {
     "SecAdvisories: VMCHECK-SEC-NONE  Unknown    layered-sec-none-2.0-1.x86_64" \
     "               VMCHECK-SEC-LOW   Low        layered-sec-low-2.0-1.x86_64" \
     "               VMCHECK-SEC-CRIT  Critical   layered-sec-crit-2.0-1.x86_64"
+
+  # make sure any future call doesn't forget to create fresh ones
+  rm -f out.txt out-verbose.txt
 }
 
 # now add all of them
@@ -201,6 +204,9 @@ assert_output2() {
     'Downgraded: base-pkg-bar 1.0-1 -> 0.9-3' \
     'Removed: base-pkg-baz-1.1-1.x86_64' \
     'Added: base-pkg-boo-3.7-2.11.x86_64'
+
+  # make sure any future call doesn't forget to create fresh ones
+  rm -f out.txt out-verbose.txt
 }
 
 vm_rpmostree status > out.txt
@@ -238,6 +244,11 @@ assert_default_deployment_is_update() {
 vm_rpmostree cleanup -m
 vm_cmd systemctl stop rpm-ostreed
 vm_rpmostree upgrade
+vm_rpmostree status > out.txt
+vm_rpmostree status -v > out-verbose.txt
+# we should have printed as part of the pending deployment
+assert_not_file_has_content out.txt "Available update"
+assert_not_file_has_content out-verbose.txt "Available update"
 assert_output2
 assert_default_deployment_is_update
 echo "ok upgrade"


### PR DESCRIPTION
Not sure about the code structure here yet, but it looks nice!

```
# rpm-ostree status
State: idle; auto updates disabled
Deployments:
  ostree://fedora-atomic:fedora/27/x86_64/atomic-host
                   Version: 27.122 (2018-04-18 23:34:24)
                    Commit: 931ebb3941fc49af706ac5a90ad3b5a493be4ae35e85721dabbfd966b1ecbf99
              GPGSignature: Valid signature by 860E19B0AFA800A1751881A6F55E7430F5282EE4
                      Diff: 71 upgraded, 1 removed, 1 added

● ostree://fedora-atomic:fedora/27/x86_64/atomic-host
                   Version: 27.105 (2018-03-25 21:28:49)
                    Commit: c4015063c00515ddbbaa4c484573d38376db270b09adb22a4859faa0a39d5d93
              GPGSignature: Valid signature by 860E19B0AFA800A1751881A6F55E7430F5282EE4
                  Unlocked: development
```