### PR TITLE
app/compose: Fix g_propagate_error ownership

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1059,7 +1059,7 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
           }
         else
           {
-            g_propagate_error (error, temp_error);
+            g_propagate_error (error, g_steal_pointer (&temp_error));
             return FALSE;
           }
       }


### PR DESCRIPTION
We weren't actually transferring ownership of the error, which meant
that the error message was freed before we could even print it to the
user.