### PR TITLE
rust: Fix automake warnings, add unit tests to glibutils

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -75,11 +75,15 @@ else
 CARGO_RELEASE_ARGS=--release
 endif
 
-check-local:
+.PHONY: check-local-cargo
+check-local-cargo:
 	cd $(srcdir)/rust && CARGO_TARGET_DIR=$(abs_top_builddir)/target cargo test
+check-local: check-local-cargo
 
-clean-local:
+.PHONY: clean-local-cargo
+clean-local-cargo:
 	cd $(srcdir)/rust && CARGO_TARGET_DIR=$(abs_top_builddir)/target cargo clean
+clean-local: clean-local-cargo
 
 dist-hook:
 	(cd $(distdir)/rust && \

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,7 @@ serde_yaml = "0.7"
 libc = "0.2"
 glib-sys = "0.6.0"
 gio-sys = "0.6.0"
+glib = "0.5.0"
 
 [lib]
 name = "treefile_rs"

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -22,6 +22,7 @@
 
 extern crate gio_sys;
 extern crate glib_sys;
+extern crate glib;
 extern crate libc;
 
 #[macro_use]

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -21,8 +21,8 @@
  * */
 
 extern crate gio_sys;
-extern crate glib_sys;
 extern crate glib;
+extern crate glib_sys;
 extern crate libc;
 
 #[macro_use]


### PR DESCRIPTION
Automake was warning about duplicate `clean-local` definitions, let's
do the nonrecursive automake dance.

And while I'm here, let's add some Rust unit tests that actually run
on `make check` too, since the whole unit testing bits of Rust are
awesome.

(I also tweaked the propagate bits to use the nicer `is_null()` method)
