### PR TITLE
livefs: Require deployment staging

### DIFF
--- a/src/daemon/rpmostreed-transaction-livefs.c
+++ b/src/daemon/rpmostreed-transaction-livefs.c
@@ -677,6 +677,8 @@ livefs_transaction_execute_inner (LiveFsTransaction *self,
    */
   if (origin_merge_deployment == booted_deployment)
     return glnx_throw (error, "No pending deployment");
+  if (!ostree_deployment_is_staged (origin_merge_deployment))
+    return glnx_throw (error, "livefs requires staged deployments");
 
   /* Open a fd for the booted deployment */
   g_autofree char *deployment_path = ostree_sysroot_get_deployment_dirpath (sysroot, booted_deployment);
@@ -876,10 +878,6 @@ livefs_transaction_execute_inner (LiveFsTransaction *self,
                                   cancellable, error))
         return FALSE;
     }
-
-  /* XXX: right now we don't have a good solution for this:
-   * https://github.com/projectatomic/rpm-ostree/issues/40 */
-  rpmostree_output_message ("WARNING: any changes to /etc will be lost on next reboot");
 
   /* Write out the origin as having completed this */
   if (!write_livefs_state (sysroot, booted_deployment, NULL, target_csum, error))

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -24,6 +24,11 @@ set -euo pipefail
 
 set -x
 
+# Uses livefs
+vm_cmd 'echo "[Experimental]" >> /etc/rpm-ostreed.conf'
+vm_cmd 'echo StageDeployments=true >> /etc/rpm-ostreed.conf'
+vm_rpmostree reload
+
 # SUMMARY: check that RPM scripts are properly handled during package layering
 
 # do a bunch of tests together so that we only have to reboot once


### PR DESCRIPTION
Staging fixes the `/etc` bug for livefs.  There's actually more
we could do here around taking advantage of staging for livefs;
for example, I think once the livefs is complete, we could just delete
the staged deployment.  And then we don't need to render on the next
boot the live status, etc.

Anyways, all that can come in the future.  This is prep for
enabling staging by default.
