### PR TITLE
libpriv/core: Always call rpmtsSetRootDir()

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -4009,6 +4009,8 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
   }
 
   g_auto(rpmts) rpmdb_ts = rpmtsCreate ();
+  /* Always call rpmtsSetRootDir() here so rpmtsRootDir() isn't NULL -- see rhbz#1613517 */
+  rpmtsSetRootDir (rpmdb_ts, "/");
   rpmtsSetVSFlags (rpmdb_ts, _RPMVSF_NOSIGNATURES | _RPMVSF_NODIGESTS);
   /* https://bugzilla.redhat.com/show_bug.cgi?id=1607223
    * Newer librpm defaults to doing a full payload checksum, which we can't


### PR DESCRIPTION
Call `rpmtsSetRootDir()` even in the `JUSTDB` run. This brings us in
line with libdnf and the rpm CLI itself, which both unconditionally call
`rpmtsSetRootDir()` regardless of whether we're targeting the system
root or a subdir.

This doesn't cause a `chroot()` to happen since librpm only does this
if the target root dir is not `/`.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1613517