### PR TITLE
doc: add repo_structure section

### DIFF
--- a/docs/repo_structure.md
+++ b/docs/repo_structure.md
@@ -4,20 +4,14 @@
 ### Rpm-ostree source code
 ```
 .
-└─ src                          Contains source code for rpm-ostree
-```
-
-#### File structures under src
-```
-.
 └─ src
-  ├── app                       Contains the "frontend" logic (display CLI commands, function calls to daemon etc) for each command
+  ├── app                       rpm-ostree CLI application
   |
-  ├── daemon                    Usually has the "backend" logic for each command that involves with dbus daemon and transactions
+  ├── daemon                    rpm-ostree daemon providing D-Bus API
   |
-  ├── lib                       Contains package and db libraries
+  ├── lib                       Public library: contains APIs for exploring rpmdb in OSTrees
   |
-  └── libpriv                   Underlying API libraries used by files from both daemon and app
+  └── libpriv                   Private API shared between app and daemon
 
 ```
 
@@ -39,7 +33,7 @@
 
 ```
 .
-└── test                        Contains tests
+└── tests                       Contains tests
 ```
 
 ### Documentation

--- a/docs/repo_structure.md
+++ b/docs/repo_structure.md
@@ -1,0 +1,73 @@
+# Repository structure
+
+
+### Rpm-ostree source code
+```
+.
+└─ src                          Contains source code for rpm-ostree
+```
+
+#### File structures under src
+```
+.
+└─ src
+  ├── app                       Contains the "frontend" logic (display CLI commands, function calls to daemon etc) for each command
+  |
+  ├── daemon                    Usually has the "backend" logic for each command that involves with dbus daemon and transactions
+  |
+  ├── lib                       Contains package and db libraries
+  |
+  └── libpriv                   Underlying API libraries used by files from both daemon and app
+
+```
+
+### Rust Libraries
+```
+.
+└─ rust                         Contains rust libraries that rpm-ostree uses─
+```
+
+### CI
+```
+.
+├── ci                          Contains scripts to install build dependencies and run tests locally
+└── .papr.yml                   PAPR(https://github.com/projectatomic/papr) uses it to define the test environment and test scripts
+```
+
+
+### tests
+
+```
+.
+└── test                        Contains tests
+```
+
+### Documentation
+
+```
+.
+├── docs                        Contains documentation for this repository
+|
+├── HACKING.md                  Contains hacking information for developers
+|
+└── man                         Contains man page for rpm-ostree
+```
+
+### Makefiles
+These files are used when doing raw build instructions. You can find more info [here](https://github.com/projectatomic/rpm-ostree/blob/master/HACKING.md#raw-build-instructions)
+```
+.
+├── Makefile-daemon.am
+├── Makefile-decls.am
+├── Makefile-lib-defines.am
+├── Makefile-lib.am
+├── Makefile-libpriv.am
+├── Makefile-libdnf.am
+├── Makefile-man.am
+├── Makefile-tests.am
+├── Makefile.am
+├── Makefile-rpm-ostree.am
+|
+├── configure.ac
+└── autogen.sh
+```


### PR DESCRIPTION
This commit plans to add repo_structure document to better explain
what is the meaning for each folder under this repo. A similar approach can be found
in https://github.com/openshift/openshift-ansible/blob/master/docs/repo_structure.md

The output md can be viewed at https://github.com/peterbaouoft/rpm-ostree/blob/pr/add_repo_structure_doc/docs/repo_structure.md. 

There are still folders/files I am not too familiar with, so there might be errors for the description. Please point them out when you find it. Comments are welcome :). Thanks! 
