### PR TITLE
tests/vmcheck: Fix expected prefix

### DIFF
--- a/src/libpriv/rpmostree-rojig-assembler.c
+++ b/src/libpriv/rpmostree-rojig-assembler.c
@@ -172,7 +172,7 @@ peel_entry_pathname (struct archive_entry *entry,
                      GError    **error)
 {
   const char *pathname = archive_entry_pathname (entry);
-  static const char prefix[] = "./usr/lib/ostree-jigdo/";
+  static const char prefix[] = "./usr/lib/ostree-rojig/";
   if (!g_str_has_prefix (pathname, prefix))
     return glnx_null_throw (error, "Entry does not have prefix '%s': %s", prefix, pathname);
   pathname += strlen (prefix);

--- a/tests/vmcheck/test-rojig-client.sh
+++ b/tests/vmcheck/test-rojig-client.sh
@@ -24,6 +24,12 @@ set -euo pipefail
 
 set -x
 
+osid=$(vm_cmd grep -E '^ID=' /etc/os-release)
+if test "${osid}" != 'ID=fedora'; then
+    echo "ok skip on OS ID=${osid}"
+    exit 0
+fi
+
 # Test rebasing to https://pagure.io/fedora-atomic-host-continuous
 # in rojig:// mode.
 


### PR DESCRIPTION
The directory in which we output the rojig tree was changed in FAHC to
`/usr/lib/ostree-rojig`:

https://pagure.io/fedora-atomic/c/49e75c1bf6af8be48df47d5eda598e5b34915d5c

Change the code accordingly to keep tests happy.