### PR TITLE
compose: Add a missing `return` in error path

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1267,7 +1267,7 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
       if (!rpmostree_check_groups (self->repo, self->rootfs_dfd, treefile_dirpath, self->treefile,
                                    self->previous_checksum,
                                    cancellable, error))
-        glnx_prefix_error (error, "Handling group db");
+        return glnx_prefix_error (error, "Handling group db");
     }
 
   /* See comment above */


### PR DESCRIPTION
Was hitting a `SEGV` in a build that *might* be this.
