### PR TITLE
compose: Stop calling fchdir in --unified-core mode

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1025,9 +1025,16 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
       g_printerr ("NOTICE: Proceeding anyways.\n");
     }
 
-  /* FIXME - is this still necessary? */
-  if (fchdir (self->workdir_dfd) != 0)
-    return glnx_throw_errno_prefix (error, "fchdir");
+  if (!opt_unified_core)
+    {
+      /* This call is...old, dates back to when rpm-ostree wrapped
+       * running yum as a subprocess.  It shouldn't be necessary
+       * any more, but let's be conservative and not do it in
+       * unified core mode.
+       */
+      if (fchdir (self->workdir_dfd) != 0)
+        return glnx_throw_errno_prefix (error, "fchdir");
+    }
 
   /* Set this early here, so we only have to set it one more time in the
    * complete exit path too.


### PR DESCRIPTION
Changing the process' working directory is evil in potentially
multi-threaded code, and at this point we really should be using
`openat()`/fd-relative bits most everywhere.  But let's be
conservative and only stop doing it in `--unified-core` mode.
