### PR TITLE
Rebase to latest libdnf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://gitlab.gnome.org/GNOME/libglnx.git
 [submodule "libdnf"]
 	path = libdnf
-	url = https://github.com/projectatomic/libdnf
+	url = https://github.com/rpm-software-management/libdnf

--- a/Makefile-libdnf.am
+++ b/Makefile-libdnf.am
@@ -21,14 +21,14 @@
 ALL_LOCAL_HOOKS += libdnf-local
 libdnf-local:
 	cd libdnf-build && $(MAKE) $(if $(subst 0,,$(V)),VERBOSE=1,)
-	ln -sf libdnf-build/libdnf/libdnf.so.1 .
-libdnf.so.1: libdnf-local
-CLEANFILES += libdnf.so.1
+	ln -sf libdnf-build/libdnf/libdnf.so.2 .
+libdnf.so.2: libdnf-local
+CLEANFILES += libdnf.so.2
 GITIGNOREFILES += libdnf-build/
 
 install-libdnf-hook:
 	install -d -m 0755 $(DESTDIR)$(libdir)/rpm-ostree
-	install -m 0755 $$(readlink libdnf.so.1) $(DESTDIR)$(libdir)/rpm-ostree
+	install -m 0755 $$(readlink libdnf.so.2) $(DESTDIR)$(libdir)/rpm-ostree
 INSTALL_DATA_HOOKS += install-libdnf-hook
 
 clean-local: clean-local-dnf

--- a/Makefile-libpriv.am
+++ b/Makefile-libpriv.am
@@ -85,7 +85,7 @@ librpmostreepriv_la_LIBADD = \
 	$(NULL)
 
 # bundled libdnf
-EXTRA_librpmostreepriv_la_DEPENDENCIES = libdnf.so.1
+EXTRA_librpmostreepriv_la_DEPENDENCIES = libdnf.so.2
 
 gperf_gperf_sources = src/libpriv/rpmostree-script-gperf.gperf
 BUILT_SOURCES += $(gperf_gperf_sources:-gperf.gperf=-gperf.c)

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,9 +34,7 @@ endif
 RPM_OSTREE_GITREV=$(shell if command -v git >/dev/null 2>&1 && test -e $(srcdir)/.git; then git describe --abbrev=42 --tags --always HEAD; fi)
 
 ACLOCAL_AMFLAGS += -I m4 ${ACLOCAL_FLAGS}
-# WITH_SWDB is a hackaround for it being used in libdnf headers
 AM_CPPFLAGS += -DDATADIR='"$(datadir)"' \
-	-DWITH_SWDB=0 \
 	-DLIBEXECDIR='"$(libexecdir)"' \
 	-DLOCALEDIR=\"$(datadir)/locale\" \
 	-DSYSCONFDIR='"$(sysconfdir)"' \

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -22,6 +22,9 @@ fi
 pkg_upgrade
 pkg_install_if_os centos epel-release
 pkg_install_builddeps rpm-ostree
+# XXX: new libdnf deps until next release
+pkg_install json-c-devel cppunit{,-devel} swig sqlite-devel \
+    libmodulemd1-devel libsmartcols-devel gpgme-devel
 # Mostly dependencies for tests
 pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML \
     libubsan libasan libtsan elfutils fuse sudo python-gobject-base \

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -425,10 +425,11 @@ rpmostree_context_new_system (OstreeRepo   *repo,
   dnf_context_set_solv_dir (self->dnfctx, RPMOSTREE_CORE_CACHEDIR RPMOSTREE_DIR_CACHE_SOLV);
   dnf_context_set_lock_dir (self->dnfctx, "/run/rpm-ostree/" RPMOSTREE_DIR_LOCK);
   dnf_context_set_user_agent (self->dnfctx, PACKAGE_NAME "/" PACKAGE_VERSION);
+  /* don't need SWDB: https://github.com/rpm-software-management/libdnf/issues/645 */
+  dnf_context_set_write_history (self->dnfctx, FALSE);
 
   dnf_context_set_check_disk_space (self->dnfctx, FALSE);
   dnf_context_set_check_transaction (self->dnfctx, FALSE);
-  dnf_context_set_yumdb_enabled (self->dnfctx, FALSE);
 
   return self;
 }

--- a/src/libpriv/rpmostree-rojig-client.c
+++ b/src/libpriv/rpmostree-rojig-client.c
@@ -34,8 +34,7 @@
 #include "rpmostree-rpm-util.h"
 #include "rpmostree-output.h"
 // For the rojig Requires parsing
-#include <libdnf/dnf-reldep-private.hpp>
-#include <libdnf/dnf-sack-private.hpp>
+#include <libdnf/dnf-reldep-list.h>
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -1170,7 +1170,7 @@ rpmostree_get_matching_packages (DnfSack *sack,
   HySubject subject = NULL;
 
   subject = hy_subject_create (pattern);
-  selector = hy_subject_get_best_selector (subject, sack, false);
+  selector = hy_subject_get_best_selector (subject, sack, NULL, FALSE, NULL);
   matches = hy_selector_matches (selector);
 
   hy_selector_free (selector);

--- a/tests/vmcheck/install.sh
+++ b/tests/vmcheck/install.sh
@@ -18,7 +18,9 @@ ostree --version
 # We don't want to sync all of userspace, just things
 # that rpm-ostree links to or uses and tend to drift
 # in important ways.
-pkgs="libsolv"
+# XXX: We add libmodulemd manually for now until it's
+# part of the image.
+pkgs="libsolv libmodulemd1"
 if rpm -q zchunk-libs 2>/dev/null; then
     pkgs="${pkgs} zchunk-libs"
 fi


### PR DESCRIPTION
This brings us back in sync with the latest libdnf git master. This
required a bunch of work both on the libdnf and rpm-ostree side to get
working. See e.g.
rpm-software-management/libdnf#645.

A few things to adapt to:

- soname bump to `libdnf.so.2`
- `DnfAdvisory` is no longer a `GObject` (annoyingly it's not replaced
  by something we can keep a ref on, so this requires some hacks to
  steal from the `GPtrArray` -- could enhance libdnf for this later)
- disable SWDB history writing
- use new reldep public API
- update for latest `hy_subject_get_best_selector()` API

This now unlocks the possibility to add support for modules. (One can
see hints of this in the diff by the fact that `libdnf` links to
`libmodulemd1`.)

Update submodule: libdnf