### PR TITLE
app: Lift kargs out of experimental

### DIFF
--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -512,6 +512,29 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
+        <term><command>kargs</command></term>
+
+        <listitem>
+          <para>
+            Without options, display current default kernel arguments. Modify
+            arguments using <option>--append</option>,
+            <option>--replace</option>, <option>--delete</option>, or
+            <option>--editor</option>. This will create a new deployment with
+            the modified kernel arguments. Previous deployments are never
+            changed.
+          </para>
+
+          <para>
+            By default, modifications are applied to the kernel arguments of the
+            default deployment to get the final arguments. Use
+            <option>--deploy-index</option> or
+            <option>--import-proc-cmdline</option> to instead base them off of a
+            specific deployment or the current boot.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><command>cleanup</command></term>
 
         <listitem>

--- a/src/app/main.c
+++ b/src/app/main.c
@@ -89,6 +89,9 @@ static RpmOstreeCommand commands[] = {
   { "refresh-md", 0,
     "Generate rpm repo metadata",
     rpmostree_builtin_refresh_md },
+  { "kargs", 0,
+    "Query or modify kernel arguments",
+    rpmostree_builtin_kargs },
   /* Legacy aliases */
   { "pkg-add", RPM_OSTREE_BUILTIN_FLAG_HIDDEN,
     NULL, rpmostree_builtin_install },

--- a/src/app/rpmostree-builtin-ex.c
+++ b/src/app/rpmostree-builtin-ex.c
@@ -28,12 +28,13 @@ static RpmOstreeCommand ex_subcommands[] = {
     rpmostree_ex_builtin_livefs },
   { "container", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "Assemble local unprivileged containers", rpmostree_builtin_container },
-  { "kargs", 0,
-    "Query or Modify the kernel arguments", rpmostree_ex_builtin_kargs },
   { "commit2rojig", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "Convert an OSTree commit into an rpm-ostree rojig", rpmostree_ex_builtin_commit2rojig },
   { "rojig2commit", RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD,
     "Convert an rpm-ostree rojig into an OSTree commit", rpmostree_ex_builtin_rojig2commit },
+  /* temporary aliases; nuke in next version */
+  { "kargs", RPM_OSTREE_BUILTIN_FLAG_HIDDEN,
+    NULL, rpmostree_builtin_kargs },
   { NULL, 0, NULL, NULL }
 };
 

--- a/src/app/rpmostree-builtin-kargs.c
+++ b/src/app/rpmostree-builtin-kargs.c
@@ -39,7 +39,7 @@ static char  *opt_deploy_index;
 
 static GOptionEntry option_entries[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operation on provided OSNAME", "OSNAME" },
-  { "deploy-index", 0, 0, G_OPTION_ARG_STRING, &opt_deploy_index, "Modify the kernel args from a specific deployment based on index. Index is in the form of a number (e.g 0 means the first deployment in the list)", "INDEX"},
+  { "deploy-index", 0, 0, G_OPTION_ARG_STRING, &opt_deploy_index, "Modify the kernel args from a specific deployment based on index. Index is in the form of a number (e.g. 0 means the first deployment in the list)", "INDEX"},
   { "reboot", 0, 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after operation is complete", NULL},
   { "append", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_kernel_append_strings, "Append kernel argument; useful with e.g. console= that can be used multiple times. empty value for an argument is allowed", "KEY=VALUE" },
   { "replace", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_kernel_replace_strings, "Replace existing kernel argument, the user is also able to replace an argument with KEY=VALUE if only one value exist for that argument ", "KEY=VALUE=NEWVALUE" },
@@ -169,11 +169,11 @@ kernel_arg_handle_editor (const char     *input_kernel_arg,
 
 
 gboolean
-rpmostree_ex_builtin_kargs (int            argc,
-                            char         **argv,
-                            RpmOstreeCommandInvocation *invocation,
-                            GCancellable  *cancellable,
-                            GError       **error)
+rpmostree_builtin_kargs (int            argc,
+                         char         **argv,
+                         RpmOstreeCommandInvocation *invocation,
+                         GCancellable  *cancellable,
+                         GError       **error)
 {
   _cleanup_peer_ GPid peer_pid = 0;
   glnx_unref_object RPMOSTreeSysroot *sysroot_proxy = NULL;
@@ -217,7 +217,7 @@ rpmostree_ex_builtin_kargs (int            argc,
   if (opt_import_proc_cmdline && opt_deploy_index)
     {
       g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_ARGUMENT,
-                   "Cannot specify both --import-from-proc-cmdline and --deployid");
+                   "Cannot specify both --import-from-proc-cmdline and --deploy-index");
       return FALSE;
     }
   if (opt_import_proc_cmdline && opt_osname)

--- a/src/app/rpmostree-builtins.h
+++ b/src/app/rpmostree-builtins.h
@@ -48,6 +48,7 @@ BUILTINPROTO(container);
 BUILTINPROTO(install);
 BUILTINPROTO(uninstall);
 BUILTINPROTO(override);
+BUILTINPROTO(kargs);
 BUILTINPROTO(start_daemon);
 BUILTINPROTO(ex);
 

--- a/src/app/rpmostree-ex-builtins.h
+++ b/src/app/rpmostree-ex-builtins.h
@@ -32,8 +32,6 @@ G_BEGIN_DECLS
 
 BUILTINPROTO(unpack);
 BUILTINPROTO(livefs);
-BUILTINPROTO(override);
-BUILTINPROTO(kargs);
 BUILTINPROTO(commit2rojig);
 BUILTINPROTO(rojig2commit);
 

--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -1139,7 +1139,7 @@ os_handle_get_deployment_boot_config (RPMOSTreeOS *interface,
     }
   else
     {
-      /* If the deploy_index is speicified, we ignore the pending option */
+      /* If the deploy_index is specified, we ignore the pending option */
       target_deployment = rpmostreed_deployment_get_for_index (ot_sysroot, arg_deploy_index,
                                                                &local_error);
       if (target_deployment == NULL)


### PR DESCRIPTION
It's been in experimental for a while now, and we've had good feedback
that it's working. With #1392 fixed, it seems in a good position to
declare stable and commit to that API. This also helps empty out `ex` a
bit.