### PR TITLE
libpriv/origin: Allow removing local RPMs by name only

### DIFF
--- a/tests/vmcheck/test-layering-local.sh
+++ b/tests/vmcheck/test-layering-local.sh
@@ -40,6 +40,15 @@ vm_has_local_packages foo-1.2-3.x86_64
 vm_assert_layered_pkg foo-1.2-3.x86_64 present
 echo "ok pkg foo added locally"
 
+# check we could uninstall the package using either its NEVRA or name
+vm_rpmostree uninstall foo-1.2-3.x86_64
+vm_assert_status_jq '.deployments[0]["requested-local-packages"]|length == 0'
+vm_rpmostree cleanup -p
+vm_rpmostree uninstall foo
+vm_assert_status_jq '.deployments[0]["requested-local-packages"]|length == 0'
+vm_rpmostree cleanup -p
+echo "ok uninstall by NEVRA or name"
+
 # check that we can still request foo and it's dormant
 vm_rpmostree install foo
 


### PR DESCRIPTION
This fixes a painful UX issue where one must use the full NEVRA when
uninstalling a locally layered RPM. Now, one can specify either the
NEVRA or the package name only. Though we still try to interpret the
request first as a NEVRA or a capability.

Closes: #1386