### PR TITLE
 app/pkg-builtins: Add --idempotent

### DIFF
--- a/src/app/rpmostree-builtin-types.h
+++ b/src/app/rpmostree-builtin-types.h
@@ -28,6 +28,9 @@ G_BEGIN_DECLS
  * Use alongside EXIT_SUCCESS and EXIT_FAILURE. */
 #define RPM_OSTREE_EXIT_UNCHANGED  (77)
 
+/* Exit code for when a pending deployment can be rebooted into. */
+#define RPM_OSTREE_EXIT_PENDING  (77)
+
 typedef enum {
   RPM_OSTREE_BUILTIN_FLAG_NONE = 0,
   RPM_OSTREE_BUILTIN_FLAG_LOCAL_CMD = 1 << 0,

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -39,6 +39,7 @@ static gboolean opt_cache_only;
 static gboolean opt_download_only;
 static gboolean opt_allow_inactive;
 static gboolean opt_uninstall_all;
+static gboolean opt_unchanged_exit_77;
 
 static GOptionEntry option_entries[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
@@ -46,6 +47,7 @@ static GOptionEntry option_entries[] = {
   { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction", NULL },
   { "allow-inactive", 0, 0, G_OPTION_ARG_NONE, &opt_allow_inactive, "Allow inactive package requests", NULL },
   { "idempotent", 0, 0, G_OPTION_ARG_NONE, &opt_idempotent, "Do nothing if package already (un)installed", NULL },
+  { "unchanged-exit-77", 0, 0, G_OPTION_ARG_NONE, &opt_unchanged_exit_77, "If no overlays were changed, exit 77", NULL },
   { NULL }
 };
 
@@ -133,7 +135,7 @@ pkg_change (RpmOstreeCommandInvocation *invocation,
     }
 
   return rpmostree_transaction_client_run (invocation, sysroot_proxy, os_proxy,
-                                           options, FALSE,
+                                           options, opt_unchanged_exit_77,
                                            transaction_address,
                                            previous_deployment,
                                            cancellable, error);

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -32,6 +32,7 @@
 static char *opt_osname;
 static gboolean opt_reboot;
 static gboolean opt_dry_run;
+static gboolean opt_idempotent;
 static gchar **opt_install;
 static gchar **opt_uninstall;
 static gboolean opt_cache_only;
@@ -44,6 +45,7 @@ static GOptionEntry option_entries[] = {
   { "reboot", 'r', 0, G_OPTION_ARG_NONE, &opt_reboot, "Initiate a reboot after operation is complete", NULL },
   { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Exit after printing the transaction", NULL },
   { "allow-inactive", 0, 0, G_OPTION_ARG_NONE, &opt_allow_inactive, "Allow inactive package requests", NULL },
+  { "idempotent", 0, 0, G_OPTION_ARG_NONE, &opt_idempotent, "Do nothing if package already (un)installed", NULL },
   { NULL }
 };
 
@@ -91,6 +93,7 @@ pkg_change (RpmOstreeCommandInvocation *invocation,
   g_variant_dict_insert (&dict, "dry-run", "b", opt_dry_run);
   g_variant_dict_insert (&dict, "allow-inactive", "b", opt_allow_inactive);
   g_variant_dict_insert (&dict, "no-layering", "b", opt_uninstall_all);
+  g_variant_dict_insert (&dict, "idempotent-layering", "b", opt_idempotent);
   g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
   gboolean met_local_pkg = FALSE;

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -310,9 +310,14 @@
             Stop short of deploying the new tree. If layering packages,
             the pkg diff is printed but packages are not downloaded or
             imported.
+         "no-layering" (type 'b')
+            Remove all package requests. Requests in "install-packages"
+            are still subsequently processed if specified.
          "no-overrides" (type 'b')
             Remove all active overrides. Not valid if any override
             modifiers are specified.
+         "no-initramfs" (type 'b')
+            Disable any initramfs regeneration.
          "cache-only" (type 'b')
             Do not update rpmmd repo metadata cache or ostree refspec.
             Not valid if "download-only" is specified.

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -329,6 +329,9 @@
          "allow-inactive-requests" (type 'b')
             When installing packages, allow package requests which would
             not immediately be active.
+         "idempotent-layering" (type 'b')
+            Don't error out on requests in install-* or uninstall-*
+            modifiers that are already satisfied.
     -->
     <method name="UpdateDeployment">
       <arg type="a{sv}" name="modifiers" direction="in"/>

--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -782,10 +782,6 @@ rpmostree_origin_remove_packages (RpmOstreeOrigin  *origin,
     update_keyfile_pkgs_from_cache (origin, "packages", "requested-local",
                                     origin->cached_local_packages, TRUE);
 
-  /* in reality, there may not be any new layer required (if e.g. we're
-   * removing a duplicate provides), though the origin has changed so we
-   * need to create a new deployment -- see also
-   * https://github.com/projectatomic/rpm-ostree/issues/753 */
   *out_changed = changed || local_changed;
   return TRUE;
 }

--- a/src/libpriv/rpmostree-origin.h
+++ b/src/libpriv/rpmostree-origin.h
@@ -152,11 +152,15 @@ gboolean
 rpmostree_origin_add_packages (RpmOstreeOrigin   *origin,
                                char             **packages,
                                gboolean           local,
+                               gboolean           allow_existing,
+                               gboolean          *out_changed,
                                GError           **error);
 
 gboolean
 rpmostree_origin_remove_packages (RpmOstreeOrigin  *origin,
                                   char            **packages,
+                                  gboolean          allow_noent,
+                                  gboolean         *out_changed,
                                   GError          **error);
 gboolean
 rpmostree_origin_remove_all_packages (RpmOstreeOrigin  *origin,

--- a/tests/vmcheck/test-layering-basic-1.sh
+++ b/tests/vmcheck/test-layering-basic-1.sh
@@ -109,7 +109,10 @@ if vm_rpmostree uninstall foo-1.0 &> out.txt; then
 fi
 assert_file_has_content_literal out.txt 'not currently requested'
 vm_rpmostree uninstall foo-1.0 --idempotent
+rc=0
+vm_rpmostree uninstall foo-1.0 --idempotent --unchanged-exit-77 || rc=$?
 assert_streq $old_pending $(vm_get_pending_csum)
+assert_streq $rc 77
 echo "ok idempotent uninstall"
 
 # Test `rpm-ostree status --pending-exit-77`
@@ -118,7 +121,8 @@ vm_rpmostree status --pending-exit-77 || rc=$?
 assert_streq $rc 77
 
 # Test that we don't do progress bars if on a tty (with the client)
-vm_rpmostree install foo-1.0 > foo-install.txt
+# (And use --unchanged-exit-77 to verify that we *don't* exit 77).
+vm_rpmostree install foo-1.0 --unchanged-exit-77 > foo-install.txt
 assert_file_has_content_literal foo-install.txt 'Checking out packages (1/1) 100%'
 echo "ok install not on a tty"
 

--- a/tests/vmcheck/test-layering-basic-1.sh
+++ b/tests/vmcheck/test-layering-basic-1.sh
@@ -90,13 +90,25 @@ vm_rpmostree db diff --format=diff \
 assert_file_has_content_literal 'db-diff.txt' "+foo-1.0-1.x86_64"
 echo "ok pkg-add foo"
 
-# Test that we don't do progress bars if on a tty (with the client)
 vm_rpmostree uninstall foo-1.0
+
+# Test `rpm-ostree status --pending-exit-77`
+rc=0
+vm_rpmostree status --pending-exit-77 || rc=$?
+assert_streq $rc 77
+
+# Test that we don't do progress bars if on a tty (with the client)
 vm_rpmostree install foo-1.0 > foo-install.txt
 assert_file_has_content_literal foo-install.txt 'Checking out packages (1/1) 100%'
 echo "ok install not on a tty"
 
 vm_reboot
+
+# Test `rpm-ostree status --pending-exit-77`, with no actual pending deployment
+rc=0
+vm_rpmostree status --pending-exit-77 || rc=$?
+assert_streq $rc 0
+
 vm_assert_status_jq \
   '.deployments[0]["base-checksum"]' \
   '.deployments[0]["pending-base-checksum"]|not' \


### PR DESCRIPTION
Add a new `install/uninstall --idempotent` option to make it easier to
interact with the CLI through scripts. E.g. one doesn't have to check
first if a request has already been installed/uninstalled.

Closes: #1467