### PR TITLE
daemon/upgrader: Reuse sack from core for advisories

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -391,7 +391,6 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
                       gboolean          first,
                       gboolean          have_any_live_overlay,
                       gboolean          have_multiple_stateroots,
-                      const char       *last_osname,
                       GError          **error)
 {
   /* Add the long keys here */
@@ -837,7 +836,7 @@ print_deployments (RPMOSTreeSysroot *sysroot_proxy,
         break;
 
       if (!print_one_deployment (sysroot_proxy, child, first, have_any_live_overlay,
-                                 have_multiple_stateroots, last_osname, error))
+                                 have_multiple_stateroots, error))
         return FALSE;
       if (first)
         first = FALSE;

--- a/src/app/rpmostree-dbus-helpers.h
+++ b/src/app/rpmostree-dbus-helpers.h
@@ -124,6 +124,13 @@ rpmostree_update_deployment (RPMOSTreeOS  *os_proxy,
                              GError      **error);
 
 gboolean
+rpmostree_print_diff_advisories (GVariant         *rpm_diff,
+                                 GVariant         *advisories,
+                                 gboolean          verbose,
+                                 guint             max_key_len,
+                                 GError          **error);
+
+gboolean
 rpmostree_print_cached_update (GVariant         *cached_update,
                                gboolean          verbose,
                                GCancellable     *cancellable,

--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -87,6 +87,10 @@ rpmostree_sysroot_upgrader_set_origin (RpmOstreeSysrootUpgrader *self,
 const char *
 rpmostree_sysroot_upgrader_get_base (RpmOstreeSysrootUpgrader *self);
 
+DnfSack*
+rpmostree_sysroot_upgrader_get_sack (RpmOstreeSysrootUpgrader *self,
+                                     GError                  **error);
+
 gboolean
 rpmostree_sysroot_upgrader_pull_base (RpmOstreeSysrootUpgrader  *self,
                                       const char             *dir_to_pull,

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -943,7 +943,7 @@ gboolean
 rpmostreed_update_generate_variant (OstreeDeployment  *booted_deployment,
                                     OstreeDeployment  *staged_deployment,
                                     OstreeRepo        *repo,
-                                    DnfSack           *sack,
+                                    DnfSack           *sack, /* allow-none */
                                     GVariant         **out_update,
                                     GCancellable      *cancellable,
                                     GError           **error)

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -198,7 +198,7 @@ static gboolean
 generate_update_variant (OstreeRepo       *repo,
                          OstreeDeployment *booted_deployment,
                          OstreeDeployment *staged_deployment,
-                         DnfSack          *sack,
+                         DnfSack          *sack, /* allow-none */
                          GCancellable     *cancellable,
                          GError          **error)
 {
@@ -1189,15 +1189,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
           OstreeDeployment *booted_deployment =
             ostree_sysroot_get_booted_deployment (sysroot);
 
-          g_autoptr(DnfSack) sack = NULL;
-          if (g_hash_table_size (rpmostree_origin_get_packages (origin)) > 0)
-            {
-              /* don't force a refresh; we want the same sack state used by the core */
-              if (!get_sack_for_booted (sysroot, repo, booted_deployment, FALSE, &sack,
-                                        cancellable, error))
-                return FALSE;
-            }
-
+          DnfSack *sack = rpmostree_sysroot_upgrader_get_sack (upgrader, error);
           if (!generate_update_variant (repo, booted_deployment, new_deployment, sack,
                                         cancellable, error))
             return FALSE;

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1905,7 +1905,11 @@ rpmostree_context_prepare (RpmOstreeContext *self,
   /* setup sack if not yet set up */
   if (dnf_context_get_sack (dnfctx) == NULL)
     {
-      if (!rpmostree_context_download_metadata (self, 0, cancellable, error))
+      /* default to loading updateinfo in this path; this allows the sack to be used later
+       * on for advisories -- it's always downloaded anyway */
+      if (!rpmostree_context_download_metadata (self,
+                                                DNF_CONTEXT_SETUP_SACK_FLAG_LOAD_UPDATEINFO,
+                                                cancellable, error))
         return FALSE;
       journal_rpmmd_info (self);
     }


### PR DESCRIPTION
In #1344, we changed `upgrade` to always write the cached update. One
thing I hadn't noticed was that with pkglayering, loading the sack twice
meant we printed all that gory repo info twice.

Really, the much nicer thing to do is just to make an effort to try to
*keep* the original sack that the core used so that we skip all that
overhead completely.

---

I also rolled up some prep patches for #1350 in there.