### PR TITLE
man/rpm-ostree: --check always updates RPM metadata

### DIFF
--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -427,7 +427,8 @@ Boston, MA 02111-1307, USA.
             available, without downloading it or performing a
             package-level diff.  Using this flag will force an update
             of the RPM metadata from the enabled repos in
-            <filename>/etc/yum.repos.d/</filename>.
+            <filename>/etc/yum.repos.d/</filename>, if there are any
+            layered packages.
           </para>
 
           <para>

--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -425,7 +425,9 @@ Boston, MA 02111-1307, USA.
           <para>
             <option>--check</option> to just check if an upgrade is
             available, without downloading it or performing a
-            package-level diff.
+            package-level diff.  Using this flag will force an update
+            of the RPM metadata from the enabled repos in
+            <filename>/etc/yum.repos.d/</filename>.
           </para>
 
           <para>


### PR DESCRIPTION
Add a short note explaining that the RPM metadata is always refreshed
when using the `--check` flag.