### PR TITLE
status: Assert that we have deployments

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -926,6 +926,7 @@ rpmostree_builtin_status (int             argc,
     return FALSE;
 
   g_autoptr(GVariant) deployments = rpmostree_sysroot_dup_deployments (sysroot_proxy);
+  g_assert (deployments);
   g_autoptr(GVariant) cached_update = NULL;
   if (rpmostree_os_get_has_cached_update_rpm_diff (os_proxy))
     cached_update = rpmostree_os_dup_cached_update (os_proxy);


### PR DESCRIPTION
I think this is what's showing up in a PR test:
https://s3.amazonaws.com/aos-ci/ghprb/projectatomic/rpm-ostree/21b68a68ff79f6a399553f6132922b15f777b86a.2.1529072619059542132/artifacts/vmcheck/livefs.log
```
(rpm-ostree status:17017): Json-CRITICAL **: json_gvariant_serialize: assertion 'variant != NULL' failed
```

It shouldn't be happening; let's add an assertion which will give us a core
dump reliably instead of the "stumble on" `g_warning()` default.
