### PR TITLE
db: Add some error prefixing around rpmdb loading

### DIFF
--- a/src/lib/rpmostree-package.c
+++ b/src/lib/rpmostree-package.c
@@ -249,6 +249,7 @@ _rpm_ostree_package_list_for_commit (OstreeRepo   *repo,
                                      GCancellable *cancellable,
                                      GError      **error)
 {
+  GLNX_AUTO_PREFIX_ERROR ("Loading package list", error);
   g_autofree char *checksum = NULL;
   if (!ostree_repo_resolve_rev (repo, rev, FALSE, &checksum, error))
     return FALSE;

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -771,6 +771,7 @@ checkout_only_rpmdb (OstreeRepo       *repo,
                      GCancellable     *cancellable,
                      GError          **error)
 {
+  GLNX_AUTO_PREFIX_ERROR ("rpmdb checkout", error);
   g_autofree char *commit = NULL;
   if (!ostree_repo_resolve_rev (repo, ref, FALSE, &commit, error))
     return FALSE;
@@ -804,6 +805,7 @@ get_sack_for_root (int               dfd,
                    DnfSack         **out_sack,
                    GError          **error)
 {
+  GLNX_AUTO_PREFIX_ERROR ("Loading sack", error);
   g_return_val_if_fail (out_sack != NULL, FALSE);
 
   g_autofree char *fullpath = glnx_fdrel_abspath (dfd, path);


### PR DESCRIPTION
In https://github.com/cockpit-project/cockpit/pull/9090#issuecomment-386564044
we're seeing:
`Txn DownloadUpdateRpmDiff ... failed: open(O_TMPFILE): No such file or directory`

Looking at the error paths in the rpmdb diff code, there's not really
any error prefixing.  Let's add some so this is easier to debug.
