### PR TITLE
WIP: add sysusers to compose

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -46,11 +46,16 @@ tests_check_test_kargs_CPPFLAGS = $(testbin_cppflags)
 tests_check_test_kargs_CFLAGS = $(testbin_cflags)
 tests_check_test_kargs_LDADD = $(testbin_ldadd) libtest.la
 
+tests_check_test_sysusers_CPPFLAGS = $(testbin_cppflags)
+tests_check_test_sysusers_CFLAGS = $(testbin_cflags)
+tests_check_test_sysusers_LDADD = $(testbin_ldadd) libtest.la
+
 uninstalled_test_programs = \
 	tests/check/jsonutil			\
 	tests/check/postprocess			\
 	tests/check/test-utils			\
 	tests/check/test-kargs 			\
+        tests/check/test-sysusers               \
 	$(NULL)
 
 uninstalled_test_scripts = \

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1259,15 +1259,27 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
   if (self->treefile)
     {
       g_autoptr(GFile) treefile_dirpath = g_file_get_parent (self->treefile_path);
+      g_autoptr(GHashTable) sysusers_table = NULL;
       if (!rpmostree_check_passwd (self->repo, self->rootfs_dfd, treefile_dirpath, self->treefile,
-                                   self->previous_checksum,
+                                   self->previous_checksum, &sysusers_table,
                                    cancellable, error))
         return glnx_prefix_error (error, "Handling passwd db");
 
       if (!rpmostree_check_groups (self->repo, self->rootfs_dfd, treefile_dirpath, self->treefile,
-                                   self->previous_checksum,
+                                   self->previous_checksum, &sysusers_table,
                                    cancellable, error))
         return glnx_prefix_error (error, "Handling group db");
+      if (sysusers_table)
+        {
+          /* Do conversion and write files here */
+          g_autofree gchar* sysuser_content = NULL;
+          if (!rpmostree_passwd_sysusers2char (sysusers_table,
+                                               &sysuser_content, error))
+            return glnx_prefix_error (error, "Handling sysusers conversion");
+          /* Write to the sysusers directory */
+          ;
+          /* May be delete the /usr/lib/passwd generated? */
+        }
     }
 
   /* See comment above */

--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -384,6 +384,7 @@ rpmostree_check_passwd_groups (gboolean         passwd,
                                GFile           *treefile_dirpath,
                                JsonObject      *treedata,
                                const char      *previous_commit,
+                               GHashTable     **out_hashtable,
                                GCancellable    *cancellable,
                                GError         **error)
 {
@@ -411,7 +412,7 @@ rpmostree_check_passwd_groups (gboolean         passwd,
         return TRUE; /* Note early return */
       else if (g_str_equal (chk_type, "previous"))
         ; /* Handled below */
-      else if (g_str_equal (chk_type, "file"))
+      else if (g_str_equal (chk_type, "file") || g_str_equal (chk_type, "sysusers"))
         {
           direct = _rpmostree_jsonutil_object_require_string_member (chk,
                                                                      "filename",
@@ -516,7 +517,7 @@ rpmostree_check_passwd_groups (gboolean         passwd,
           return TRUE;
         }
     }
-  else if (g_str_equal (chk_type, "file"))
+  else if (g_str_equal (chk_type, "file") || g_str_equal (chk_type, "sysusers"))
     {
       old_path = g_file_resolve_relative_path (treefile_dirpath, direct);
       old_contents = glnx_file_get_contents_utf8_at (AT_FDCWD, gs_file_get_path_cached (old_path), NULL,
@@ -525,7 +526,7 @@ rpmostree_check_passwd_groups (gboolean         passwd,
         return FALSE;
     }
 
-  if (g_str_equal (chk_type, "previous") || g_str_equal (chk_type, "file"))
+  if (g_str_equal (chk_type, "previous") || g_str_equal (chk_type, "file") || g_str_equal (chk_type, "sysusers"))
     {
       if (passwd)
         old_ents = rpmostree_passwd_data2passwdents (old_contents);
@@ -723,11 +724,12 @@ rpmostree_check_passwd (OstreeRepo      *repo,
                         GFile           *treefile_dirpath,
                         JsonObject      *treedata,
                         const char      *previous_commit,
+                        GHashTable     **out_hashtable,
                         GCancellable    *cancellable,
                         GError         **error)
 {
   return rpmostree_check_passwd_groups (TRUE, repo, rootfs_fd, treefile_dirpath,
-                                        treedata, previous_commit,
+                                        treedata, previous_commit, out_hashtable,
                                         cancellable, error);
 }
 
@@ -740,11 +742,12 @@ rpmostree_check_groups (OstreeRepo      *repo,
                         GFile           *treefile_dirpath,
                         JsonObject      *treedata,
                         const char      *previous_commit,
+                        GHashTable     **out_hashtable,
                         GCancellable    *cancellable,
                         GError         **error)
 {
   return rpmostree_check_passwd_groups (TRUE, repo, rootfs_fd, treefile_dirpath,
-                                        treedata, previous_commit,
+                                        treedata, previous_commit, out_hashtable,
                                         cancellable, error);
 }
 

--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -136,6 +136,8 @@ conv_passwd_ent_free (void *vptr)
   struct conv_passwd_ent *ptr = vptr;
 
   g_free (ptr->name);
+  g_free (ptr->pw_gecos);
+  g_free (ptr->pw_dir);
   g_free (ptr);
 }
 
@@ -157,7 +159,8 @@ rpmostree_passwd_data2passwdents (const char *data)
       convent->uid  = ent->pw_uid;
       convent->gid  = ent->pw_gid;
       /* Want to add anymore, like dir? */
-
+      convent->pw_gecos = g_strdup(ent->pw_gecos);
+      convent->pw_dir = g_strdup(ent->pw_dir);
       g_ptr_array_add (ret, convent);
     }
 

--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -292,7 +292,7 @@ rpmostree_groupents2sysusers (GPtrArray  *group_ents,
 
       if (!sysent)
         sysent = g_new (struct sysuser_ent, 1);
-      else 
+      else
         {
           /* For now the simplest thing would be to check if uid:gid is set for "u" */
           if (g_str_equal (sysent->type, "u"))
@@ -300,11 +300,10 @@ rpmostree_groupents2sysusers (GPtrArray  *group_ents,
               g_autofree char *current_gid = g_strdup_printf ("%u", convent->gid);
               if (g_str_equal (sysent->id, current_gid))
                 {
-                  g_print("yes, let's also skip\n");
                   continue;
                 }
               char *colon = strchr (sysent->id, ':');
-              if (colon) 
+              if (colon)
                 {
                   char *stored_gid = colon + 1;
                   g_print ("current_gid is %s\n", current_gid);
@@ -312,7 +311,6 @@ rpmostree_groupents2sysusers (GPtrArray  *group_ents,
                   /* We skip the insertion if we found gid matches */
                   if (g_str_equal (stored_gid, current_gid))
                   {
-                    g_print("continued\n");
                     continue;
                   }
                   else
@@ -323,7 +321,6 @@ rpmostree_groupents2sysusers (GPtrArray  *group_ents,
                 }
 
             }
-          g_print("test\n");
         }
       sysent->id = g_strdup_printf ("%u", convent->gid);
       sysent->type = g_strdup("g");
@@ -339,6 +336,27 @@ rpmostree_groupents2sysusers (GPtrArray  *group_ents,
   if (*out_sysusers_table == NULL)
     *out_sysusers_table = g_steal_pointer (&sysusers_table);
 
+  return TRUE;
+}
+
+gboolean
+rpmostree_passwd_sysusers2char (GHashTable *sysusers_table,
+                                char      **out_content,
+                                GError    **error)
+{
+  /* Sinc ethe collision is handled during insertion, we just need to
+   * do the conversion directly */
+  GString* sysuser_content = g_string_new (NULL);
+  GLNX_HASH_TABLE_FOREACH_KV (sysusers_table, const char*,  key, struct sysuser_ent*, sysuser_ent)
+    {
+      g_autofree gchar* line_content = g_strjoin(" ", sysuser_ent->type,
+                                                 sysuser_ent->name, sysuser_ent->id,
+                                                 sysuser_ent->gecos, sysuser_ent->dir,
+                                                 NULL);
+      g_string_append_printf(sysuser_content, "%s\n", line_content);
+    }
+
+  *out_content = g_string_free(sysuser_content, FALSE);
   return TRUE;
 }
 

--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -216,6 +216,42 @@ compare_group_ents (gconstpointer a, gconstpointer b)
   return strcmp ((*sa)->name, (*sb)->name);
 }
 
+gboolean
+rpmostree_passwdents2sysusers (GPtrArray  *passwd_ents,
+                               GHashTable *sysusers_table,
+                               GError     **error)
+{
+
+  for (int counter=0; counter < passwd_ents->len; counter++)
+    {
+      struct conv_passwd_ent *convent = passwd_ents->pdata[counter]
+
+      struct sysuser_ent *sysent = g_hash_table_lookup (sysusers_table, convent->name)
+      // handles collision in a different commit, for now let's keep things simpler
+      if (!sysent)
+        sysent = g_new (struct sysuser_ent, 1)
+      
+      // Note, sysuser support uid:gid format when uid is not equal
+      // to gid, and that allows sysusers to add both group and user entries
+      if (convent->uid != convent->gid)
+        sysent->id = g_strdup_printf ("%zu:%zu", convent->uid, convent->gid);
+      else
+        sysent->id = g_strdup_printf ("%zu", convent->uid)
+      
+      sysent->type = g_strdup ('u');
+      sysent->name =  g_strdup (convent->name);
+      // Apparently those two fields were not used other places,
+      // let's steal the poitner 
+      sysent->gecos = g_steal_pointer (&convent->pw_gecos);
+      sysent->dir = g_steal_pointer (&convent->pw_dir);
+      
+      // Not sure if we need the sysent name for now...
+      // so, suggestions are welcome =) 
+      char *name = g_strdup (sysent->name);
+      g_hash_table_insert (sysusers_table, name, sysent)  
+    }
+  
+}
 /* See "man 5 passwd" We just make sure the name and uid/gid match,
    and that none are missing. don't care about GECOS/dir/shell.
 */

--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -229,6 +229,20 @@ compare_group_ents (gconstpointer a, gconstpointer b)
 }
 
 gboolean
+rpmostree_passwd_ents2sysusers (gboolean is_passwd,
+                                GPtrArray  *input_ents,
+                                GHashTable **out_sysusers_table,
+                                GError     **error)
+{
+  gboolean ret;
+  if (is_passwd)
+    ret = rpmostree_passwdents2sysusers (input_ents, out_sysusers_table, error);
+  else
+    ret = rpmostree_groupents2sysusers (input_ents, out_sysusers_table, error);
+  return ret;
+}
+
+gboolean
 rpmostree_passwdents2sysusers (GPtrArray  *passwd_ents,
                                GHashTable **out_sysusers_table,
                                GError     **error)
@@ -692,6 +706,11 @@ rpmostree_check_passwd_groups (gboolean         passwd,
         }
     }
 
+  /* Now, at the end of checking, if all goes correctly, we put entries into
+   * hashtable for sysusers */
+  if (g_str_equal (chk_type, "sysusers") &&
+      !rpmostree_passwd_ents2sysusers (passwd, new_ents, out_hashtable, error))
+    return FALSE;
   return TRUE;
 }
 

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -89,6 +89,14 @@ gboolean
 rpmostree_passwd_complete_rpm_layering (int       rootfs_dfd,
                                         GError  **error);
 
+struct sysuser_ent {
+  char *type;       /* type of sysuser entry, can be 1: u (user) 2: g (group) 3: m (mixed) 4: r (ranged ids) */
+  char *name;
+  char *id;         /* id in sysuser entry, can be in the form of 1: uid 2:gid 3: uid:gid */
+  char *gecos;      /* user information */
+  char *dir;        /* home directory */
+} 
+
 struct conv_passwd_ent {
   char *name;
   uid_t uid;

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -92,7 +92,7 @@ rpmostree_passwd_complete_rpm_layering (int       rootfs_dfd,
 struct sysuser_ent {
   char *type;       /* type of sysuser entry, can be 1: u (user) 2: g (group) 3: m (mixed) 4: r (ranged ids) */
   char *name;
-  char *id;         /* id in sysuser entry, can be in the form of 1: uid 2:gid 3: uid:gid */
+  char *id;         /* id in sysuser entry, can be in the form of 1: uid 2:gid 3: uid:gid, or we can separate this into uid_t and gid_t*/
   char *gecos;      /* user information */
   char *dir;        /* home directory */
 };

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -129,3 +129,9 @@ gboolean
 rpmostree_passwd_sysusers2char (GHashTable *sysusers_table,
                                 char      **out_content,
                                 GError    **error);
+
+gboolean
+rpmostree_passwd_ents2sysusers (gboolean is_passwd,
+                                GPtrArray  *input_ents,
+                                GHashTable **out_sysusers_table,
+                                GError     **error);

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -120,3 +120,7 @@ gboolean
 rpmostree_passwdents2sysusers (GPtrArray *passwd_ents,
                                GHashTable **out_sysusers_table,
                                GError **error);
+gboolean
+rpmostree_groupents2sysusers (GPtrArray *passwd_ents,
+                              GHashTable **out_sysusers_table,
+                              GError **error);

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -30,6 +30,7 @@ rpmostree_check_passwd (OstreeRepo      *repo,
                         GFile           *treefile_path,
                         JsonObject      *treedata,
                         const char      *previous_commit,
+                        GHashTable     **out_hashtable,
                         GCancellable    *cancellable,
                         GError         **error);
 
@@ -39,6 +40,7 @@ rpmostree_check_groups (OstreeRepo      *repo,
                         GFile           *treefile_path,
                         JsonObject      *treedata,
                         const char      *previous_commit,
+                        GHashTable     **out_hashtable,
                         GCancellable    *cancellable,
                         GError         **error);
 

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -124,3 +124,8 @@ gboolean
 rpmostree_groupents2sysusers (GPtrArray *passwd_ents,
                               GHashTable **out_sysusers_table,
                               GError **error);
+
+gboolean
+rpmostree_passwd_sysusers2char (GHashTable *sysusers_table,
+                                char      **out_content,
+                                GError    **error);

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -95,7 +95,7 @@ struct sysuser_ent {
   char *id;         /* id in sysuser entry, can be in the form of 1: uid 2:gid 3: uid:gid */
   char *gecos;      /* user information */
   char *dir;        /* home directory */
-} 
+};
 
 struct conv_passwd_ent {
   char *name;
@@ -115,3 +115,8 @@ rpmostree_passwd_data2passwdents (const char *data);
 
 GPtrArray *
 rpmostree_passwd_data2groupents (const char *data);
+
+gboolean
+rpmostree_passwdents2sysusers (GPtrArray *passwd_ents,
+                               GHashTable **out_sysusers_table,
+                               GError **error);

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -93,6 +93,8 @@ struct conv_passwd_ent {
   char *name;
   uid_t uid;
   gid_t gid;
+  char *pw_gecos;   /* user information */
+  char *pw_dir;     /* home directory */
 };
 
 struct conv_group_ent {

--- a/tests/check/test-sysusers.c
+++ b/tests/check/test-sysusers.c
@@ -15,7 +15,7 @@ static const gchar *test_passwd[] = {
 static const gchar *expected_sysuser_passwd_content[] ={
   "u chrony 994:992 - /var/lib/chrony",
   "u tcpdump 72 - /",
-  "u systemd-timesync 993:991 'systemd Time Synchronization' /",
+  "u systemd-timesync 993:991 \"systemd Time Synchronization\" /",
   "u cockpit-ws 988:987 'User for cockpit-ws' /",
   NULL
 };
@@ -133,7 +133,17 @@ test_sysuser_entry_collision(void)
   g_assert_cmpuint (5, ==, g_hash_table_size (sysusers_table));
 }
 
+static void
+test_sysusers_conversion(void)
+{
+  g_autoptr(GHashTable) sysusers_table = NULL;
+  g_autoptr(GError) error = NULL;
 
+  setup_passwd_sysusers (&sysusers_table, &error);
+  g_autofree gchar* converted_content = NULL;
+  rpmostree_passwd_sysusers2char (sysusers_table, &converted_content, &error);
+  g_print ("%s\n", converted_content);
+}
 int
 main (int argc,
       char *argv[])
@@ -142,8 +152,8 @@ main (int argc,
 
   g_test_add_func ("/sysusers/passwd_conversion", test_passwd_conversion);
   g_test_add_func ("/sysusers/group_conversion", test_group_conversion);
-  g_usleep (10000);
   g_test_add_func ("/sysusers/collision_check", test_sysuser_entry_collision);
+  g_test_add_func ("/sysusers/conversion_test", test_sysusers_conversion);
   return g_test_run ();
 }
 

--- a/tests/check/test-sysusers.c
+++ b/tests/check/test-sysusers.c
@@ -1,0 +1,20 @@
+#include "config.h"
+#include "libglnx.h"
+#include "sysusers.h"
+
+
+static const gchar *test_passwd[] = {
+  "chrony:x:994:992::/var/lib/chrony:/sbin/nologin",
+  "tcpdump:x:72:72::/:/sbin/nologin",
+  "systemd-timesync:x:993:991:systemd Time Synchronization:/:/sbin/nologin",
+  "cockpit-ws:x:988:987:User for cockpit-ws:/:/sbin/nologin"
+}
+
+static void
+test_passwd_conversion(void)
+{
+  g_autoptr(GPtrArray) passwd_ents = rpmostree_passwd_data2passwdents (test_passwd)
+  g_auto
+  if (!rpmostree_passwdents2sysusers(passwd_ents, 
+}
+

--- a/tests/check/test-sysusers.c
+++ b/tests/check/test-sysusers.c
@@ -1,20 +1,81 @@
 #include "config.h"
 #include "libglnx.h"
-#include "sysusers.h"
-
+#include "rpmostree-util.h"
+#include "rpmostree-json-parsing.h"
+#include "rpmostree-passwd-util.h"
 
 static const gchar *test_passwd[] = {
   "chrony:x:994:992::/var/lib/chrony:/sbin/nologin",
   "tcpdump:x:72:72::/:/sbin/nologin",
   "systemd-timesync:x:993:991:systemd Time Synchronization:/:/sbin/nologin",
-  "cockpit-ws:x:988:987:User for cockpit-ws:/:/sbin/nologin"
+  "cockpit-ws:x:988:987:User for cockpit-ws:/:/sbin/nologin",
+  NULL
+};
+
+static const gchar *expected_sysuser_passwd_content[] ={
+  "u chrony 994:992 - /var/lib/chrony",
+  "u tcpdump 72 - /",
+  "u systemd-timesync 993:991 'systemd Time Synchronization' /",
+  "u cockpit-ws 988:987 'User for cockpit-ws' /",
+  NULL
+};
+
+/* Create a variant for mapping name --> sysuser string content */
+static GVariantDict
+get_sysuser_content_variant (const char **content)
+{
+  GVariantDict dict;
+  g_variant_dict_init (&dict, NULL);
+  for (char **iter = (char **)content; iter && *iter; iter++)
+  {
+    const char *sysuser_ent_content = *iter;
+    g_auto(GStrv) entry_list = g_strsplit(sysuser_ent_content, " ", -1);
+    char *sysuser_name = entry_list[1];
+    g_variant_dict_insert(&dict, sysuser_name, "^as", entry_list);
+  }
+
+  return dict;
 }
 
 static void
 test_passwd_conversion(void)
 {
-  g_autoptr(GPtrArray) passwd_ents = rpmostree_passwd_data2passwdents (test_passwd)
-  g_auto
-  if (!rpmostree_passwdents2sysusers(passwd_ents, 
+  gboolean ret;
+  g_autoptr(GHashTable) sysusers_table = NULL;
+  g_autoptr(GError) error = NULL;
+
+  /* Check validity of the sysusers conversion */
+  g_autofree char* test_content = g_strjoinv ("\n", (char **)test_passwd);
+  g_autoptr(GPtrArray) passwd_ents = rpmostree_passwd_data2passwdents (test_content);
+  ret = rpmostree_passwdents2sysusers (passwd_ents, &sysusers_table, &error);
+  g_assert (ret);
+  g_assert_no_error (error);
+
+  /* Check Hashtable properties */
+  g_assert (sysusers_table);
+  g_assert_cmpuint (4, ==, g_hash_table_size (sysusers_table));
+
+  /* Check Hashtable content */
+  g_auto(GVariantDict) sysuser_dict =  get_sysuser_content_variant (expected_sysuser_passwd_content);
+  GLNX_HASH_TABLE_FOREACH_KV (sysusers_table, const char*,  key, struct sysuser_ent*, sysuser_ent)
+    {
+      g_assert (g_str_equal (key, sysuser_ent->name));
+      g_autofree const char *const * sysent_list = NULL;
+      g_variant_dict_lookup (&sysuser_dict, key, "^a&s", &sysent_list);
+      g_assert (g_str_equal (sysuser_ent->type, (char **)sysent_list[0]));
+      g_assert (g_str_equal (sysuser_ent->name, (char **)sysent_list[1]));
+      g_assert (g_str_equal (sysuser_ent->id, (char **)sysent_list[2]));\
+    }
+
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/sysusers/passwd_conversion", test_passwd_conversion);
+  return g_test_run ();
 }
 


### PR DESCRIPTION
Hi, this PR includes the early version of implementation for #49.  There are still many parts can be added/improved, but I would like to put this PR out to have some feedback/discussion to make sure I am on the right track :p.

Things did so far in this PR, also [see discussion](https://github.com/projectatomic/rpm-ostree/issues/49#issuecomment-376197202)
- Convert passwd entries into sysuser struct 
- Convert group entries into sysuser struct 
- Collect sysuser struct information and put them into hashtable
- Added initial logic for conversion into compose and `rpmostree_check_passwd_groups`

Things still left undone:
- Test the integration and usability of sysusers with compose
- Refactor duplicated code, corner cases, and integration test
- Add logic of removing /usr/lib/passwd and nss-altfiles?, when sysusers option is specified. 

**PS:** sorry for this PR to be taking so long... I had really bad time management for past few months, and I was kinda hesitant to have a discussion back then :(. But hopefully, I will do better at those in the future =).
