### PR TITLE
ci: Split compose test into two

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -105,11 +105,11 @@ branches:
 
 # NB: when bumping 28 here, also bump fedora.repo, and compose script
 
-context: f28-compose
+context: f28-compose1
 
 build: false
 
-timeout: 50m
+timeout: 30m
 
 required: true
 
@@ -122,6 +122,9 @@ host:
   specs:
     cpus: 4
 
+env:
+  RPMOSTREE_COMPOSE_TEST_FILTER: odd
+
 # Copy yum.repos.d to get any injected repos from the host, which
 # will point to a closer mirror.  Note we substitute $releasever
 # since https://github.com/projectatomic/rpm-ostree/pull/875
@@ -129,6 +132,7 @@ tests:
   - docker run --privileged --rm
     -e CONFIGOPTS=--enable-rust
     -e CI_PKGS=cargo
+    -e RPMOSTREE_COMPOSE_TEST_FILTER
     -e RPMOSTREE_COMPOSE_TEST_USE_REPOS=/etc/yum.repos.d.host
     -v /etc/yum.repos.d:/etc/yum.repos.d.host:ro
     -v $(pwd):/srv/code -w /srv/code
@@ -137,6 +141,13 @@ tests:
 
 artifacts:
   - test-compose-logs
+
+---
+
+inherit: true
+context: f28-compose2
+env:
+  RPMOSTREE_COMPOSE_TEST_FILTER: even
 
 ---
 

--- a/tests/compose
+++ b/tests/compose
@@ -59,6 +59,12 @@ pass=0
 fail=0
 skip=0
 all_tests="$(cd ${dn}/compose-tests && ls test-*.sh | sort)"
+if [ "${RPMOSTREE_COMPOSE_TEST_FILTER:-}" == odd ]; then
+  # https://superuser.com/a/101760/237392
+  all_tests="$(sed -n 'p;n' <<< ${all_tests})"
+elif [ "${RPMOSTREE_COMPOSE_TEST_FILTER:-}" == even ]; then
+  all_tests="$(sed -n 'n;p' <<< ${all_tests})"
+fi
 tests=""
 if [ -n "${TESTS+ }" ]; then
     for tf in ${all_tests}; do


### PR DESCRIPTION
The `f28-compose` test keeps timing out. Some time recently, I/O
performance of the internal OpenStack instance used for testing has
degraded. I have a ticket open to investigate the regression though
haven't had any luck so far.

Let's just take the easy way out and split the test into two testsuites.
This is obviously hacky, and sad, and unfortunate. But the PRs must keep
flowing until we finally wean off of OpenStack.