### PR TITLE
compose: Support arch-specific packages in YAML (and in JSON again)

### DIFF
--- a/rust/include/rpmostree-rust.h
+++ b/rust/include/rpmostree-rust.h
@@ -20,4 +20,6 @@
 
 #pragma once
 
-int rpmostree_rs_treefile_read (const char *filename, int output_fd, GError **error);
+int rpmostree_rs_treefile_read (const char *filename,
+                                const char *arch,
+                                int output_fd, GError **error);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -27,9 +27,9 @@ extern crate serde;
 extern crate serde_json;
 extern crate serde_yaml;
 
-use std::ffi::CStr;
+use std::ffi::{CStr, OsStr};
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{FromRawFd, IntoRawFd};
-use std::path::Path;
 use std::{fs, io};
 
 mod glibutils;
@@ -51,6 +51,12 @@ fn str_from_nullable<'a>(s: *const libc::c_char) -> Option<&'a str> {
     }
 }
 
+/// Convert a C "bytestring" to a OsStr; panics if `s` is `NULL`.
+fn bytes_from_nonnull<'a>(s: *const libc::c_char) -> &'a [u8] {
+    assert!(!s.is_null());
+    unsafe { CStr::from_ptr(s) }.to_bytes()
+}
+
 #[no_mangle]
 pub extern "C" fn rpmostree_rs_treefile_read(
     filename: *const libc::c_char,
@@ -59,15 +65,15 @@ pub extern "C" fn rpmostree_rs_treefile_read(
     error: *mut *mut glib_sys::GError,
 ) -> libc::c_int {
     // Convert arguments
-    let filename = Path::new(unsafe { CStr::from_ptr(filename).to_str().unwrap() });
+    let filename = OsStr::from_bytes(bytes_from_nonnull(filename));
     let arch = str_from_nullable(arch);
-    // using an O_TMPFILE is an easy way to avoid ownership transfer issues w/ returning allocated
-    // memory across the Rust/C boundary
-    // The dance with `file` is to avoid dup()ing the fd unnecessarily
+    // Using an O_TMPFILE is an easy way to avoid ownership transfer issues w/
+    // returning allocated memory across the Rust/C boundary; the dance with
+    // `file` is to avoid dup()ing the fd unnecessarily.
     let file = unsafe { fs::File::from_raw_fd(fd) };
     let r = {
         let output = io::BufWriter::new(&file);
-        treefile_read_impl(filename, arch, output).to_glib_convention(error)
+        treefile_read_impl(filename.as_ref(), arch, output).to_glib_convention(error)
     };
     file.into_raw_fd(); // Drop ownership of the FD again
     r

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -268,10 +268,17 @@ packages-s390x:
     #[test]
     fn basic_valid() {
         let input = io::BufReader::new(VALID_PRELUDE.as_bytes());
-        let treefile = treefile_parse_yaml(input, ARCH_X86_64).unwrap();
+        let treefile = treefile_parse_yaml(input, Some(ARCH_X86_64)).unwrap();
         assert!(treefile.treeref == "exampleos/x86_64/blah");
-        eprintln!("{:?}", treefile);
         assert!(treefile.packages.unwrap().len() == 5);
+    }
+
+    #[test]
+    fn basic_valid_noarch() {
+        let input = io::BufReader::new(VALID_PRELUDE.as_bytes());
+        let treefile = treefile_parse_yaml(input, None).unwrap();
+        assert!(treefile.treeref == "exampleos/x86_64/blah");
+        assert!(treefile.packages.unwrap().len() == 3);
     }
 
     fn test_invalid(data: &'static str) {
@@ -279,7 +286,7 @@ packages-s390x:
         buf.push_str(data);
         let buf = buf.as_bytes();
         let input = io::BufReader::new(buf);
-        match treefile_parse_yaml(input, ARCH_X86_64) {
+        match treefile_parse_yaml(input, Some(ARCH_X86_64)) {
             Err(ref e) if e.kind() == io::ErrorKind::InvalidInput => {}
             Err(ref e) => panic!("Expected invalid treefile, not {}", e.to_string()),
             _ => panic!("Expected invalid treefile"),

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -26,7 +26,7 @@ use serde_yaml;
 use std::path::Path;
 use std::{fs, io};
 
-const ARCH_X86_64 : &'static str = "x86_64";
+const ARCH_X86_64: &'static str = "x86_64";
 
 /// Parse a YAML treefile definition using architecture `arch`.
 fn treefile_parse_yaml<R: io::Read>(input: R, arch: &'static str) -> io::Result<TreeComposeConfig> {
@@ -43,7 +43,7 @@ fn treefile_parse_yaml<R: io::Read>(input: R, arch: &'static str) -> io::Result<
     // Special handling for packages, since we allow whitespace within items.
     // We also canonicalize bootstrap_packages to packages here so it's
     // easier to append the arch packages after.
-    let mut pkgs : Vec<String> = vec![];
+    let mut pkgs: Vec<String> = vec![];
     {
         if let Some(base_pkgs) = treefile.packages.take() {
             pkgs.extend_from_slice(&whitespace_split_packages(&base_pkgs));
@@ -66,8 +66,10 @@ fn treefile_parse_yaml<R: io::Read>(input: R, arch: &'static str) -> io::Result<
         pkgs.extend_from_slice(&whitespace_split_packages(&arch_pkgs));
     }
     if pkgs.len() == 0 {
-        return Err(io::Error::new(io::ErrorKind::InvalidInput,
-                                  format!("Missing 'packages' entry")))
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Missing 'packages' entry"),
+        ));
     };
 
     treefile.packages = Some(pkgs);
@@ -247,7 +249,7 @@ pub struct TreeComposeConfig {
 mod tests {
     use super::*;
 
-    static VALID_PRELUDE : &str = r###"
+    static VALID_PRELUDE: &str = r###"
 ref: "exampleos/x86_64/blah"
 packages:
  - foo bar
@@ -273,24 +275,28 @@ packages-s390x:
         let buf = buf.as_bytes();
         let input = io::BufReader::new(buf);
         match treefile_parse_yaml(input, ARCH_X86_64) {
-            Err(ref e) if e.kind() == io::ErrorKind::InvalidInput => {},
-        Err(ref e) => panic!("Expected invalid treefile, not {}", e.to_string()),
-    _ => panic!("Expected invalid treefile"),
+            Err(ref e) if e.kind() == io::ErrorKind::InvalidInput => {}
+            Err(ref e) => panic!("Expected invalid treefile, not {}", e.to_string()),
+            _ => panic!("Expected invalid treefile"),
         }
     }
 
     #[test]
     fn test_invalid_install_langs() {
-        test_invalid(r###"install_langs:
+        test_invalid(
+            r###"install_langs:
   - "klingon"
   - "esperanto"
-"###);
+"###,
+        );
     }
 
     #[test]
     fn test_invalid_arch() {
-        test_invalid(r###"packages-hal9000:
+        test_invalid(
+            r###"packages-hal9000:
   - podbaydoor glowingredeye
-"###);
+"###,
+        );
     }
 }

--- a/tests/composedata/fedora-base.json
+++ b/tests/composedata/fedora-base.json
@@ -5,8 +5,19 @@
     "repos": ["fedora", "updates"],
 
     "packages": ["kernel", "nss-altfiles", "systemd", "ostree", "selinux-policy-targeted", "chrony",
-                 "tuned", "iputils", "fedora-release-atomichost", "docker", "container-selinux",
-                 "grub2", "grub2-efi", "ostree-grub2", "efibootmgr", "shim"],
+                 "tuned", "iputils", "fedora-release-atomichost", "docker", "container-selinux"],
+
+    "packages-aarch64": ["grub2-efi", "ostree-grub2",
+                         "efibootmgr", "shim"],
+
+    "packages-armhfp": ["extlinux-bootloader"],
+
+    "packages-ppc64": ["grub2", "ostree-grub2"],
+
+    "packages-ppc64le": ["grub2", "ostree-grub2"],
+
+    "packages-x86_64": ["grub2", "grub2-efi", "ostree-grub2",
+                        "efibootmgr", "shim"],
 
     "ignore-removed-users": ["root"],
     "ignore-removed-groups": ["root"],


### PR DESCRIPTION
Follow up to: https://github.com/projectatomic/rpm-ostree/pull/1459

We now honor arch-specific packages in YAML, and reject unknown
architectures.  I looked a little bit at how to avoid having hardcoded
arch lists, but it doesn't seem worth it right now.
