### PR TITLE
Clarify the use of --uninstall switch

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -128,8 +128,8 @@ static GOptionEntry daemon_entries[] = {
 };
 
 static GOptionEntry pkg_entries[] = {
-  { "install", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_install, "Install a package", "PKG" },
-  { "uninstall", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_uninstall, "Uninstall a layered package", "PKG" },
+  { "install", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_install, "Overlay additional package", "PKG" },
+  { "uninstall", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_uninstall, "Remove overlayed additional package", "PKG" },
   { NULL }
 };
 

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -129,7 +129,7 @@ static GOptionEntry daemon_entries[] = {
 
 static GOptionEntry pkg_entries[] = {
   { "install", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_install, "Install a package", "PKG" },
-  { "uninstall", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_uninstall, "Uninstall a package", "PKG" },
+  { "uninstall", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_uninstall, "Uninstall a layered package", "PKG" },
   { NULL }
 };
 

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -54,7 +54,7 @@ static GOptionEntry uninstall_option_entry[] = {
 };
 
 static GOptionEntry install_option_entry[] = {
-  { "uninstall", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_uninstall, "Uninstall a package", "PKG" },
+  { "uninstall", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_uninstall, "Uninstall a layered package", "PKG" },
   { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Do not download latest ostree and RPM data", NULL },
   { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only, "Just download latest ostree and RPM data, don't deploy", NULL },
   { NULL }

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -48,13 +48,13 @@ static GOptionEntry option_entries[] = {
 };
 
 static GOptionEntry uninstall_option_entry[] = {
-  { "install", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_install, "Install a package", "PKG" },
-  { "all", 0, 0, G_OPTION_ARG_NONE, &opt_uninstall_all, "Remove all layered packages", NULL },
+  { "install", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_install, "Overlay additional package", "PKG" },
+  { "all", 0, 0, G_OPTION_ARG_NONE, &opt_uninstall_all, "Remove all overlayed additional packages", NULL },
   { NULL }
 };
 
 static GOptionEntry install_option_entry[] = {
-  { "uninstall", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_uninstall, "Uninstall a layered package", "PKG" },
+  { "uninstall", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_uninstall, "Remove overlayed additional package", "PKG" },
   { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Do not download latest ostree and RPM data", NULL },
   { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only, "Just download latest ostree and RPM data, don't deploy", NULL },
   { NULL }


### PR DESCRIPTION
While looking at the inline help for `install`, I thought we could do
better by specifically stating that the `--uninstall` switch only
operates on layered packages.  This might prevent any users from
trying to use the `--uninstall` switch on a package that is part of
the base deployment.