### PR TITLE
scripts: Add Lua overrides for fedora-release and also -workstation

### DIFF
--- a/src/libpriv/rpmostree-script-gperf.gperf
+++ b/src/libpriv/rpmostree-script-gperf.gperf
@@ -25,7 +25,6 @@ ca-certificates.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE
 libgcc.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
 setup.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
 pinentry.prein, RPMOSTREE_SCRIPT_ACTION_IGNORE
-fedora-release.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
 fedora-release.posttrans, RPMOSTREE_SCRIPT_ACTION_IGNORE
 # These add the vagrant group which IMO is really
 # a libvirt-user group

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -102,11 +102,25 @@ typedef struct {
 } RpmOstreeLuaReplacement;
 
 static const RpmOstreeLuaReplacement lua_replacements[] = {
-  /* No bug yet */
+  /* These three don't have bugs...the release packages are implemented Lua for
+   * unnecessary reasons.  This doesn't fully generalize obviously arbitrarly
+   * release packages, but anyone doing an exampleos-release package can just implement
+   * `ln` in shell script in their package.
+   */
   { "fedora-release-atomichost.post",
     "/usr/bin/sh",
     "set -euo pipefail\n"
     "ln -s os.release.d/os-release-atomichost /usr/lib/os-release\n"
+  },
+  { "fedora-release-workstation.post",
+    "/usr/bin/sh",
+    "set -euo pipefail\n"
+    "ln -s os.release.d/os-release-workstation /usr/lib/os-release\n"
+  },
+  { "fedora-release.post",
+    "/usr/bin/sh",
+    "set -euo pipefail\n"
+    "ln -s os.release.d/os-release-fedora /usr/lib/os-release\n"
   },
   /* Upstream bug for replacing lua with shell: https://bugzilla.redhat.com/show_bug.cgi?id=1367585
    * Further note that the current glibc code triggers a chain of bugs

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -110,17 +110,17 @@ static const RpmOstreeLuaReplacement lua_replacements[] = {
   { "fedora-release-atomichost.post",
     "/usr/bin/sh",
     "set -euo pipefail\n"
-    "ln -s os.release.d/os-release-atomichost /usr/lib/os-release\n"
+    "ln -sf os.release.d/os-release-atomichost /usr/lib/os-release\n"
   },
   { "fedora-release-workstation.post",
     "/usr/bin/sh",
     "set -euo pipefail\n"
-    "ln -s os.release.d/os-release-workstation /usr/lib/os-release\n"
+    "ln -sf os.release.d/os-release-workstation /usr/lib/os-release\n"
   },
   { "fedora-release.post",
     "/usr/bin/sh",
     "set -euo pipefail\n"
-    "ln -s os.release.d/os-release-fedora /usr/lib/os-release\n"
+    "if ! test -L /usr/lib/os-release; then ln -s os.release.d/os-release-fedora /usr/lib/os-release; fi\n"
   },
   /* Upstream bug for replacing lua with shell: https://bugzilla.redhat.com/show_bug.cgi?id=1367585
    * Further note that the current glibc code triggers a chain of bugs


### PR DESCRIPTION
Dusty hit this when working on Fedora CoreOS.  IMO we don't need
to do the same for a future e.g. `fedora-release-silverblue` as
we don't support someone installing it on a non-ostree system.

(Note this all only really matters for `--unified-core` on the compose
 side)
