### PR TITLE
passwd-util: fix passwd to FALSE to allow checking groups

### DIFF
--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -577,7 +577,7 @@ rpmostree_check_groups (OstreeRepo      *repo,
                         GCancellable    *cancellable,
                         GError         **error)
 {
-  return rpmostree_check_passwd_groups (TRUE, repo, rootfs_fd, treefile_dirpath,
+  return rpmostree_check_passwd_groups (FALSE, repo, rootfs_fd, treefile_dirpath,
                                         treedata, previous_commit,
                                         cancellable, error);
 }


### PR DESCRIPTION
We are having exact same function call between rpmostree_check_groups
and rpmostree_check_passwd, which means we are ignoring all the logic
for group checking.

This commit changes the option `passwd` to FALSE in `rpmostree_check_groups` 
 to also check for groups during compose process.