### PR TITLE
tests: Update for ostree BLS file naming change

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -9,7 +9,7 @@ dn=$(dirname $0)
 # Use the latest ostree by default
 id=$(. /etc/os-release && echo $ID)
 version_id=$(. /etc/os-release && echo $VERSION_ID)
-if [ "$id" == fedora ] && [ "$version_id" == 27 ]; then
+if [ "$id" == fedora ] && [ "$version_id" == 28 ]; then
     echo -e '[fahc]\nmetadata_expire=1m\nbaseurl=https://ci.centos.org/artifacts/sig-atomic/fahc/rdgo/build/\ngpgcheck=0\n' > /etc/yum.repos.d/fahc.repo
     # Until we fix https://github.com/rpm-software-management/libdnf/pull/149
     excludes='exclude=ostree ostree-libs ostree-grub2 rpm-ostree'

--- a/tests/vmcheck/test-initramfs.sh
+++ b/tests/vmcheck/test-initramfs.sh
@@ -100,7 +100,7 @@ for file in first second; do
         '.deployments[0]["initramfs-args"]|index("-I") == 0' \
         '.deployments[0]["initramfs-args"]|index("/etc/rpmostree-initramfs-testing-'${file}'") == 1' \
         '.deployments[0]["initramfs-args"]|length == 2'
-    initramfs=$(vm_cmd grep ^initrd /boot/loader/entries/ostree-$osname-0.conf | sed -e 's,initrd ,/boot/,')
+    initramfs=$(vm_cmd grep ^initrd /boot/loader/entries/ostree-2-$osname.conf | sed -e 's,initrd ,/boot/,')
     test -n "${initramfs}"
     vm_cmd lsinitrd $initramfs > lsinitrd.txt
     assert_file_has_content lsinitrd.txt /etc/rpmostree-initramfs-testing-${file}
@@ -108,7 +108,7 @@ done
 
 vm_rpmostree initramfs --disable
 
-initramfs=$(vm_cmd grep ^initrd /boot/loader/entries/ostree-$osname-0.conf | sed -e 's,initrd ,/boot/,')
+initramfs=$(vm_cmd grep ^initrd /boot/loader/entries/ostree-2-$osname.conf | sed -e 's,initrd ,/boot/,')
 test -n "${initramfs}"
 vm_cmd lsinitrd $initramfs > lsinitrd.txt
 assert_not_file_has_content lsinitrd.txt /etc/rpmostree-initramfs-testing


### PR DESCRIPTION
We should probably add a libtest.sh API for so for this, but this is
the quick hack.  Fallout from https://github.com/ostreedev/ostree/pull/1654
