### PR TITLE
.gitmodules: Update URL for libglnx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libglnx"]
 	path = libglnx
-	url = https://git.gnome.org/browse/libglnx
+	url = https://gitlab.gnome.org/GNOME/libglnx.git
 [submodule "libdnf"]
 	path = libdnf
 	url = https://github.com/projectatomic/libdnf


### PR DESCRIPTION
Seeing a 404 in the CentOS build for some reason...something like
older versions of git not following redirects maybe?

Update submodule: libglnx
