### PR TITLE
daemon/upgrader: Consistently remove transient state

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -108,6 +108,7 @@ parse_origin_deployment (RpmOstreeSysrootUpgrader *self,
   self->origin = rpmostree_origin_parse_deployment (deployment, error);
   if (!self->origin)
     return FALSE;
+  rpmostree_origin_remove_transient_state (self->origin);
 
   if (rpmostree_origin_get_unconfigured_state (self->origin) &&
       !(self->flags & RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED))
@@ -118,11 +119,6 @@ parse_origin_deployment (RpmOstreeSysrootUpgrader *self,
                    rpmostree_origin_get_unconfigured_state (self->origin));
       return FALSE;
     }
-
-  /* A bit hacky; here we clean out the live state which is deployment specific.
-   * We don't expect users of the upgrader to want the live state.
-   */
-  rpmostree_origin_set_live_state (self->origin, NULL, NULL);
 
   return TRUE;
 }

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -52,6 +52,9 @@ rpmostree_origin_parse_deployment (OstreeDeployment *deployment,
 RpmOstreeOrigin *
 rpmostree_origin_dup (RpmOstreeOrigin *origin);
 
+void
+rpmostree_origin_remove_transient_state (RpmOstreeOrigin *origin);
+
 const char *
 rpmostree_origin_get_refspec (RpmOstreeOrigin *origin);
 


### PR DESCRIPTION
With the new support for pinning deployments, we need to also update
rpm-ostree to clean up the transient state as is now done in the ostree
sysroot upgrader.

This addresses that issue as well as tries to be a little cleaner in how
we clean up other transient state. Notably, we add a new helper function
to `RpmOstreeOrigin` to do this for us and use it in the upgrader. In
other cases, we do want this transient information since it allows us to
describe the deployment.

Closes: ostreedev/ostree#1595