### PR TITLE
libdnf: Bump and disable html and man pages

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -115,7 +115,7 @@ context: f28-compose
 
 build: false
 
-timeout: 40m
+timeout: 50m
 
 required: true
 

--- a/configure.ac
+++ b/configure.ac
@@ -238,6 +238,8 @@ dnl arbitrary path - we don't actually install there.
      -DSHARE_INSTALL_PREFIX:PATH=/usr/libexec/rpm-ostree/share \
      -DBUILD_SHARED_LIBS:BOOL=ON \
      -DWITH_SWDB:BOOL=0 \
+     -DWITH_HTML:BOOL=0 \
+     -DWITH_MAN:BOOL=0 \
      ${cmake_args} ../libdnf) || exit 1
 
 AC_CONFIG_FILES([

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -1106,7 +1106,7 @@ rpmostree_get_matching_packages (DnfSack *sack,
   HySubject subject = NULL;
 
   subject = hy_subject_create (pattern);
-  selector = hy_subject_get_best_selector (subject, sack);
+  selector = hy_subject_get_best_selector (subject, sack, false);
   matches = hy_selector_matches (selector);
 
   hy_selector_free (selector);


### PR DESCRIPTION
Skip building man pages and HTML docs for our embedded libdnf to speed
up builds.

See: https://github.com/projectatomic/libdnf/pull/3

Update submodule: libdnf