### PR TITLE
sysroot-core: Use new libostree sysroot pruning API

### DIFF
--- a/src/daemon/rpmostree-sysroot-core.c
+++ b/src/daemon/rpmostree-sysroot-core.c
@@ -334,10 +334,13 @@ rpmostree_syscore_cleanup (OstreeSysroot            *sysroot,
   /* And do a prune */
   guint64 freed_space;
   gint n_objects_total, n_objects_pruned;
-  if (!ostree_repo_prune (repo, OSTREE_REPO_PRUNE_FLAGS_REFS_ONLY, 0,
-                          &n_objects_total, &n_objects_pruned, &freed_space,
-                          cancellable, error))
-    return FALSE;
+  { g_autoptr(GHashTable) reachable = ostree_repo_traverse_new_reachable ();
+    OstreeRepoPruneOptions opts = { OSTREE_REPO_PRUNE_FLAGS_REFS_ONLY, reachable };
+    if (!ostree_sysroot_cleanup_prune_repo (sysroot, &opts, &n_objects_total,
+                                            &n_objects_pruned, &freed_space,
+                                            cancellable, error))
+      return FALSE;
+  }
 
   if (n_pkgcache_freed > 0 || freed_space > 0)
     {


### PR DESCRIPTION
Use the new API introduced in
https://github.com/ostreedev/ostree/commit/9131d8a4cc28ea498c2ebc058aac73f70d41841c
which helps avoid relying on the magical deployment refs.  I thought
this would help with a livefs+staging issue, but it doesn't.  But we might
as well do it, it's adding another level of safety.
