### PR TITLE
app/dbus-helpers: Return early if no diff to print

### DIFF
--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -1342,6 +1342,9 @@ rpmostree_print_diff_advisories (GVariant         *rpm_diff,
                                  guint             max_key_len,
                                  GError          **error)
 {
+  if (!rpm_diff)
+    return TRUE; /* Nothing to 🖨️ */
+
   if (advisories)
     print_advisories (advisories, verbose || verbose_advisories, max_key_len);
 
@@ -1455,12 +1458,9 @@ rpmostree_print_cached_update (GVariant         *cached_update,
         rpmostree_print_gpg_info (signatures, verbose, max_key_len);
     }
 
-  if (rpm_diff)
-    {
-      if (!rpmostree_print_diff_advisories (rpm_diff, advisories, verbose,
-                                            verbose_advisories, max_key_len, error))
-        return FALSE;
-    }
+  if (!rpmostree_print_diff_advisories (rpm_diff, advisories, verbose,
+                                        verbose_advisories, max_key_len, error))
+    return FALSE;
 
   return TRUE;
 }


### PR DESCRIPTION
A new update might not have any package changes at all. In which case,
we shouldn't even try to print the diff, otherwise we'll fail on trying
to lookup the `upgraded` key. We did this check already from
`rpmostree_print_cached_update`, but not from `print_one_deployment`
(when printing the diff as part of the pending deployment), so we'd
error out on no-diff upgrades.

Let's just inline a check in the function directly instead of wrapping
every call site.