### PR TITLE
packaging: Support vendoring the Rust sources

### DIFF
--- a/Makefile-decls.am
+++ b/Makefile-decls.am
@@ -57,3 +57,12 @@ install-data-hook: $(INSTALL_DATA_HOOKS)
 
 ALL_LOCAL_HOOKS =
 all-local: $(ALL_LOCAL_HOOKS)
+
+CHECK_LOCAL_HOOKS =
+check-local: $(CHECK_LOCAL_HOOKS)
+
+CLEAN_LOCAL_HOOKS =
+clean-local: $(CLEAN_LOCAL_HOOKS)
+
+DIST_HOOKS =
+dist-hook: $(DIST_HOOKS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,7 +67,10 @@ include $(INTROSPECTION_MAKEFILE)
 GIRS =
 TYPELIBS = $(GIRS:.gir=.typelib)
 
-# These bits based on gnome:librsvg/Makefile.am
+# These bits were originally based on gnome:librsvg/Makefile.am
+# but have been adapted to non-recursive Automake, and additionally
+# the "cargo vendor" bits for us live in packaging/Makefile.dist-packaging.
+.PHONY: check-local-cargo clean-local-cargo use-git-not-dist-hook
 if ENABLE_RUST
 if RUST_DEBUG
 CARGO_RELEASE_ARGS=
@@ -75,19 +78,21 @@ else
 CARGO_RELEASE_ARGS=--release
 endif
 
-.PHONY: check-local-cargo
 check-local-cargo:
 	cd $(srcdir)/rust && CARGO_TARGET_DIR=$(abs_top_builddir)/target cargo test
-check-local: check-local-cargo
+CHECK_LOCAL_HOOKS += check-local-cargo
 
-.PHONY: clean-local-cargo
 clean-local-cargo:
 	cd $(srcdir)/rust && CARGO_TARGET_DIR=$(abs_top_builddir)/target cargo clean
-clean-local: clean-local-cargo
+CLEAN_LOCAL_HOOKS += clean-local-cargo
 
-dist-hook:
-  echo 'rpm-ostree does not support "make dist"; see packaging/Makefile.dist-packaging' 1>2
-  exit 1
+use-git-not-dist-hook:
+	@echo
+	@echo 'ERROR: rpm-ostree does not use/support "make dist"; see packaging/Makefile.dist-packaging' 1>&2
+	@echo
+	@exit 1
+
+DIST_HOOKS += use-git-not-dist-hook
 
 endif # end ENABLE_RUST
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -86,13 +86,9 @@ clean-local-cargo:
 clean-local: clean-local-cargo
 
 dist-hook:
-	(cd $(distdir)/rust && \
-   cp $(abs_top_srcdir)/rust/Cargo.lock . && \
-   cargo vendor -q && \
-   mkdir .cargo && \
-	 cp cargo-vendor-config .cargo/config)
+  echo 'rpm-ostree does not support "make dist"; see packaging/Makefile.dist-packaging' 1>2
+  exit 1
 
-EXTRA_DIST += $(srcdir)/rust/Cargo.toml $(srcdir)/rust/cargo-vendor-config
 endif # end ENABLE_RUST
 
 include libglnx/Makefile-libglnx.am.inc

--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -8,7 +8,7 @@ GITREV=$1
 shift
 
 TARFILE=${PKG_VER}.tar
-TARFILE_TMP=${TARFILE}.tmp
+TARFILE_TMP=$(pwd)/${TARFILE}.tmp
 
 set -x
 set -e
@@ -29,4 +29,15 @@ ls -al ${TARFILE_TMP}
     tar -A -f ${TARFILE_TMP} submodule.tar
     rm submodule.tar
 done
+tmpd=$(mktemp -d)
+touch ${tmpd}/.tmp
+rm -f rust.tar
+(cd ${tmpd}
+ mkdir -p .cargo vendor
+ cargo vendor -q --sync ${TOP}/rust/Cargo.toml vendor
+ cp ${TOP}/rust/Cargo.lock .
+ cp ${TOP}/rust/cargo-vendor-config .cargo/config
+ tar --transform='s,^,rust/,' -vrf ${TARFILE_TMP} .
+ )
+test -f "${tmpd}/.tmp" && rm -rf "${tmpd}"
 mv ${TARFILE_TMP} ${TARFILE}

--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -29,15 +29,22 @@ ls -al ${TARFILE_TMP}
     tar -A -f ${TARFILE_TMP} submodule.tar
     rm submodule.tar
 done
-tmpd=$(mktemp -d)
-touch ${tmpd}/.tmp
-rm -f rust.tar
+tmpd=${TOP}/.dist-tmp
+trap cleanup EXIT
+function cleanup () {
+    if test -f ${tmpd}/.tmp; then
+        rm "${tmpd}" -rf
+    fi
+}
+# Run it now
+cleanup
+mkdir ${tmpd} && touch ${tmpd}/.tmp
+
 (cd ${tmpd}
  mkdir -p .cargo vendor
  cargo vendor -q --sync ${TOP}/rust/Cargo.toml vendor
  cp ${TOP}/rust/Cargo.lock .
  cp ${TOP}/rust/cargo-vendor-config .cargo/config
- tar --transform='s,^,rust/,' -vrf ${TARFILE_TMP} .
+ tar --transform="s,^,${PKG_VER}/rust/," -rf ${TARFILE_TMP} *
  )
-test -f "${tmpd}/.tmp" && rm -rf "${tmpd}"
 mv ${TARFILE_TMP} ${TARFILE}

--- a/rust/src/glibutils.rs
+++ b/rust/src/glibutils.rs
@@ -21,7 +21,6 @@
  * */
 
 use gio_sys;
-use glib;
 use glib_sys;
 use libc;
 use std;
@@ -64,6 +63,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use glib;
     use std::error::Error;
     use std::{io, ptr};
 


### PR DESCRIPTION
This ends up being different than what landed in librsvg (that
was imported into ostree) because in rpm-ostree we've basically
been using `git archive`-based tarball generation rather than `make dist`
for a long time.  And supporting `make dist` looks like it'd get into
handling the `libdnf` bits and walking into `cmake` land so...yeah
let's not do that.

The canonical sources are in git (recursively via submodule),
except for the Rust sources, which cargo can download dynamically,
and with this patch we support glomming all of that together
into a tarball.

(And turn off `make dist` so people understand how we do it)

Tested by `make -f Makefile.dist-packaging dist-snapshot`, then
copying the resulting tarball into a container with `--net=none`
and building there.
