### PR TITLE
daemon/rollback: Really fix staged deployment case

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -456,11 +456,11 @@ rollback_transaction_execute (RpmostreedTransaction *transaction,
 
   if (!rollback_deployment && !pending_deployment) /* i.e. do we just have 1 deployment? */
     return glnx_throw (error, "No rollback deployment found");
+  /* rollback with a staged deployment doesn't make any sense -- error out with hint */
+  else if (pending_deployment && ostree_deployment_is_staged (pending_deployment))
+    return glnx_throw (error, "Staged deployment (remove with cleanup -p)");
   else if (!rollback_deployment)
     {
-      if (ostree_deployment_is_staged (pending_deployment))
-        /* XXX: or just clean it up for them? also, awkward CLI mention */
-        return glnx_throw (error, "Staged deployment (remove with cleanup -p)");
 
       /* If there isn't a rollback deployment, but there *is* a pending deployment, then we
        * want "rpm-ostree rollback" to put the currently booted deployment back on top. This


### PR DESCRIPTION
Follow up to #1434. I was testing this inside my test VM, which didn't
have a rollback deployment (i.e. it was just the staged deployment and
the booted deployment). Testing the upcoming release on my real system
showed that this wasn't correctly fixed.