### PR TITLE
vmcheck/misc-2: Make compatible with staged default

### DIFF
--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -355,6 +355,16 @@ vm_assert_status_jq() {
     assert_status_file_jq status.json "$@"
 }
 
+vm_pending_is_staged() {
+    vm_rpmostree status --json > status-staged.json
+    local rc=1
+    if jq -e ".deployments[0][\"staged\"]" < status-staged.json; then
+        rc=0
+    fi
+    rm -f status-staged.json
+    return $rc
+}
+
 # Like build_rpm, but also sends it to the VM
 vm_build_rpm() {
     build_rpm "$@"


### PR DESCRIPTION
First the pinning tests would try to pin a staged deployment,
and some of the later tests here depend on a subtle way on the
state of the system.  It's tempting to do a `reset` before each one
and reboot but this makes things work.

There's some additional assertions here as I went through and
was debugging.

Prep for making staging the default.
