### PR TITLE
packaging: Fix Rust vendoring

### DIFF
--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -45,6 +45,6 @@ mkdir ${tmpd} && touch ${tmpd}/.tmp
  cargo vendor -q --sync ${TOP}/rust/Cargo.toml vendor
  cp ${TOP}/rust/Cargo.lock .
  cp ${TOP}/rust/cargo-vendor-config .cargo/config
- tar --transform="s,^,${PKG_VER}/rust/," -rf ${TARFILE_TMP} *
+ tar --transform="s,^,${PKG_VER}/rust/," -rf ${TARFILE_TMP} * .cargo/
  )
 mv ${TARFILE_TMP} ${TARFILE}


### PR DESCRIPTION
I made a subtle change at the last minute with the previous PR
to use `*` for the glob instead of `.`, because the tmpdir had a `.tmp`
file I didn't want.

But - this caused us to miss the `.cargo` directory which has
the config file.  And while I'd been testing builds with no network,
of course cargo was really pulling content from `~/.cargo`.

When I went to do a scratch build in Koji, that failed obviously.
I tested this makes things [work with a SRPM scratch](https://koji.fedoraproject.org/koji/taskinfo?taskID=27490830)
and in my dev container under `bwrap --unshare-net` with `mv ~/.cargo{,.orig}`.
