### PR TITLE
postprocess: Error if `units` with machineid-compat: false

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -204,9 +204,10 @@ It supports the following parameters:
    will cause systemd to execute `ConditionFirstBoot=`, which implies
    running `systemctl preset-all` for example.  This requires booting the system
    with `rw` so that systemd can properly populate `/etc/machine-id` and execute
-   the presets at switchroot.  If you enable this, avoid using the `units`
-   member, as it will no longer function.  Instead, create a
-   `/usr/lib/systemd/system-presets/XX-example.preset` file.
+   the presets at switchroot.  When this is enabled, the `units`
+   directive will no longer function.  Instead, create a
+   `/usr/lib/systemd/system-presets/XX-example.preset` file as part of a package
+   or in the postprocess script.
 
 Experimental options
 --------

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1476,6 +1476,11 @@ rpmostree_treefile_postprocessing (int            rootfs_fd,
   if (!rename_if_exists (rootfs_fd, "etc", rootfs_fd, "usr/etc", error))
     return FALSE;
 
+  gboolean machineid_compat = TRUE;
+  if (!_rpmostree_jsonutil_object_get_optional_boolean_member (treefile, "machineid-compat",
+                                                               &machineid_compat, error))
+    return FALSE;
+
   JsonArray *units = NULL;
   if (json_object_has_member (treefile, "units"))
     units = json_object_get_array_member (treefile, "units");
@@ -1485,6 +1490,9 @@ rpmostree_treefile_postprocessing (int            rootfs_fd,
     len = json_array_get_length (units);
   else
     len = 0;
+
+  if (len > 0 && !machineid_compat)
+    return glnx_throw (error, "'units' directive is incompatible with machineid-compat = false");
 
   {
     glnx_autofd int multiuser_wants_dfd = -1;

--- a/tests/compose-tests/run-test.sh
+++ b/tests/compose-tests/run-test.sh
@@ -7,4 +7,11 @@ mkdir -p ${TEST_ARTIFACTS}
 # Redirect our stdout/stderr, since we don't want what GNU parallel does
 exec 1>${TEST_ARTIFACTS}/output.txt
 exec 2>&1
-exec $(dirname $0)/${tf}
+# Rename the dir itself if non-zero rc to make it easy to know what failed
+rc=0
+$(dirname $0)/${tf} || rc=$?
+if [ $rc == 0 ]; then
+  mv ${TEST_ARTIFACTS}{,.pass}
+else
+  mv ${TEST_ARTIFACTS}{,.fail.$rc}
+fi

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -16,6 +16,7 @@ cat > metadata.json <<EOF
   "exampleos.tests": ["smoketested", "e2e"]
 }
 EOF
+pysetjsonmember "machineid-compat" 'False'
 runcompose --add-metadata-from-json metadata.json
 
 . ${dn}/libbasic-test.sh
@@ -32,6 +33,11 @@ echo "ok autovar"
 
 ostree --repo=${repobuild} cat ${treeref} /usr/lib/systemd/system-preset/40-rpm-ostree-auto.preset > preset.txt
 assert_file_has_content preset.txt '^enable ostree-remount.service$'
+
+# https://github.com/projectatomic/rpm-ostree/pull/1425
+ostree --repo=${repobuild} ls ${treeref} /usr/etc > ls.txt
+assert_not_file_has_content ls.txt 'machine-id'
+echo "ok machine-id"
 
 if ! rpm-ostree --version | grep -q rust; then
   echo "ok yaml (SKIP)"

--- a/tests/compose-tests/test-misc-tweaks.sh
+++ b/tests/compose-tests/test-misc-tweaks.sh
@@ -14,7 +14,6 @@ pysetjsonmember "documentation" "False"
 # $ rpm -qlv systemd|grep -F 'system/default.target '
 # lrwxrwxrwx    1 root    root                       16 May 11 06:59 /usr/lib/systemd/system/default.target -> graphical.target
 pysetjsonmember "default_target" '"multi-user.target"'
-pysetjsonmember "machineid-compat" 'False'
 pysetjsonmember "units" '["tuned.service"]'
 # And test adding/removing files
 pysetjsonmember "add-files" '[["foo.txt", "/usr/etc/foo.txt"],
@@ -83,8 +82,3 @@ echo "ok remove-from-packages"
 ostree --repo=${repobuild} ls  ${treeref} /tmp > ls.txt
 assert_file_has_content ls.txt 'd01777 0 0      0 /tmp'
 echo "ok /tmp"
-
-# https://github.com/projectatomic/rpm-ostree/pull/1425
-ostree --repo=${repobuild} ls ${treeref} /usr/etc > ls.txt
-assert_not_file_has_content ls.txt 'machine-id'
-echo "ok machine-id"


### PR DESCRIPTION
Rather than silently ignoring it.

In theory...we could write to /usr/lib/systemd instead of `/etc`
but eh...I feel like what we really want to do is make it convenient
to write a preset file from the YAML.

(We could have an `add-files` content that takes values literally
 which would be nice in YAML and suck in JSON)

A general thread running through this is that for people making
*derivatives* of a CoreOS-like system, having to create their
own `exampleos-release` package is an annoying hurdle.

Anyways for now we're fixing the bug that we were silently ignoring
it.
