### PR TITLE
rust: Add support for inline rojig spec files

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -213,6 +213,9 @@ Experimental options
 All options listed here are subject to change or removal in a future
 version of `rpm-ostree`.
 
+ * `rojig`: Object, optional.  Sub-keys are `name`, `summary`, `license`,
+   and `description`.  Of those, `name` and `license` are mandatory.
  * `ex-rojig-spec`: string, optional:  If specified, will also cause
    a run of `rpm-ostree ex commit2rojig` on changes.  Also requires the
    `--ex-rojig-output-rpm` commandline option.
+   Deprecated in favor of `rojig`.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,6 +13,7 @@ glib-sys = "0.6.0"
 gio-sys = "0.6.0"
 glib = "0.5.0"
 tempfile = "3.0.3"
+openat = "0.1.15"
 
 [lib]
 name = "rpmostree_rust"

--- a/rust/include/rpmostree-rust.h
+++ b/rust/include/rpmostree-rust.h
@@ -24,9 +24,12 @@ typedef struct RpmOstreeRsTreefile RpmOstreeRsTreefile;
 
 RpmOstreeRsTreefile *rpmostree_rs_treefile_new (const char *filename,
                                                 const char *arch,
-                                                GError **error);
+                                                int         workdir_dfd,
+                                                GError    **error);
 
 int rpmostree_rs_treefile_to_json (RpmOstreeRsTreefile *tf, GError **error);
+
+const char *rpmostree_rs_treefile_get_rojig_spec_path (RpmOstreeRsTreefile *tf);
 
 void rpmostree_rs_treefile_free (RpmOstreeRsTreefile *tf);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRsTreefile, rpmostree_rs_treefile_free);

--- a/src/app/rpmostree-ex-builtin-commit2rojig.c
+++ b/src/app/rpmostree-ex-builtin-commit2rojig.c
@@ -93,7 +93,7 @@ rpmostree_ex_builtin_commit2rojig (int             argc,
   g_autoptr(OstreeRepo) pkgcache_repo = ostree_repo_open_at (AT_FDCWD, opt_pkgcache_repo, cancellable, error);
   if (!pkgcache_repo)
     return FALSE;
-  if (!rpmostree_commit2rojig (repo, pkgcache_repo, rev, oirpm_spec, outputdir,
+  if (!rpmostree_commit2rojig (repo, pkgcache_repo, rev, AT_FDCWD, oirpm_spec, outputdir,
                                cancellable, error))
     return FALSE;
 

--- a/src/libpriv/rpmostree-rojig-build.h
+++ b/src/libpriv/rpmostree-rojig-build.h
@@ -27,6 +27,7 @@ gboolean
 rpmostree_commit2rojig (OstreeRepo   *repo,
                         OstreeRepo   *pkgcache_repo,
                         const char   *commit,
+                        int           spec_dfd,
                         const char   *spec,
                         const char   *outputdir,
                         GCancellable *cancellable,

--- a/tests/compose-tests/test-compose2jigdo.sh
+++ b/tests/compose-tests/test-compose2jigdo.sh
@@ -8,7 +8,19 @@ dn=$(cd $(dirname $0) && pwd)
 . ${dn}/../common/libtest.sh
 
 prepare_compose_test "compose2jigdo"
-pysetjsonmember "ex-rojig-spec" '"fedora-atomic-host-oirpm.spec"'
+if rpm-ostree --version | grep -q rust; then
+    pysetjsonmember "rojig" '{ "name": "fedora-atomic-host", "license": "MIT", "summary": "Fedora Atomic Host"}'
+    python <<EOF
+import json, yaml
+jd=json.load(open("$treefile"))
+with open("$treefile.yaml", "w") as f:
+  f.write(yaml.dump(jd))
+EOF
+    export treefile=$treefile.yaml
+else
+    pysetjsonmember "ex-rojig-spec" '"fedora-atomic-host-oirpm.spec"'
+fi
+
 mkdir cache
 mkdir jigdo-output
 runcompose --ex-rojig-output-rpm $(pwd)/jigdo-output --cachedir $(pwd)/cache --add-metadata-string version=42.0


### PR DESCRIPTION
The rojig spec is almost entirely rpm-ostree implementation details;
let's not have lots of people fork/duplicate it.  Rather add the bits
of rojig to the treefile that people need to define (most notably
the name).

Prep for stabilizing rojig.

I had a few false starts with this PR; managing ownership/lifetimes
across C/Rust is just complicated.  I got bit hard by the fact that
the workdir in `--unified-core` is really dfd-relative, and had to
do a dance to propagate the dfd into rust, as well as down into
the rojig builder.
