### PR TITLE
app/dbus-helpers: Initialize reboot & dry run vars

### DIFF
--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -852,9 +852,9 @@ rpmostree_transaction_client_run (RpmOstreeCommandInvocation *invocation,
 
   g_auto(GVariantDict) optdict = G_VARIANT_DICT_INIT (options);
   /* Parse back the options variant */
-  gboolean opt_reboot;
+  gboolean opt_reboot = FALSE;
   g_variant_dict_lookup (&optdict, "reboot", "b", &opt_reboot);
-  gboolean opt_dry_run;
+  gboolean opt_dry_run = FALSE;
   g_variant_dict_lookup (&optdict, "dry-run", "b", &opt_dry_run);
 
   if (opt_dry_run)


### PR DESCRIPTION
Minor regression from #1382. Since we no longer always include all the
option keys, we actually need to initialize the default values now.

Closes: #1410