### PR TITLE
upgrader: Add missing values to flags GType

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1306,7 +1306,16 @@ rpmostree_sysroot_upgrader_flags_get_type (void)
           "allow-older" },
         { RPMOSTREE_SYSROOT_UPGRADER_FLAGS_DRY_RUN,
           "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_DRY_RUN",
-          "dry-run" }
+          "dry-run" },
+        { RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGCACHE_ONLY,
+          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGCACHE_ONLY",
+          "pkgcache-only" },
+        { RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL,
+          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_SYNTHETIC_PULL",
+          "synthetic-pull" },
+        { RPMOSTREE_SYSROOT_UPGRADER_FLAGS_STAGE,
+          "RPMOSTREE_SYSROOT_UPGRADER_FLAGS_STAGE",
+          "stage" },
       };
       GType g_define_type_id =
         g_flags_register_static (g_intern_static_string ("RpmOstreeSysrootUpgraderFlags"), values);

--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -48,6 +48,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC (RpmOstreeSysrootUpgrader, g_object_unref)
  * Flags controlling operation of an #RpmOstreeSysrootUpgrader.
  */
 typedef enum {
+  /* NB: When changing here, also change rpmostree_sysroot_upgrader_flags_get_type(). */
   RPMOSTREE_SYSROOT_UPGRADER_FLAGS_NONE                 = (1 << 0),
   RPMOSTREE_SYSROOT_UPGRADER_FLAGS_IGNORE_UNCONFIGURED  = (1 << 1),
   RPMOSTREE_SYSROOT_UPGRADER_FLAGS_ALLOW_OLDER          = (1 << 2),


### PR DESCRIPTION
We were missing a bunch of flags as part of the property GType. I was
getting a warning that's become fatal because we set
`G_DEBUG=fatal-warnings` for `make vmsync`, which is how I was testing
this:

```
rpm-ostree[1813]: value "((RpmOstreeSysrootUpgraderFlags) 48)" of type 'RpmOstreeSysrootUpgraderFlags' is invalid or out of range for property 'flags' of type 'RpmOstreeSysrootUpgraderFlags'
kernel: traps: pool[1816] trap int3 ip:7f47f4b4b6d5 sp:7f47e989d1f0 error:0 in libglib-2.0.so.0.5600.1[7f47f4af9000+115000]
```

I'm not quite sure why this is happening now though, since I use
`make vmsync` a lot. My guess would be something to do with how we
changed flag passing in d568e54d from "all of them" to "only those we
need", but I didn't verify that.