### PR TITLE
treefile.rs: Deny unknown fields by default

### DIFF
--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/bash
 
 pkg_upgrade() {
+    echo "Running yum -y distro-sync... $(date)"
     yum -y distro-sync
+    echo "Done yum -y distro-sync! $(date)"
 }
 
 make() {
@@ -15,7 +17,9 @@ build() {
 }
 
 pkg_install() {
+    echo "Running yum -y install... $(date)"
     yum -y install "$@"
+    echo "Done running yum -y install! $(date)"
 }
 
 pkg_install_if_os() {
@@ -31,25 +35,26 @@ pkg_install_if_os() {
 }
 
 pkg_builddep() {
+    echo "Running builddep... $(date)"
     # This is sadly the only case where it's a different command
     if test -x /usr/bin/dnf; then
         dnf builddep -y "$@"
     else
         yum-builddep -y "$@"
     fi
+    echo "Done running builddep! $(date)"
 }
 
 pkg_install_builddeps() {
     pkg=$1
     if test -x /usr/bin/dnf; then
-        yum -y install dnf-plugins-core
-        yum install -y 'dnf-command(builddep)'
+        pkg_install dnf-plugins-core 'dnf-command(builddep)'
         # Base buildroot
         pkg_install @buildsys-build
     else
-        yum -y install yum-utils
+        pkg_install yum-utils
         # Base buildroot, copied from the mock config sadly
-        yum -y install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz
+        pkg_install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz
     fi
     # builddeps+runtime deps
     pkg_builddep $pkg

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -214,12 +214,16 @@ packages:
     #[test]
     fn basic_invalid() {
         let mut buf = VALID_PRELUDE.to_string();
-        buf.push_str("install-langs: 42\n");
+        buf.push_str(r###"install_langs:
+  - "klingon"
+  - "esperanto"
+"###);
         let buf = buf.as_bytes();
         let input = io::BufReader::new(buf);
         match treefile_parse_yaml(input) {
-            Ok(_) => panic!("Expected invalid treefile"),
-            Err(_) => {}
+            Err(ref e) if e.kind() == io::ErrorKind::InvalidInput => {},
+            Err(ref e) => panic!("Expected invalid treefile, not {}", e.to_string()),
+            _ => panic!("Expected invalid treefile"),
         }
     }
 }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -26,10 +26,8 @@ use serde_yaml;
 use std::path::Path;
 use std::{fs, io};
 
-pub fn treefile_read_impl<W: io::Write>(filename: &Path, output: W) -> io::Result<()> {
-    let f = io::BufReader::new(fs::File::open(filename)?);
-
-    let mut treefile: TreeComposeConfig = match serde_yaml::from_reader(f) {
+fn treefile_parse_yaml<R: io::Read>(input: R) -> io::Result<TreeComposeConfig> {
+    let mut treefile: TreeComposeConfig = match serde_yaml::from_reader(input) {
         Ok(t) => t,
         Err(e) => {
             return Err(io::Error::new(
@@ -44,8 +42,13 @@ pub fn treefile_read_impl<W: io::Write>(filename: &Path, output: W) -> io::Resul
         treefile.packages = Some(whitespace_split_packages(&pkgs));
     }
 
-    serde_json::to_writer_pretty(output, &treefile)?;
+    Ok(treefile)
+}
 
+pub fn treefile_read_impl<W: io::Write>(filename: &Path, output: W) -> io::Result<()> {
+    let f = io::BufReader::new(fs::File::open(filename)?);
+    let treefile = treefile_parse_yaml(f)?;
+    serde_json::to_writer_pretty(output, &treefile)?;
     Ok(())
 }
 
@@ -99,6 +102,7 @@ fn serde_true() -> bool {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct TreeComposeConfig {
     // Compose controls
     #[serde(rename = "ref")]
@@ -186,4 +190,36 @@ pub struct TreeComposeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "remove-from-packages")]
     pub remove_from_packages: Option<Vec<Vec<String>>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static VALID_PRELUDE : &str = r###"
+ref: "exampleos/x86_64/blah"
+packages:
+ - foo bar
+ - baz
+"###;
+
+    #[test]
+    fn basic_valid() {
+        let input = io::BufReader::new(VALID_PRELUDE.as_bytes());
+        let treefile = treefile_parse_yaml(input).unwrap();
+        assert!(treefile.treeref == "exampleos/x86_64/blah");
+        assert!(treefile.packages.unwrap().len() == 3);
+    }
+
+    #[test]
+    fn basic_invalid() {
+        let mut buf = VALID_PRELUDE.to_string();
+        buf.push_str("install-langs: 42\n");
+        let buf = buf.as_bytes();
+        let input = io::BufReader::new(buf);
+        match treefile_parse_yaml(input) {
+            Ok(_) => panic!("Expected invalid treefile"),
+            Err(_) => {}
+        }
+    }
 }

--- a/tests/compose
+++ b/tests/compose
@@ -41,7 +41,7 @@ datadir_owner=$(stat -c '%u' ${test_compose_datadir})
 test ${uid} = ${datadir_owner}
 
 # Create a consistent cache of the RPMs
-echo "Preparing compose tests..."
+echo "Preparing compose tests... $(date)"
 tmp_repo=${test_compose_datadir}/tmp-repo
 if test -z "${RPMOSTREE_COMPOSE_CACHEONLY:-}"; then
     mkdir -p ${test_compose_datadir}/cache
@@ -51,6 +51,7 @@ if test -z "${RPMOSTREE_COMPOSE_CACHEONLY:-}"; then
     rpm-ostree compose --repo=${tmp_repo} tree --download-only --cachedir=${test_compose_datadir}/cache ${dn}/composedata/fedora-base.json
     (cd ${test_compose_datadir}/cache && createrepo_c .)
 fi
+echo "Done preparing compose tests! $(date)"
 rm ${tmp_repo} -rf
 
 total=0

--- a/tests/composedata/fedora-base.json
+++ b/tests/composedata/fedora-base.json
@@ -5,7 +5,8 @@
     "repos": ["fedora", "updates"],
 
     "packages": ["kernel", "nss-altfiles", "systemd", "ostree", "selinux-policy-targeted", "chrony",
-                 "tuned", "iputils", "fedora-release-atomichost", "docker", "container-selinux"],
+                 "tuned", "iputils", "fedora-release-atomichost", "docker", "container-selinux",
+                 "grub2", "grub2-efi", "ostree-grub2", "efibootmgr", "shim"],
 
     "ignore-removed-users": ["root"],
     "ignore-removed-groups": ["root"],

--- a/tests/composedata/fedora-base.json
+++ b/tests/composedata/fedora-base.json
@@ -7,18 +7,6 @@
     "packages": ["kernel", "nss-altfiles", "systemd", "ostree", "selinux-policy-targeted", "chrony",
                  "tuned", "iputils", "fedora-release-atomichost", "docker", "container-selinux"],
 
-    "packages-aarch64": ["grub2-efi", "ostree-grub2",
-                         "efibootmgr", "shim"],
-
-    "packages-armhfp": ["extlinux-bootloader"],
-
-    "packages-ppc64": ["grub2", "ostree-grub2"],
-
-    "packages-ppc64le": ["grub2", "ostree-grub2"],
-
-    "packages-x86_64": ["grub2", "grub2-efi", "ostree-grub2",
-                        "efibootmgr", "shim"],
-
     "ignore-removed-users": ["root"],
     "ignore-removed-groups": ["root"],
     "check-passwd": { "type": "file", "filename": "passwd" },


### PR DESCRIPTION
Let's not make the same mistake we did with JSON where typoing a
field means it's silently ignored.  This actually caught a bug
in a YAML usage we had:

```
error: Failed to load YAML treefile: unknown field `install_langs`, expected one of ... `install-langs` ...
```

Yes, this is a compatibility break with the feature we just announced
but...I seriously doubt anyone (that isn't known to me) has converted
yet, and if they are excited enough to start using a two-week-old feature
they can adjust.
