### PR TITLE
compose: Fix mutate-os-release handling

### DIFF
--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -56,6 +56,12 @@ void rpmostree_bwrap_set_child_setup (RpmOstreeBwrap *bwrap,
                                       GSpawnChildSetupFunc func,
                                       gpointer             data);
 
+gboolean rpmostree_bwrap_run_captured (RpmOstreeBwrap *bwrap,
+                                       GBytes        **stdout_buf,
+                                       GBytes        **stderr_buf,
+                                       GCancellable   *cancellable,
+                                       GError        **error);
+
 gboolean rpmostree_bwrap_run (RpmOstreeBwrap *bwrap,
                               GCancellable   *cancellable,
                               GError        **error);

--- a/tests/compose-tests/test-mutate-os-release.sh
+++ b/tests/compose-tests/test-mutate-os-release.sh
@@ -19,7 +19,7 @@ ostree --repo=${repobuild} cat ${treeref} \
 
 assert_file_has_content os-release.prop VERSION_ID=${releasever}
 assert_not_file_has_content os-release.prop OSTREE_VERSION=
-assert_file_has_content os-release.prop 'VERSION="'${releasever}' (Twenty '
+assert_file_has_content os-release.prop 'VERSION="'${releasever}' (Atomic '
 echo "ok mutate-os-release-none"
 
 # make sure --add-metadata-string has precedence and works with
@@ -38,7 +38,7 @@ ostree --repo=${repobuild} cat ${treeref} \
 # (https://github.com/projectatomic/rpm-ostree/pull/433)
 assert_file_has_content os-release.prop VERSION_ID=${releasever}
 assert_file_has_content os-release.prop OSTREE_VERSION=${releasever}.444
-assert_file_has_content os-release.prop 'VERSION="'${releasever}'\.444 (Twenty '
+assert_file_has_content os-release.prop 'VERSION="'${releasever}'\.444 (Atomic '
 echo "ok mutate-os-release-cli"
 
 # make sure automatic_version_prefix works
@@ -56,5 +56,5 @@ ostree --repo=${repobuild} cat ${treeref} \
 # (https://github.com/projectatomic/rpm-ostree/pull/433)
 assert_file_has_content os-release.prop VERSION_ID=${releasever}
 assert_file_has_content os-release.prop OSTREE_VERSION=${releasever}.555
-assert_file_has_content os-release.prop 'VERSION="'${releasever}'\.555 (Twenty '
+assert_file_has_content os-release.prop 'VERSION="'${releasever}'\.555 (Atomic '
 echo "ok mutate-os-release (auto)"

--- a/tests/compose-tests/test-mutate-os-release.sh
+++ b/tests/compose-tests/test-mutate-os-release.sh
@@ -15,7 +15,7 @@ runcompose
 echo "ok compose (none)"
 
 ostree --repo=${repobuild} cat ${treeref} \
-    /usr/lib/os.release.d/os-release-fedora > os-release.prop
+    /usr/lib/os.release.d/os-release-atomichost > os-release.prop
 
 assert_file_has_content os-release.prop VERSION_ID=${releasever}
 assert_not_file_has_content os-release.prop OSTREE_VERSION=
@@ -32,7 +32,7 @@ runcompose --add-metadata-string=version=${releasever}.444
 echo "ok compose (cli)"
 
 ostree --repo=${repobuild} cat ${treeref} \
-    /usr/lib/os.release.d/os-release-fedora > os-release.prop
+    /usr/lib/os.release.d/os-release-atomichost > os-release.prop
 
 # VERSION_ID *shouldn't* change
 # (https://github.com/projectatomic/rpm-ostree/pull/433)
@@ -50,7 +50,7 @@ runcompose
 echo "ok compose (auto)"
 
 ostree --repo=${repobuild} cat ${treeref} \
-    /usr/lib/os.release.d/os-release-fedora > os-release.prop
+    /usr/lib/os.release.d/os-release-atomichost > os-release.prop
 
 # VERSION_ID *shouldn't* change
 # (https://github.com/projectatomic/rpm-ostree/pull/433)


### PR DESCRIPTION
I noticed that the latest Fedora Atomic Host 28 and Silverblue did not
have an `OSTREE_VERSION` line in `/etc/os-release` even though both
specified `mutate-os-release` in their manifests. This turned out to be
due to the fact that `/usr/lib/os-release` is now a symlink to a
variant-specific file (e.g. `os-release-atomichost`), so we would
fallback to mutating `/usr/lib/os.release.d/os-release-fedora` instead.

Fix this by just taking the nuclear option of running `realpath` in the
rootfs directly. This is more maintainable than trying to keep up with
changes in variants/naming/etc. There's related discussions to this in
the original [PR](#410)
which introduced the feature re. resolving symlinks within the rootfs.