### PR TITLE
livefs: Rename --replace to --dangerous-do-not-use-replace

### DIFF
--- a/src/app/rpmostree-builtin-livefs.c
+++ b/src/app/rpmostree-builtin-livefs.c
@@ -34,7 +34,8 @@ static gboolean opt_replace;
 
 static GOptionEntry option_entries[] = {
   { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Only perform analysis, do not make changes", NULL },
-  { "replace", 0, 0, G_OPTION_ARG_NONE, &opt_replace, "Completely replace all files in /usr", NULL },
+  /* Known broken with kernel updates; see https://github.com/projectatomic/rpm-ostree/issues/1495 */
+  { "dangerous-do-not-use-replace", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_replace, "Completely replace all files in /usr (known broken)", NULL },
   { NULL }
 };
 

--- a/src/daemon/rpmostreed-transaction-livefs.c
+++ b/src/daemon/rpmostreed-transaction-livefs.c
@@ -732,11 +732,11 @@ livefs_transaction_execute_inner (LiveFsTransaction *self,
   if (!replacing)
     {
       if (!adds_packages)
-        return glnx_throw (error, "No packages added, and replacement not enabled");
+        return glnx_throw (error, "No packages added; cannot apply");
       if (modifies_packages)
-        return glnx_throw (error, "livefs update modifies/replaces packages and replacement not enabled");
+        return glnx_throw (error, "livefs update modifies/replaces packages; cannot apply");
       else if ((diff->flags & COMMIT_DIFF_FLAGS_REPLACEMENT) > 0)
-        return glnx_throw (error, "livefs update would replace files in /usr, and replacement not enabled");
+        return glnx_throw (error, "livefs update would replace files in /usr; cannot apply");
     }
   if ((self->flags & RPMOSTREE_TRANSACTION_LIVEFS_FLAG_DRY_RUN) > 0)
     {

--- a/tests/vmcheck/test-livefs.sh
+++ b/tests/vmcheck/test-livefs.sh
@@ -184,7 +184,7 @@ vm_rpmostree ex livefs -n --replace &> livefs-analysis.txt
 assert_file_has_content livefs-analysis.txt 'livefs OK (dry run)'
 vm_assert_status_jq '.deployments|length == 2' '.deployments[0]["live-replaced"]|not' \
                     '.deployments[1]["live-replaced"]|not'
-vm_rpmostree ex livefs --replace
+vm_rpmostree ex livefs --dangerous-do-not-use-replace
 vm_cmd cat /${dummy_file_to_modify} > dummyfile.txt
 assert_file_has_content dummyfile.txt "JUST KIDDING DO WHATEVER"
 vm_cmd test -f /usr/newsubdir/date.txt

--- a/tests/vmcheck/test-livefs.sh
+++ b/tests/vmcheck/test-livefs.sh
@@ -176,11 +176,11 @@ if vm_rpmostree ex livefs -n &> livefs-analysis.txt; then
 fi
 vm_assert_status_jq '.deployments|length == 2' '.deployments[0]["live-replaced"]|not' \
                     '.deployments[1]["live-replaced"]|not'
-assert_file_has_content livefs-analysis.txt 'No packages added.*replacement not enabled'
+assert_file_has_content livefs-analysis.txt 'No packages added'
 echo "ok no modifications"
 
 # And now replacement
-vm_rpmostree ex livefs -n --replace &> livefs-analysis.txt
+vm_rpmostree ex livefs -n --dangerous-do-not-use-replace &> livefs-analysis.txt
 assert_file_has_content livefs-analysis.txt 'livefs OK (dry run)'
 vm_assert_status_jq '.deployments|length == 2' '.deployments[0]["live-replaced"]|not' \
                     '.deployments[1]["live-replaced"]|not'


### PR DESCRIPTION
And don't mention "replace" in the error texts.
This is (now) known broken with kernel updates; making that not
dangerous isn't going to be easy.  I debated entirely removing it
but for now let's just make it harder to use.

Ref: https://github.com/projectatomic/rpm-ostree/issues/1495
