### PR TITLE
status: Rework auto-update status display

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -288,7 +288,7 @@ print_daemon_state (RPMOSTreeSysroot *sysroot_proxy,
   const char *policy = rpmostree_sysroot_get_automatic_update_policy (sysroot_proxy);
 
   g_print ("State: %s\n", txn_proxy ? "busy" : "idle");
-  g_print ("Automatic Updates: ");
+  g_print ("AutomaticUpdates: ");
   if (g_str_equal (policy, "none"))
     g_print ("disabled\n");
   else
@@ -314,12 +314,12 @@ print_daemon_state (RPMOSTreeSysroot *sysroot_proxy,
             {
             case AUTO_UPDATE_SDSTATE_TIMER_UNKNOWN:
               {
-                g_print ("unknown state: %s\n", RPMOSTREE_AUTOMATIC_TIMER_UNIT);
+                g_print ("%s: unknown state\n", RPMOSTREE_AUTOMATIC_TIMER_UNIT);
                 break;
               }
             case AUTO_UPDATE_SDSTATE_TIMER_INACTIVE:
               {
-                g_print ("%s inactive\n", RPMOSTREE_AUTOMATIC_TIMER_UNIT);
+                g_print ("%s: inactive\n", RPMOSTREE_AUTOMATIC_TIMER_UNIT);
                 break;
               }
             case AUTO_UPDATE_SDSTATE_SERVICE_FAILED:

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -39,6 +39,10 @@
 
 #include <libglnx.h>
 
+#define RPMOSTREE_AUTOMATIC_TIMER_UNIT \
+  "rpm-ostreed-automatic.timer"
+#define RPMOSTREE_AUTOMATIC_SERVICE_UNIT          \
+  "rpm-ostreed-automatic.service"
 #define RPMOSTREE_AUTOMATIC_TIMER_OBJPATH \
   "/org/freedesktop/systemd1/unit/rpm_2dostreed_2dautomatic_2etimer"
 #define RPMOSTREE_AUTOMATIC_SERVICE_OBJPATH \
@@ -283,20 +287,23 @@ print_daemon_state (RPMOSTreeSysroot *sysroot_proxy,
 
   const char *policy = rpmostree_sysroot_get_automatic_update_policy (sysroot_proxy);
 
-  g_print ("State: %s", txn_proxy ? "busy" : "idle");
+  g_print ("State: %s\n", txn_proxy ? "busy" : "idle");
+  g_print ("Automatic Updates: ");
   if (g_str_equal (policy, "none"))
-    g_print ("; auto updates disabled\n");
+    g_print ("disabled\n");
   else
     {
-      g_print ("; auto updates enabled ");
+      g_print ("%s", policy);
 
       /* don't try to get info from systemd if we're not on the system bus */
       if (bus_type != G_BUS_TYPE_SYSTEM)
-        g_print ("(%s)\n", policy);
+        g_print ("\n");
       else
         {
           AutoUpdateSdState state;
           g_autofree char *last_run = NULL;
+
+          g_print ("; ");
 
           GDBusConnection *connection =
             g_dbus_proxy_get_connection (G_DBUS_PROXY (sysroot_proxy));
@@ -307,33 +314,34 @@ print_daemon_state (RPMOSTreeSysroot *sysroot_proxy,
             {
             case AUTO_UPDATE_SDSTATE_TIMER_UNKNOWN:
               {
-                g_print ("(%s; unknown timer state)\n", policy);
+                g_print ("unknown state: %s\n", RPMOSTREE_AUTOMATIC_TIMER_UNIT);
                 break;
               }
             case AUTO_UPDATE_SDSTATE_TIMER_INACTIVE:
               {
-                g_print ("(%s; timer inactive)\n", policy);
+                g_print ("%s inactive\n", RPMOSTREE_AUTOMATIC_TIMER_UNIT);
                 break;
               }
             case AUTO_UPDATE_SDSTATE_SERVICE_FAILED:
               {
-                g_print ("(%s; %s%slast run failed%s%s)\n", policy,
+                g_print ("%s: %s%slast run failed%s%s\n",
+                         RPMOSTREE_AUTOMATIC_SERVICE_UNIT,
                          get_red_start (), get_bold_start (),
                          get_bold_end (), get_red_end ());
                 break;
               }
             case AUTO_UPDATE_SDSTATE_SERVICE_RUNNING:
               {
-                g_print ("(%s; running)\n", policy);
+                g_print ("%s: running\n", RPMOSTREE_AUTOMATIC_SERVICE_UNIT);
                 break;
               }
             case AUTO_UPDATE_SDSTATE_SERVICE_EXITED:
               {
                 if (last_run)
                   /* e.g. "last run 4h 32min ago" */
-                  g_print ("(%s; last run %s)\n", policy, last_run);
+                  g_print ("%s: last run %s\n", RPMOSTREE_AUTOMATIC_TIMER_UNIT, last_run);
                 else
-                  g_print ("(%s; no runs since boot)\n", policy);
+                  g_print ("%s: no runs since boot\n", RPMOSTREE_AUTOMATIC_TIMER_UNIT);
                 break;
               }
             default:

--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -1441,7 +1441,7 @@ rpmostree_print_cached_update (GVariant         *cached_update,
 
   /* and now we can print 🖨️ things! */
 
-  g_print ("Available update:\n");
+  g_print ("AvailableUpdate:\n");
 
   /* add the long keys here */
   const guint max_key_len = MAX (strlen ("SecAdvisories"),

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -526,7 +526,7 @@ vm_ostreeupdate_prepare_reboot() {
                         ".deployments[0][\"booted\"]" \
                         ".deployments[0][\"version\"] == \"v1\""
     vm_rpmostree status > status.txt
-    assert_file_has_content_literal status.txt 'auto updates disabled'
+    assert_file_has_content_literal status.txt 'AutomaticUpdates: disabled'
     # start it up again since we rebooted
     vm_start_httpd ostree_server $REMOTE_OSTREE 8888
 }

--- a/tests/vmcheck/test-autoupdate-check.sh
+++ b/tests/vmcheck/test-autoupdate-check.sh
@@ -59,7 +59,7 @@ vm_rpmostree cleanup -m
 
 # make sure that off means off
 vm_change_update_policy off
-vm_rpmostree status | grep 'auto updates disabled'
+vm_rpmostree status | grep 'AutomaticUpdates: disabled'
 vm_rpmostree upgrade --trigger-automatic-update-policy > out.txt
 assert_file_has_content out.txt "Automatic updates are not enabled; exiting"
 # check we didn't download any metadata (skip starting dir)
@@ -78,7 +78,7 @@ echo "ok --check/--preview no updates"
 
 # ok, let's test out check
 vm_change_update_change_policy check
-vm_rpmostree status | grep 'auto updates enabled (check'
+vm_rpmostree status | grep 'AutomaticUpdates: check'
 
 # build an *older version* and check that we don't report an update
 vm_build_rpm layered-cake version 2.1 release 2
@@ -86,7 +86,7 @@ cursor=$(vm_get_journal_cursor)
 vm_cmd systemctl start rpm-ostree-automatic.service
 vm_wait_content_after_cursor $cursor 'Txn AutomaticUpdateTrigger.*successful'
 vm_rpmostree status -v > out.txt
-assert_not_file_has_content out.txt "Available update"
+assert_not_file_has_content out.txt "AvailableUpdate"
 # And check the unit name https://github.com/projectatomic/rpm-ostree/pull/1368
 vm_cmd journalctl -u rpm-ostreed --after-cursor ${cursor} > journal.txt
 assert_file_has_content journal.txt 'client(id:cli.*unit:rpm-ostreed-automatic.service'
@@ -96,15 +96,15 @@ rm -f journal.txt
 vm_build_rpm layered-cake version 2.1 release 4
 vm_rpmostree upgrade --trigger-automatic-update-policy
 vm_rpmostree status > out.txt
-assert_file_has_content out.txt "Available update"
+assert_file_has_content out.txt "AvailableUpdate"
 assert_file_has_content out.txt "Diff: 1 upgraded"
 assert_not_file_has_content out.txt "SecAdvisories"
 vm_rpmostree status -v > out.txt
 assert_file_has_content out.txt "Upgraded: layered-cake 2.1-3 -> 2.1-4"
 # make sure we don't report ostree-based stuff somehow
-! grep -A999 'Available update' out.txt | grep "Version"
-! grep -A999 'Available update' out.txt | grep "Timestamp"
-! grep -A999 'Available update' out.txt | grep "Commit"
+! grep -A999 'AvailableUpdate' out.txt | grep "Version"
+! grep -A999 'AvailableUpdate' out.txt | grep "Timestamp"
+! grep -A999 'AvailableUpdate' out.txt | grep "Commit"
 echo "ok check mode layered only"
 
 # confirm no filelists were fetched
@@ -159,7 +159,7 @@ echo "ok --check/--preview layered pkgs check policy"
 vm_change_update_policy off
 vm_rpmostree cleanup -m
 vm_cmd systemctl stop rpm-ostreed
-vm_rpmostree status | grep 'auto updates disabled'
+vm_rpmostree status | grep 'AutomaticUpdates: disabled'
 vm_rpmostree upgrade --check > out.txt
 vm_rpmostree upgrade --preview > out-verbose.txt
 assert_output

--- a/tests/vmcheck/test-autoupdate-stage.sh
+++ b/tests/vmcheck/test-autoupdate-stage.sh
@@ -33,10 +33,10 @@ vm_ostreeupdate_create v2
 vm_rpmostree cleanup -m
 
 vm_rpmostree status > status.txt
-assert_file_has_content status.txt 'auto updates disabled'
+assert_file_has_content status.txt 'AutomaticUpdates: disabled'
 vm_change_update_policy ex-stage
 vm_rpmostree status > status.txt
-assert_file_has_content_literal status.txt 'auto updates enabled (ex-stage'
+assert_file_has_content_literal status.txt 'AutomaticUpdates: ex-stage; rpm-ostree-automatic.timer: inactive'
 
 vm_rpmostree upgrade --trigger-automatic-update-policy
 vm_assert_status_jq ".deployments[1][\"booted\"]" \

--- a/tests/vmcheck/test-autoupdate-stage.sh
+++ b/tests/vmcheck/test-autoupdate-stage.sh
@@ -36,7 +36,7 @@ vm_rpmostree status > status.txt
 assert_file_has_content status.txt 'AutomaticUpdates: disabled'
 vm_change_update_policy ex-stage
 vm_rpmostree status > status.txt
-assert_file_has_content_literal status.txt 'AutomaticUpdates: ex-stage; rpm-ostree-automatic.timer: inactive'
+assert_file_has_content_literal status.txt 'AutomaticUpdates: ex-stage; rpm-ostreed-automatic.timer: inactive'
 
 vm_rpmostree upgrade --trigger-automatic-update-policy
 vm_assert_status_jq ".deployments[1][\"booted\"]" \


### PR DESCRIPTION
First, split it into its own section; it's important enough to merit it.
Second, explicitly reference the systemd timer/service units.  For
example, a question I often have is "when is the next run" and of course
you can get that rpm `systemctl status rpm-ostreed-automatic.timer` but
you have to know that, and the reminder helps.

(I briefly looked at implementing the `Trigger` line from `systemctl status`
 but it's not entirely trivial...tempting to just fork off a `systemctl status | grep `)

Prep for unifying this text with the message we print when one does
`rpm-ostree upgrade` when auto-updates are enabled.
