### PR TITLE
daemon/deploy: Allow layering with no-layering option

### DIFF
--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -211,13 +211,6 @@ rpmostree_builtin_uninstall (int            argc,
       return FALSE;
     }
 
-  if (opt_install && opt_uninstall_all)
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
-                   "Cannot specify both --install and --all");
-      return FALSE;
-    }
-
   /* shift to first pkgspec and ensure it's a proper strv (previous parsing
    * might have moved args around) */
   argv++; argc--;

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -788,12 +788,6 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
       upgrader_flags |= RPMOSTREE_SYSROOT_UPGRADER_FLAGS_PKGCACHE_ONLY;
     }
 
-  /* these should have been checked already */
-  if (no_layering)
-    {
-      g_assert (self->install_pkgs == NULL);
-      g_assert (self->install_local_pkgs == NULL);
-    }
   if (no_overrides)
     {
       g_assert (self->override_replace_pkgs == NULL);
@@ -1544,9 +1538,6 @@ rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
        self->override_replace_pkgs || override_replace_local_pkgs_idxs))
     return glnx_null_throw (error, "Can't specify no-overrides if setting "
                                    "override modifiers");
-  if (vardict_lookup_bool (self->options, "no-layering", FALSE) &&
-      (self->install_pkgs || self->install_local_pkgs))
-    return glnx_null_throw (error, "Can't specify no-layering if also layering packages");
 
   return (RpmostreedTransaction *) g_steal_pointer (&self);
 }

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -447,6 +447,8 @@ rollback_transaction_execute (RpmostreedTransaction *transaction,
   OstreeSysroot *sysroot = rpmostreed_transaction_get_sysroot (transaction);
   OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);
 
+  rpmostree_transaction_set_title ((RPMOSTreeTransaction*)self, "rollback");
+
   g_autoptr(OstreeDeployment) pending_deployment = NULL;
   g_autoptr(OstreeDeployment) rollback_deployment = NULL;
   ostree_sysroot_query_deployments_for (sysroot, self->osname,
@@ -1574,12 +1576,14 @@ initramfs_state_transaction_finalize (GObject *object)
 
 static gboolean
 initramfs_state_transaction_execute (RpmostreedTransaction *transaction,
-                            GCancellable *cancellable,
-                            GError **error)
+                                     GCancellable *cancellable,
+                                     GError **error)
 {
 
   InitramfsStateTransaction *self = (InitramfsStateTransaction *) transaction;
   OstreeSysroot *sysroot = rpmostreed_transaction_get_sysroot (transaction);
+
+  rpmostree_transaction_set_title ((RPMOSTreeTransaction*)self, "initramfs");
 
   g_autoptr(RpmOstreeSysrootUpgrader) upgrader =
     rpmostree_sysroot_upgrader_new (sysroot, self->osname, 0,
@@ -1735,6 +1739,8 @@ cleanup_transaction_execute (RpmostreedTransaction *transaction,
   CleanupTransaction *self = (CleanupTransaction *) transaction;
   const gboolean cleanup_pending = (self->flags & RPMOSTREE_TRANSACTION_CLEANUP_PENDING_DEPLOY) > 0;
   const gboolean cleanup_rollback = (self->flags & RPMOSTREE_TRANSACTION_CLEANUP_ROLLBACK_DEPLOY) > 0;
+
+  rpmostree_transaction_set_title ((RPMOSTreeTransaction*)self, "cleanup");
 
   OstreeSysroot *sysroot = rpmostreed_transaction_get_sysroot (transaction);
   g_autoptr(OstreeRepo) repo = NULL;
@@ -1984,6 +1990,8 @@ kernel_arg_transaction_execute (RpmostreedTransaction *transaction,
 {
   KernelArgTransaction *self = (KernelArgTransaction *) transaction;
   OstreeSysroot *sysroot = rpmostreed_transaction_get_sysroot (transaction);
+
+  rpmostree_transaction_set_title ((RPMOSTreeTransaction*)self, "kargs");
 
   /* Read in the existing kernel args and convert those to an #OstreeKernelArg instance for API usage */
   __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *kargs = _ostree_kernel_args_from_string (self->existing_kernel_args);

--- a/tests/vmcheck/test-layering-basic-2.sh
+++ b/tests/vmcheck/test-layering-basic-2.sh
@@ -104,6 +104,7 @@ vm_rpmostree uninstall --all |& tee out.txt
 assert_file_has_content out.txt "No change."
 vm_build_rpm test-uninstall-all-pkg1
 vm_build_rpm test-uninstall-all-pkg2
+vm_build_rpm test-uninstall-all-pkg3
 # do one from repo and one local for funsies
 vm_rpmostree install test-uninstall-all-pkg1 \
   /tmp/vmcheck/yumrepo/packages/x86_64/test-uninstall-all-pkg2-1.0-1.x86_64.rpm
@@ -119,3 +120,17 @@ vm_assert_status_jq \
   '.deployments[0]["requested-local-packages"]|length == 0'
 vm_rpmostree cleanup -p
 echo "ok uninstall --all"
+
+vm_rpmostree install test-uninstall-all-pkg1
+vm_assert_status_jq \
+  '.deployments[0]["packages"]|length == 1' \
+  '.deployments[0]["packages"]|index("test-uninstall-all-pkg1") >= 0' \
+  '.deployments[0]["requested-packages"]|length == 1' \
+  '.deployments[0]["requested-local-packages"]|length == 0'
+vm_rpmostree uninstall --all --install test-uninstall-all-pkg3
+vm_assert_status_jq \
+  '.deployments[0]["packages"]|length == 1' \
+  '.deployments[0]["packages"]|index("test-uninstall-all-pkg3") >= 0' \
+  '.deployments[0]["requested-packages"]|length == 1' \
+  '.deployments[0]["requested-local-packages"]|length == 0'
+echo "ok uninstall --all --install <pkg>"


### PR DESCRIPTION
We added the `no-layering` option, but made it conflicting with
`--install`. This loosens that requirement so that one can do e.g.

    rpm-ostree uninstall --all -install foobar

to essentially remove all layered packages and then add back `foobar`.
Prep for `reset` command.