### PR TITLE
core: Tweak package checkout message

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -3813,15 +3813,15 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
   }
 
   guint overrides_total = overrides_remove->len + overrides_replace->len;
+  const char *progress_msg = "Checking out packages";
   if (!layering_on_base)
     {
       g_assert_cmpint (overrides_total, ==, 0);
-      rpmostree_output_message ("Installing %u package%s", overlays->len,
-                                _NS(overlays->len));
     }
   else if (overrides_total > 0)
     {
       g_assert (layering_on_base);
+      progress_msg = "Processing packages";
       if (overlays->len > 0)
         rpmostree_output_message ("Applying %u override%s and %u overlay%s",
                                   overrides_total, _NS(overrides_total),
@@ -3830,10 +3830,8 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
         rpmostree_output_message ("Applying %u override%s", overrides_total,
                                   _NS(overrides_total));
     }
-
   else if (overlays->len > 0)
-    rpmostree_output_message ("Applying %u overlay%s", overlays->len,
-                              _NS(overlays->len));
+    ;
   else
     g_assert_not_reached ();
 
@@ -3861,7 +3859,7 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
                                        cancellable, error))
         return FALSE;
       n_rpmts_done++;
-      rpmostree_output_progress_n_items ("Building filesystem", n_rpmts_done, n_rpmts_elements);
+      rpmostree_output_progress_n_items (progress_msg, n_rpmts_done, n_rpmts_elements);
     }
 
   g_autoptr(GHashTable) files_skip_add = NULL;
@@ -3896,7 +3894,7 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
                                      dirs_to_remove, cancellable, error))
         return FALSE;
       n_rpmts_done++;
-      rpmostree_output_progress_n_items ("Building filesystem", n_rpmts_done, n_rpmts_elements);
+      rpmostree_output_progress_n_items (progress_msg, n_rpmts_done, n_rpmts_elements);
     }
   g_clear_pointer (&files_skip_delete, g_hash_table_unref);
 
@@ -3933,7 +3931,7 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
                                        files_skip_add, ovwmode, cancellable, error))
         return FALSE;
       n_rpmts_done++;
-      rpmostree_output_progress_n_items ("Building filesystem", n_rpmts_done, n_rpmts_elements);
+      rpmostree_output_progress_n_items (progress_msg, n_rpmts_done, n_rpmts_elements);
     }
 
   rpmostree_output_progress_end ();

--- a/tests/vmcheck/test-layering-basic.sh
+++ b/tests/vmcheck/test-layering-basic.sh
@@ -93,7 +93,7 @@ echo "ok pkg-add foo"
 # Test that we don't do progress bars if on a tty (with the client)
 vm_rpmostree uninstall foo-1.0
 vm_rpmostree install foo-1.0 > foo-install.txt
-assert_file_has_content_literal foo-install.txt 'Building filesystem (1/1) 100%'
+assert_file_has_content_literal foo-install.txt 'Checking out packages (1/1) 100%'
 echo "ok install not on a tty"
 
 vm_reboot


### PR DESCRIPTION
The common case is having layered packages and no overrides; seeing
`Applying 8 overlays` then `Building filesystem [0/8]` is redundant.
Tweak the progress to avoid the double message.  Also change the terminology
to clarify that each item is a package.

