### PR TITLE
compose: Check for packages after processing includes

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -74,12 +74,6 @@ fn treefile_parse_yaml<R: io::Read>(input: R, arch: Option<&str>) -> io::Result<
     if let Some(arch_pkgs) = arch_pkgs {
         pkgs.extend_from_slice(&whitespace_split_packages(&arch_pkgs));
     }
-    if pkgs.len() == 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("Missing 'packages' entry"),
-        ));
-    };
 
     treefile.packages = Some(pkgs);
     Ok(treefile)

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1142,6 +1142,11 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
           return FALSE;
       }
   }
+
+  if (packages->len == 0)
+    return glnx_throw (error, "Missing 'packages' entry");
+
+  /* make NULL-terminated */
   g_ptr_array_add (packages, NULL);
 
   { glnx_unref_object JsonGenerator *generator = json_generator_new ();


### PR DESCRIPTION
Otherwise we risk rejecting perfectly valid treefiles. E.g.
fedora-atomic only defines packages in the `-base` file. Let's just move
the check to after having processed all the includes, right where we
collate packages from all the various entries.

The FAHC treecompose is hitting this right now.