### PR TITLE
docs/treefile: Mention `rw` in for machineid-compat option

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -202,10 +202,11 @@ It supports the following parameters:
    rpm-ostree creates `/usr/etc/machine-id` as an empty file for historical
    reasons.  Set this to `false` to ensure it's not present at all.  This
    will cause systemd to execute `ConditionFirstBoot=`, which implies
-   running `systemctl preset-all` for example.  If you enable this, avoid
-   using the `units` member, as it will no longer function.  Instead,
-   create a `/usr/lib/systemd/system-presets/XX-example.preset` file.
-
+   running `systemctl preset-all` for example.  This requires booting the system
+   with `rw` so that systemd can properly populate `/etc/machine-id` and execute
+   the presets at switchroot.  If you enable this, avoid using the `units`
+   member, as it will no longer function.  Instead, create a
+   `/usr/lib/systemd/system-presets/XX-example.preset` file.
 
 Experimental options
 --------


### PR DESCRIPTION
See discussions in https://github.com/systemd/systemd/issues/8268 for
more information.