### PR TITLE
Update libdnf, disable Python bindings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -261,6 +261,7 @@ dnl arbitrary path - we don't actually install there.
      -DSHARE_INSTALL_PREFIX:PATH=/usr/libexec/rpm-ostree/share \
      -DBUILD_SHARED_LIBS:BOOL=ON \
      -DWITH_SWDB:BOOL=0 \
+     -DWITH_BINDINGS:BOOL=0 \
      -DWITH_HTML:BOOL=0 \
      -DWITH_MAN:BOOL=0 \
      ${cmake_args} ../libdnf) || exit 1


### PR DESCRIPTION
This entirely drops out Sphinx as well as python-devel from our
builds, makes builds faster, and silences a lot of warnings too.

Update submodule: libdnf
