### PR TITLE
postprocess: Set default.target in /usr

### DIFF
--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1525,7 +1525,12 @@ rpmostree_treefile_postprocessing (int            rootfs_fd,
       g_autofree char *dest_default_target_path =
         g_strconcat ("/usr/lib/systemd/system/", default_target, NULL);
 
-      static const char default_target_path[] = "usr/etc/systemd/system/default.target";
+      /* This used to be in /etc, but doing it in /usr makes more sense, as it's
+       * part of the OS defaults. This was changed in particular to work with
+       * ConditionFirstBoot= which runs `systemctl preset-all`:
+       * https://github.com/projectatomic/rpm-ostree/pull/1425
+       */
+      static const char default_target_path[] = "usr/lib/systemd/system/default.target";
       (void) unlinkat (rootfs_fd, default_target_path, 0);
 
       if (symlinkat (dest_default_target_path, rootfs_fd, default_target_path) < 0)

--- a/tests/compose-tests/test-misc-tweaks.sh
+++ b/tests/compose-tests/test-misc-tweaks.sh
@@ -8,7 +8,11 @@ dn=$(cd $(dirname $0) && pwd)
 prepare_compose_test "misc-tweaks"
 # No docs
 pysetjsonmember "documentation" "False"
-# And tweak some of the systemd units
+# Note this overrides:
+# $ rpm -q systemd
+# systemd-238-8.git0e0aa59.fc28.x86_64
+# $ rpm -qlv systemd|grep -F 'system/default.target '
+# lrwxrwxrwx    1 root    root                       16 May 11 06:59 /usr/lib/systemd/system/default.target -> graphical.target
 pysetjsonmember "default_target" '"multi-user.target"'
 pysetjsonmember "machineid-compat" 'False'
 pysetjsonmember "units" '["tuned.service"]'
@@ -45,8 +49,8 @@ echo "ok no manpages"
 
 # Tests for units
 ostree --repo=${repobuild} ls ${treeref} \
-       /usr/etc/systemd/system/default.target > out.txt
-assert_file_has_content out.txt '-> .*/multi-user\.target'
+       /usr/lib/systemd/system/default.target > out.txt
+assert_file_has_content out.txt '-> .*multi-user\.target'
 echo "ok default target"
 
 ostree --repo=${repobuild} ls ${treeref} \


### PR DESCRIPTION
Follow-up improvement after
https://github.com/openshift/os/pull/135

This should ensure it survives systemd's preset run on firstboot.

Although honestly...what we should *really* do is check whether
the `default.target` symlink target exists, and if not reset it
to `multi-user.target` so no one would have to care, but that'd
be conceptually separate from this, so I may do it later.
