### PR TITLE
postprocess: Stop creating /etc/machine-id

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -198,6 +198,15 @@ It supports the following parameters:
    to be writable. For host system composes, we recommend turning this on;
    it's left off by default to ease the transition.
 
+ * `machineid-compat`: boolean, optional: Defaults to `true`.  By default,
+   rpm-ostree creates `/usr/etc/machine-id` as an empty file for historical
+   reasons.  Set this to `false` to ensure it's not present at all.  This
+   will cause systemd to execute `ConditionFirstBoot=`, which implies
+   running `systemctl preset-all` for example.  If you enable this, avoid
+   using the `units` member, as it will no longer function.  Instead,
+   create a `/usr/lib/systemd/system-presets/XX-example.preset` file.
+
+
 Experimental options
 --------
 

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -122,6 +122,11 @@ pub struct CheckPasswd {
     // entries: Option<Map<>String>,
 }
 
+// https://github.com/serde-rs/serde/issues/368
+fn serde_true() -> bool {
+    true
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TreeComposeConfig {
     // Compose controls
@@ -164,6 +169,9 @@ pub struct TreeComposeConfig {
     pub units: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_target: Option<String>,
+    #[serde(default = "serde_true")]
+    #[serde(rename = "machineid-compat")]
+    pub machineid_compat: bool,
 
     // versioning
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -34,6 +34,10 @@ ostree --repo=${repobuild} ls -R ${treeref} /usr/share/man > manpages.txt
 assert_file_has_content manpages.txt man5/ostree.repo.5
 echo "ok manpages"
 
+# https://github.com/projectatomic/rpm-ostree/pull/1425
+ostree --repo=${repobuild} ls ${treeref} /usr/etc/machine-id
+echo "ok machine-id"
+
 ostree --repo=${repobuild} ls ${treeref} usr/etc/systemd/system/multi-user.target.wants/chronyd.service > preset.txt
 assert_file_has_content_literal preset.txt '-> /usr/lib/systemd/system/chronyd.service'
 echo "ok systemctl preset"

--- a/tests/compose-tests/test-misc-tweaks.sh
+++ b/tests/compose-tests/test-misc-tweaks.sh
@@ -10,6 +10,7 @@ prepare_compose_test "misc-tweaks"
 pysetjsonmember "documentation" "False"
 # And tweak some of the systemd units
 pysetjsonmember "default_target" '"multi-user.target"'
+pysetjsonmember "machineid-compat" 'false'
 pysetjsonmember "units" '["tuned.service"]'
 # And test adding/removing files
 pysetjsonmember "add-files" '[["foo.txt", "/usr/etc/foo.txt"],
@@ -19,6 +20,7 @@ pysetjsonmember "postprocess-script" \"$PWD/postprocess.sh\"
 cat > postprocess.sh << EOF
 #!/bin/bash
 set -xeuo pipefail
+test '!' -f /etc/machine-id
 echo misc-tweaks-postprocess-done > /usr/share/misc-tweaks-postprocess-done.txt
 cp -a /usr/etc/foo.txt /usr/share/misc-tweaks-foo.txt
 EOF
@@ -78,3 +80,8 @@ echo "ok remove-from-packages"
 ostree --repo=${repobuild} ls  ${treeref} /tmp > ls.txt
 assert_file_has_content ls.txt 'd01777 0 0      0 /tmp'
 echo "ok /tmp"
+
+# https://github.com/projectatomic/rpm-ostree/pull/1425
+ostree --repo=${repobuild} ls ${treeref} /usr/etc > ls.txt
+assert_not_file_has_content ls.txt 'machine-id'
+echo "ok machine-id"

--- a/tests/compose-tests/test-misc-tweaks.sh
+++ b/tests/compose-tests/test-misc-tweaks.sh
@@ -20,7 +20,6 @@ pysetjsonmember "postprocess-script" \"$PWD/postprocess.sh\"
 cat > postprocess.sh << EOF
 #!/bin/bash
 set -xeuo pipefail
-test '!' -f /etc/machine-id
 echo misc-tweaks-postprocess-done > /usr/share/misc-tweaks-postprocess-done.txt
 cp -a /usr/etc/foo.txt /usr/share/misc-tweaks-foo.txt
 EOF

--- a/tests/compose-tests/test-misc-tweaks.sh
+++ b/tests/compose-tests/test-misc-tweaks.sh
@@ -10,7 +10,7 @@ prepare_compose_test "misc-tweaks"
 pysetjsonmember "documentation" "False"
 # And tweak some of the systemd units
 pysetjsonmember "default_target" '"multi-user.target"'
-pysetjsonmember "machineid-compat" 'false'
+pysetjsonmember "machineid-compat" 'False'
 pysetjsonmember "units" '["tuned.service"]'
 # And test adding/removing files
 pysetjsonmember "add-files" '[["foo.txt", "/usr/etc/foo.txt"],


### PR DESCRIPTION
We actually want systemd's `ConditionFirstBoot` to fire.  The
primary rationale here is that we're adopting Ignition for Fedora CoreOS,
and having `ConditionFirstBoot=` function will help a lot, as the idea
is it only runs once.
