### PR TITLE
Custom origin

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -22,18 +22,10 @@ cluster:
   hosts:
     - name: vmcheck1
       distro: fedora/28/atomic
-      # XXX: use updates ref for now so that we can use GA kernel in
-      # test-override-kernel.sh -- remove once another f28 AH update comes out
-      ostree:
-        branch: fedora/28/x86_64/updates/atomic-host
     - name: vmcheck2
       distro: fedora/28/atomic
-      ostree:
-        branch: fedora/28/x86_64/updates/atomic-host
     - name: vmcheck3
       distro: fedora/28/atomic
-      ostree:
-        branch: fedora/28/x86_64/updates/atomic-host
   container:
     image: registry.fedoraproject.org/fedora:28
 
@@ -71,6 +63,8 @@ cluster:
     - name: vmcheck1
       distro: centos/7/atomic/smoketested
       # XXX: temp hack until smoketested has newer glib2
+      # XXX: and also causes layering-relabel to fail?
+      # https://github.com/projectatomic/rpm-ostree/pull/1406
       ostree:
         branch: centos-atomic-host/7/x86_64/devel/continuous
     - name: vmcheck2

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -144,9 +144,11 @@ rpmostree_builtin_rebase (int             argc,
   g_variant_dict_insert (&dict, "skip-purge", "b", opt_skip_purge);
   if (opt_custom_origin_url)
     {
+      if (!opt_custom_origin_description)
+        return glnx_throw (error, "--custom-origin-description must be supplied with --custom-origin-url");
       g_variant_dict_insert (&dict, "custom-origin", "(ss)",
                              opt_custom_origin_url,
-                             opt_custom_origin_description ?: "");
+                             opt_custom_origin_description);
     }
   g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -36,6 +36,8 @@ static gboolean opt_reboot;
 static gboolean opt_skip_purge;
 static char * opt_branch;
 static char * opt_remote;
+static char * opt_custom_origin_url;
+static char * opt_custom_origin_description;
 static gboolean opt_cache_only;
 static gboolean opt_download_only;
 static gboolean opt_experimental;
@@ -48,6 +50,8 @@ static GOptionEntry option_entries[] = {
   { "skip-purge", 0, 0, G_OPTION_ARG_NONE, &opt_skip_purge, "Keep previous refspec after rebase", NULL },
   { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Do not download latest ostree and RPM data", NULL },
   { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only, "Just download latest ostree and RPM data, don't deploy", NULL },
+  { "custom-origin-description", 0, 0, G_OPTION_ARG_STRING, &opt_custom_origin_description, "Human-readable description of custom origin", NULL },
+  { "custom-origin-url", 0, 0, G_OPTION_ARG_STRING, &opt_custom_origin_url, "Machine-readable description of custom origin", NULL },
   { "experimental", 0, 0, G_OPTION_ARG_NONE, &opt_experimental, "Enable experimental features", NULL },
   { NULL }
 };
@@ -138,6 +142,12 @@ rpmostree_builtin_rebase (int             argc,
   g_variant_dict_insert (&dict, "cache-only", "b", opt_cache_only);
   g_variant_dict_insert (&dict, "download-only", "b", opt_download_only);
   g_variant_dict_insert (&dict, "skip-purge", "b", opt_skip_purge);
+  if (opt_custom_origin_url)
+    {
+      g_variant_dict_insert (&dict, "custom-origin", "(ss)",
+                             opt_custom_origin_url,
+                             opt_custom_origin_description ?: "");
+    }
   g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
   /* Use newer D-Bus API only if we have to. */

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -480,6 +480,8 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
   g_print ("%s ", is_booted ? libsd_special_glyph (BLACK_CIRCLE) : " ");
 
   RpmOstreeRefspecType refspectype = RPMOSTREE_REFSPEC_TYPE_OSTREE;
+  const char *custom_origin_url = NULL;
+  const char *custom_origin_description = NULL;
   if (origin_refspec)
     {
       const char *refspec_data;
@@ -489,6 +491,21 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
       switch (refspectype)
         {
         case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
+          {
+            g_variant_dict_lookup (dict, "custom-origin", "(&s&s)",
+                                   &custom_origin_url,
+                                   &custom_origin_description);
+            /* Canonicalize the empty string to NULL */
+            if (custom_origin_url && !*custom_origin_url)
+              custom_origin_url = NULL;
+            if (custom_origin_description && !*custom_origin_description)
+              custom_origin_description = NULL;
+            if (custom_origin_url)
+              g_print ("%s", custom_origin_url);
+            else
+              g_print ("%s", canonrefspec);
+          }
+          break;
         case RPMOSTREE_REFSPEC_TYPE_OSTREE:
           {
             g_print ("%s", canonrefspec);
@@ -525,6 +542,9 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
   else
     g_print ("%s", checksum);
   g_print ("\n");
+
+  if (custom_origin_description)
+    rpmostree_print_kv ("CustomOrigin", max_key_len, custom_origin_description);
 
   const char *remote_not_found = NULL;
   g_variant_dict_lookup (dict, "remote-error", "s", &remote_not_found);

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -498,10 +498,11 @@ print_one_deployment (RPMOSTreeSysroot *sysroot_proxy,
             /* Canonicalize the empty string to NULL */
             if (custom_origin_url && !*custom_origin_url)
               custom_origin_url = NULL;
-            if (custom_origin_description && !*custom_origin_description)
-              custom_origin_description = NULL;
             if (custom_origin_url)
-              g_print ("%s", custom_origin_url);
+              {
+                g_assert (custom_origin_description && *custom_origin_description);
+                g_print ("%s", custom_origin_url);
+              }
             else
               g_print ("%s", canonrefspec);
           }

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -291,6 +291,7 @@
          "override-reset-packages" (type 'as')
          "override-replace-packages" (type 'as')
          "override-replace-local-packages" (type 'ah')
+         "custom-origin" (type '(ss)')
 
          Available options:
          "reboot" (type 'b')

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -304,7 +304,16 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
   switch (refspec_type)
     {
     case RPMOSTREE_REFSPEC_TYPE_CHECKSUM:
-      /* Nothing to do here */
+      {
+        g_autofree char *custom_origin_url = NULL;
+        g_autofree char *custom_origin_description = NULL;
+        rpmostree_origin_get_custom_description (origin, &custom_origin_url,
+                                                 &custom_origin_description);
+        if (custom_origin_url)
+          g_variant_dict_insert (&dict, "custom-origin", "(ss)",
+                                 custom_origin_url,
+                                 custom_origin_description ?: "");
+      }
       break;
     case RPMOSTREE_REFSPEC_TYPE_OSTREE:
       {

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -312,7 +312,7 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
         if (custom_origin_url)
           g_variant_dict_insert (&dict, "custom-origin", "(ss)",
                                  custom_origin_url,
-                                 custom_origin_description ?: "");
+                                 custom_origin_description);
       }
       break;
     case RPMOSTREE_REFSPEC_TYPE_OSTREE:

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1330,9 +1330,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
           g_autofree char *custom_origin_description = NULL;
           rpmostree_origin_get_custom_description (origin, &custom_origin_url,
                                                    &custom_origin_description);
-          const char *custom_origin = custom_origin_description ?: custom_origin_url;
-          if (custom_origin)
-            rpmostree_output_message ("Pinned to commit by custom origin: %s", custom_origin);
+          if (custom_origin_description)
+            rpmostree_output_message ("Pinned to commit by custom origin: %s", custom_origin_description);
           else
             rpmostree_output_message ("Pinned to commit; no upgrade available");
         }

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -113,6 +113,12 @@ change_origin_refspec (GVariantDict    *options,
       g_variant_dict_lookup (options, "custom-origin", "(&s&s)",
                              &custom_origin_url,
                              &custom_origin_description);
+      if (custom_origin_url && *custom_origin_url)
+        {
+          g_assert (custom_origin_description);
+          if (!*custom_origin_description)
+            return glnx_throw (error, "Invalid custom-origin");
+        }
       if (!rpmostree_origin_set_rebase_custom (origin, new_refspec,
                                                custom_origin_url,
                                                custom_origin_description,

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -42,7 +42,8 @@ vardict_lookup_bool (GVariantDict *dict,
                      gboolean      dfault);
 
 static gboolean
-change_origin_refspec (OstreeSysroot *sysroot,
+change_origin_refspec (GVariantDict    *options,
+                       OstreeSysroot *sysroot,
                        RpmOstreeOrigin *origin,
                        const gchar *src_refspec,
                        GCancellable *cancellable,
@@ -101,8 +102,28 @@ change_origin_refspec (OstreeSysroot *sysroot,
   if (strcmp (current_refspec, new_refspec) == 0)
     return glnx_throw (error, "Old and new refs are equal: %s", new_refspec);
 
-  if (!rpmostree_origin_set_rebase (origin, new_refspec, error))
+  /* Re-classify after canonicalization to ensure we handle TYPE_CHECKSUM */
+  if (!rpmostree_refspec_classify (new_refspec, &refspectype, &refspecdata, error))
     return FALSE;
+
+  if (refspectype == RPMOSTREE_REFSPEC_TYPE_CHECKSUM)
+    {
+      const char *custom_origin_url = NULL;
+      const char *custom_origin_description = NULL;
+      g_variant_dict_lookup (options, "custom-origin", "(&s&s)",
+                             &custom_origin_url,
+                             &custom_origin_description);
+      if (!rpmostree_origin_set_rebase_custom (origin, new_refspec,
+                                               custom_origin_url,
+                                               custom_origin_description,
+                                               error))
+        return FALSE;
+    }
+  else
+    {
+      if (!rpmostree_origin_set_rebase (origin, new_refspec, error))
+        return FALSE;
+    }
 
   g_autofree gchar *current_remote = NULL;
   g_autofree gchar *current_branch = NULL;
@@ -305,7 +326,7 @@ package_diff_transaction_execute (RpmostreedTransaction *transaction,
 
   if (self->refspec != NULL)
     {
-      if (!change_origin_refspec (sysroot, origin, self->refspec,
+      if (!change_origin_refspec (NULL, sysroot, origin, self->refspec,
                                   cancellable, NULL, NULL, error))
         return FALSE;
     }
@@ -828,7 +849,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
   g_autofree gchar *old_refspec = NULL;
   if (self->refspec)
     {
-      if (!change_origin_refspec (sysroot, origin, self->refspec, cancellable,
+      if (!change_origin_refspec (self->options, sysroot, origin, self->refspec, cancellable,
                                   &old_refspec, &new_refspec, error))
         return FALSE;
     }
@@ -1304,7 +1325,16 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
     {
       if (refspec_type == RPMOSTREE_REFSPEC_TYPE_CHECKSUM
           && layering_type < RPMOSTREE_SYSROOT_UPGRADER_LAYERING_RPMMD_REPOS)
-        rpmostree_output_message ("Pinned to commit; no upgrade available");
+        {
+          g_autofree char *custom_origin_url = NULL;
+          g_autofree char *custom_origin_description = NULL;
+          rpmostree_origin_get_custom_description (origin, &custom_origin_url,
+                                                   &custom_origin_description);
+          if (custom_origin_url)
+            rpmostree_output_message ("Pinned to commit by custom origin: %s", custom_origin_description);
+          else
+            rpmostree_output_message ("Pinned to commit; no upgrade available");
+        }
       else if (is_upgrade)
         rpmostree_output_message ("No upgrade available.");
       else

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1330,8 +1330,9 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
           g_autofree char *custom_origin_description = NULL;
           rpmostree_origin_get_custom_description (origin, &custom_origin_url,
                                                    &custom_origin_description);
-          if (custom_origin_url)
-            rpmostree_output_message ("Pinned to commit by custom origin: %s", custom_origin_description);
+          const char *custom_origin = custom_origin_description ?: custom_origin_url;
+          if (custom_origin)
+            rpmostree_output_message ("Pinned to commit by custom origin: %s", custom_origin);
           else
             rpmostree_output_message ("Pinned to commit; no upgrade available");
         }

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -496,9 +496,10 @@ rpmostree_origin_set_rebase_custom (RpmOstreeOrigin *origin,
 {
   /* Require non-empty strings */
   if (custom_origin_url)
-    g_return_val_if_fail (*custom_origin_url, FALSE);
-  if (custom_origin_description)
-    g_return_val_if_fail (*custom_origin_description, FALSE);
+    {
+      g_return_val_if_fail (*custom_origin_url, FALSE);
+      g_return_val_if_fail (custom_origin_description && *custom_origin_description, FALSE);
+    }
 
    /* We don't want to carry any commit overrides or version pinning during a
    * rebase by default.

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -75,6 +75,11 @@ rpmostree_origin_get_rojig_version (RpmOstreeOrigin *origin);
 GVariant *
 rpmostree_origin_get_rojig_description (RpmOstreeOrigin *origin);
 
+void
+rpmostree_origin_get_custom_description (RpmOstreeOrigin *origin,
+                                         char           **custom_type,
+                                         char           **custom_description);
+
 GHashTable *
 rpmostree_origin_get_packages (RpmOstreeOrigin *origin);
 
@@ -136,6 +141,12 @@ gboolean
 rpmostree_origin_set_rebase (RpmOstreeOrigin *origin,
                              const char      *new_refspec,
                              GError         **error);
+gboolean
+rpmostree_origin_set_rebase_custom (RpmOstreeOrigin *origin,
+                                    const char      *new_refspec,
+                                    const char      *custom_origin_url,
+                                    const char      *custom_origin_description,
+                                    GError         **error);
 
 gboolean
 rpmostree_origin_add_packages (RpmOstreeOrigin   *origin,

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -29,7 +29,7 @@ set -x
 # Custom origin https://github.com/projectatomic/rpm-ostree/pull/1406
 booted_csum=$(vm_get_booted_csum)
 oscontainer_source="oscontainer://quay.io/exampleos@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
-vm_rpmostree rebase --custom-origin-description "'Updated via pivot'" \
+vm_rpmostree rebase --skip-purge --custom-origin-description "'Updated via pivot'" \
              --custom-origin-url "${oscontainer_source}" \
              :${booted_csum}
 vm_rpmostree status > status.txt

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -26,6 +26,19 @@ set -x
 
 # More miscellaneous tests
 
+# Custom origin https://github.com/projectatomic/rpm-ostree/pull/1406
+booted_csum=$(vm_get_booted_csum)
+oscontainer_source="oscontainer://quay.io/exampleos@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+vm_rpmostree rebase --custom-origin-description "'Updated via pivot'" \
+             --custom-origin-url "${oscontainer_source}" \
+             :${booted_csum}
+vm_rpmostree status > status.txt
+assert_file_has_content_literal status.txt 'CustomOrigin: Updated via pivot'
+assert_file_has_content_literal status.txt "${oscontainer_source}"
+vm_rpmostree upgrade >out.txt
+assert_file_has_content_literal out.txt 'Pinned to commit by custom origin: Updated via pivot'
+vm_rpmostree cleanup -p
+
 # Add metadata string containing EnfOfLife attribtue
 META_ENDOFLIFE_MESSAGE="this is a test for metadata message"
 commit=$(vm_cmd ostree commit -b vmcheck \

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -29,6 +29,11 @@ set -x
 # Custom origin https://github.com/projectatomic/rpm-ostree/pull/1406
 booted_csum=$(vm_get_booted_csum)
 oscontainer_source="oscontainer://quay.io/exampleos@sha256:98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4"
+if vm_rpmostree rebase --skip-purge --custom-origin-url "${oscontainer_source}" \
+                :${booted_csum} 2>err.txt; then
+    fatal "rebased without description"
+fi
+assert_file_has_content_literal err.txt '--custom-origin-description must be supplied'
 vm_rpmostree rebase --skip-purge --custom-origin-description "'Updated via pivot'" \
              --custom-origin-url "${oscontainer_source}" \
              :${booted_csum}


### PR DESCRIPTION
Example:

```
[root@localhost ~]# rpm-ostree cleanup -pr; rpm-ostree rebase --custom-origin-type pivot://image@sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03 :94a9d06eef34aa6774c056356d3d2e024e57a0013b6f8048dbae392a84a137ca --custom-origin-description "Updated by pivot tool"; rpm-ostree status
Transaction complete; bootconfig swap: yes; deployment count change: -1
Copying /etc changes: 20 modified, 0 removed, 58 added
Transaction complete; bootconfig swap: yes; deployment count change: 1
Run "systemctl reboot" to start a reboot
State: idle; auto updates disabled
Deployments:
  pivot://image@sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
              CustomOrigin: Updated by pivot tool
                   Version: 28.20180425.0 (2018-04-25 19:14:57)

● ostree://fedora-atomic:fedora/28/x86_64/atomic-host
                   Version: 28.20180425.0 (2018-04-25 19:14:57)
                    Commit: 94a9d06eef34aa6774c056356d3d2e024e57a0013b6f8048dbae392a84a137ca
              GPGSignature: Valid signature by 128CF232A9371991C8A65695E08E7E629DB62FB1
                  Unlocked: development
```

But still TODO is to change:

```
[root@localhost ~]# rpm-ostree upgrade
Pinned to commit; no upgrade available
```

to something like:
```
[root@localhost ~]# rpm-ostree upgrade
Pinned to commit via custom origin: Updated by pivot tool
```
