### PR TITLE
scripts: Add RPMOSTREE_SCRIPT_TRACE debugging envvar

### DIFF
--- a/src/libpriv/rpmostree-bwrap.c
+++ b/src/libpriv/rpmostree-bwrap.c
@@ -145,6 +145,21 @@ rpmostree_bwrap_append_child_argv (RpmOstreeBwrap *bwrap, ...)
   va_end (args);
 }
 
+void
+rpmostree_bwrap_append_child_argva (RpmOstreeBwrap *bwrap, int argc, char **argv)
+{
+  g_assert (!bwrap->executed);
+  g_assert_cmpint (argc, >=, 0);
+  while (argc > 0)
+    {
+      const char *arg = *argv;
+      g_assert (arg);
+      g_ptr_array_add (bwrap->argv, g_strdup (arg));
+      argc--;
+      argv++;
+    }
+}
+
 static void
 child_setup_fchdir (gpointer user_data)
 {

--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -48,6 +48,7 @@ RpmOstreeBwrap *rpmostree_bwrap_new (int rootfs,
 void rpmostree_bwrap_set_inherit_stdin (RpmOstreeBwrap *bwrap);
 void rpmostree_bwrap_append_bwrap_argv (RpmOstreeBwrap *bwrap, ...) G_GNUC_NULL_TERMINATED;
 void rpmostree_bwrap_append_child_argv (RpmOstreeBwrap *bwrap, ...) G_GNUC_NULL_TERMINATED;
+void rpmostree_bwrap_append_child_argva (RpmOstreeBwrap *bwrap, int argc, char **argv);
 
 void rpmostree_bwrap_setenv (RpmOstreeBwrap *bwrap, const char *name, const char *value);
 

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -400,6 +400,17 @@ run_script_in_bwrap_container (int rootfs_fd,
       data.all_fds_initialized = TRUE;
       rpmostree_bwrap_set_child_setup (bwrap, script_child_setup, &data);
 
+      const char *script_trace = g_getenv ("RPMOSTREE_SCRIPT_TRACE");
+      if (script_trace)
+        {
+          int trace_argc = 0;
+          char **trace_argv = NULL;
+          if (!g_shell_parse_argv (script_trace, &trace_argc, &trace_argv, error))
+            return glnx_prefix_error (error, "Parsing '%s'", script_trace);
+          rpmostree_bwrap_append_child_argva (bwrap, trace_argc, trace_argv);
+          g_strfreev (trace_argv);
+        }
+
       rpmostree_bwrap_append_child_argv (bwrap,
                                          interp,
                                          postscript_path_container,


### PR DESCRIPTION
I used `env RPMOSTREE_SCRIPT_TRACE='strace -f -s2048' rpm-ostree compose ...`
to debug https://bugzilla.redhat.com/show_bug.cgi?id=1548050
