### PR TITLE
ci: Split codestyle checks into separate context

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -6,7 +6,7 @@ branches:
 context: f27-codestyle
 required: true
 container:
-  image: registry.fedoraproject.org/fedora:28
+  image: registry.fedoraproject.org/fedora:27
 
 tests:
   - ci/ci-commitmessage-submodules.sh

--- a/.papr.yml
+++ b/.papr.yml
@@ -3,9 +3,19 @@ branches:
     - auto
     - try
 
-context: f27-primary
-
+context: f27-codestyle
 required: true
+container:
+  image: registry.fedoraproject.org/fedora:28
+
+tests:
+  - ci/ci-commitmessage-submodules.sh
+  - ci/codestyle.sh
+
+---
+
+context: f27-primary
+inherit: true
 
 cluster:
   hosts:
@@ -26,8 +36,6 @@ env:
   CI_PKGS: rsync
 
 tests:
-  - ci/ci-commitmessage-submodules.sh
-  - ci/codestyle.sh
   - ci/build-check.sh
   - ci/vmcheck-provision.sh
   - make vmcheck


### PR DESCRIPTION
Prep for reworking the primary test to do vm-in-container, which
will temporarily be vm-in-container-in-vm.

See https://github.com/projectatomic/rpm-ostree/pull/1362
