### PR TITLE
daemon: Don't use absolute path for gdbus-codegen

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -4,7 +4,7 @@ dbus_built_sources = rpm-ostreed-generated.h rpm-ostreed-generated.c
 # https://github.com/projectatomic/rpm-ostree/pull/705
 rpm-ostreed-generated.h: rpm-ostreed-generated.c
 rpm-ostreed-generated.c: Makefile $(top_srcdir)/src/daemon/org.projectatomic.rpmostree1.xml
-	$(AM_V_GEN) /usr/bin/gdbus-codegen \
+	$(AM_V_GEN) gdbus-codegen \
 		--interface-prefix org.projectatomic.rpmostree1 \
 		--c-namespace RPMOSTree \
 		--c-generate-object-manager \


### PR DESCRIPTION
This breaks builds on platforms that don't have `gdbus-codegen`
installed at that path.  This reverts #1153, which was needed at the
time, but things appear to be fixed now.