### PR TITLE
 rust: Rework treefile to be an object

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,6 +12,7 @@ libc = "0.2"
 glib-sys = "0.6.0"
 gio-sys = "0.6.0"
 glib = "0.5.0"
+tempfile = "3.0.3"
 
 [lib]
 name = "rpmostree_rust"

--- a/rust/include/rpmostree-rust.h
+++ b/rust/include/rpmostree-rust.h
@@ -20,6 +20,13 @@
 
 #pragma once
 
-int rpmostree_rs_treefile_read (const char *filename,
-                                const char *arch,
-                                int output_fd, GError **error);
+typedef struct RpmOstreeRsTreefile RpmOstreeRsTreefile;
+
+RpmOstreeRsTreefile *rpmostree_rs_treefile_new (const char *filename,
+                                                const char *arch,
+                                                GError **error);
+
+int rpmostree_rs_treefile_get_json_fd (RpmOstreeRsTreefile *tf);
+
+void rpmostree_rs_treefile_free (RpmOstreeRsTreefile *tf);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRsTreefile, rpmostree_rs_treefile_free);

--- a/rust/include/rpmostree-rust.h
+++ b/rust/include/rpmostree-rust.h
@@ -26,7 +26,7 @@ RpmOstreeRsTreefile *rpmostree_rs_treefile_new (const char *filename,
                                                 const char *arch,
                                                 GError **error);
 
-int rpmostree_rs_treefile_get_json_fd (RpmOstreeRsTreefile *tf);
+int rpmostree_rs_treefile_to_json (RpmOstreeRsTreefile *tf, GError **error);
 
 void rpmostree_rs_treefile_free (RpmOstreeRsTreefile *tf);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRsTreefile, rpmostree_rs_treefile_free);

--- a/rust/src/glibutils.rs
+++ b/rust/src/glibutils.rs
@@ -34,7 +34,7 @@ use std::ptr;
 // return a Result (using the std Error).
 // TODO: Try upstreaming this into the glib crate?
 
-fn error_to_glib(e: &Error, gerror: *mut *mut glib_sys::GError) {
+pub fn error_to_glib(e: &Error, gerror: *mut *mut glib_sys::GError) {
     if gerror.is_null() {
         return;
     }

--- a/rust/src/glibutils.rs
+++ b/rust/src/glibutils.rs
@@ -49,6 +49,7 @@ fn error_to_glib(e: &Error, gerror: *mut *mut glib_sys::GError) {
     }
 }
 
+#[allow(dead_code)]
 pub fn int_glib_error<T, E>(res: Result<T, E>, gerror: *mut *mut glib_sys::GError) -> libc::c_int
 where
     E: std::error::Error,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -73,7 +73,7 @@ pub extern "C" fn rpmostree_rs_treefile_read(
     let file = unsafe { fs::File::from_raw_fd(fd) };
     let r = {
         let output = io::BufWriter::new(&file);
-        treefile_read_impl(filename.as_ref(), arch, output).to_glib_convention(error)
+        int_glib_error(treefile_read_impl(filename.as_ref(), arch, output), error)
     };
     file.into_raw_fd(); // Drop ownership of the FD again
     r

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -20,6 +20,7 @@ extern crate gio_sys;
 extern crate glib;
 extern crate glib_sys;
 extern crate libc;
+extern crate tempfile;
 
 #[macro_use]
 extern crate serde_derive;
@@ -29,13 +30,12 @@ extern crate serde_yaml;
 
 use std::ffi::{CStr, OsStr};
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::io::{FromRawFd, IntoRawFd};
-use std::{fs, io};
+use std::os::unix::io::AsRawFd;
 
 mod glibutils;
 use glibutils::*;
 mod treefile;
-use treefile::treefile_read_impl;
+use treefile::{treefile_read_impl, Treefile};
 
 /* Wrapper functions for translating from C to Rust */
 
@@ -58,23 +58,32 @@ fn bytes_from_nonnull<'a>(s: *const libc::c_char) -> &'a [u8] {
 }
 
 #[no_mangle]
-pub extern "C" fn rpmostree_rs_treefile_read(
+pub extern "C" fn rpmostree_rs_treefile_new(
     filename: *const libc::c_char,
     arch: *const libc::c_char,
-    fd: libc::c_int,
     error: *mut *mut glib_sys::GError,
-) -> libc::c_int {
+) -> *mut Treefile {
     // Convert arguments
     let filename = OsStr::from_bytes(bytes_from_nonnull(filename));
     let arch = str_from_nullable(arch);
-    // Using an O_TMPFILE is an easy way to avoid ownership transfer issues w/
-    // returning allocated memory across the Rust/C boundary; the dance with
-    // `file` is to avoid dup()ing the fd unnecessarily.
-    let file = unsafe { fs::File::from_raw_fd(fd) };
-    let r = {
-        let output = io::BufWriter::new(&file);
-        int_glib_error(treefile_read_impl(filename.as_ref(), arch, output), error)
-    };
-    file.into_raw_fd(); // Drop ownership of the FD again
-    r
+    // Run code, map error if any, otherwise extract raw pointer, passing
+    // ownership back to C.
+    ptr_glib_error(treefile_read_impl(filename.as_ref(), arch), error)
+}
+
+#[no_mangle]
+pub extern "C" fn rpmostree_rs_treefile_get_json_fd(tf: *mut Treefile) -> libc::c_int {
+    assert!(!tf.is_null());
+    let tf = unsafe { &mut *tf };
+    tf.json_fd.as_raw_fd() as libc::c_int
+}
+
+#[no_mangle]
+pub extern "C" fn rpmostree_rs_treefile_free(tf: *mut Treefile) {
+    if tf.is_null() {
+        return;
+    }
+    unsafe {
+        Box::from_raw(tf);
+    }
 }

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -702,7 +702,10 @@ parse_treefile_to_json (RpmOstreeTreeComposeContext  *self,
       if (!self->treefile_rs)
         return glnx_prefix_error (error, "Failed to load YAML treefile");
 
-      g_autoptr(GInputStream) json_s = g_unix_input_stream_new (rpmostree_rs_treefile_get_json_fd (self->treefile_rs), FALSE);
+      glnx_fd_close int json_fd = rpmostree_rs_treefile_to_json (self->treefile_rs, error);
+      if (json_fd < 0)
+        return FALSE;
+      g_autoptr(GInputStream) json_s = g_unix_input_stream_new (json_fd, FALSE);
 
       if (!json_parser_load_from_stream (parser, json_s, NULL, error))
         return FALSE;


### PR DESCRIPTION
In a later patch I'm going to add more API; basically rather
than doing the JSON parsing from C, we can add APIs to directly
access the treefile object.  This also demonstrates how we
can do more extensive APIs, in particular implement an "object"
in Rust.