### PR TITLE
upgrader: reuse existing rpmdb checkout if available

### DIFF
--- a/src/libpriv/rpmostree-origin.c
+++ b/src/libpriv/rpmostree-origin.c
@@ -334,7 +334,10 @@ rpmostree_origin_get_unconfigured_state (RpmOstreeOrigin *origin)
 
 /* Determines whether the origin hints at local assembly being required. In some
  * cases, no assembly might actually be required (e.g. if requested packages are
- * already in the base). */
+ * already in the base). IOW:
+ *    FALSE --> definitely does not require local assembly
+ *    TRUE  --> maybe requires assembly, need to investigate further by doing work
+ */
 gboolean
 rpmostree_origin_may_require_local_assembly (RpmOstreeOrigin *origin)
 {

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -107,6 +107,13 @@ rpmostree_get_refsack_for_root (int              dfd,
                                 const char      *path,
                                 GError         **error);
 
+gboolean
+rpmostree_get_base_refsack_for_root (int                dfd,
+                                     const char        *path,
+                                     RpmOstreeRefSack **out_sack,
+                                     GCancellable      *cancellable,
+                                     GError           **error);
+
 RpmOstreeRefSack *
 rpmostree_get_base_refsack_for_commit (OstreeRepo                *repo,
                                        const char                *ref,

--- a/tests/vmcheck/test-db.sh
+++ b/tests/vmcheck/test-db.sh
@@ -78,7 +78,7 @@ check_diff "$pending_csum" "" \
 check_not_diff "--base" "" pkg-to-
 
 # now let's make the pending csum become an update
-vm_cmd ostree commit -b vmcheck --tree=ref=$pending_csum
+vm_ostree_commit_layered_as_base $pending_csum vmcheck
 vm_rpmostree cleanup -p
 vm_rpmostree upgrade
 pending_csum=$(vm_get_pending_csum)

--- a/tests/vmcheck/test-download-only.sh
+++ b/tests/vmcheck/test-download-only.sh
@@ -138,7 +138,7 @@ echo "ok offline local RPM install"
 # synthesize update with foobar and barbaz builtin
 pending=$(vm_get_deployment_info 0 checksum)
 $REMOTE_OSTREE pull-local /ostree/repo $pending
-$REMOTE_OSTREE commit -b vmcheck --tree=ref=$pending
+vm_ostree_repo_commit_layered_as_base $remote_repo $pending vmcheck
 vm_rpmostree cleanup -prmb
 vm_rpmostree rebase --remote vmcheck_remote
 vm_build_rpm_repo_mode skip foobar version 2.0

--- a/tests/vmcheck/test-layering-basic-1.sh
+++ b/tests/vmcheck/test-layering-basic-1.sh
@@ -168,7 +168,7 @@ assert_not_file_has_content out.txt __db
 echo "ok no leftover rpmdb files"
 
 # upgrade to a layer with foo already builtin
-vm_cmd ostree commit -b vmcheck --tree=ref=$booted_csum
+vm_ostree_commit_layered_as_base $booted_csum vmcheck
 vm_rpmostree upgrade
 vm_build_rpm bar conflicts foo
 if vm_rpmostree install bar &> err.txt; then

--- a/tests/vmcheck/test-override-local-replace.sh
+++ b/tests/vmcheck/test-override-local-replace.sh
@@ -49,7 +49,7 @@ vm_cmd ostree refs $(vm_get_deployment_info 0 checksum) \
 vm_rpmostree cleanup -p
 
 # upgrade to new commit with foo in the base layer
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo_and_bar
+vm_ostree_commit_layered_as_base vmcheck_tmp/with_foo_and_bar vmcheck
 vm_rpmostree upgrade
 vm_reboot
 if ! vm_has_packages foo bar fooext; then
@@ -143,20 +143,20 @@ echo "ok override reset --all"
 vm_rpmostree cleanup -p
 
 # test inactive replacements
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo_and_bar
+vm_ostree_commit_layered_as_base vmcheck_tmp/with_foo_and_bar vmcheck
 vm_rpmostree upgrade
 vm_rpmostree override replace $YUMREPO/bar-0.9-1.x86_64.rpm
 vm_assert_status_jq \
   '.deployments[0]["base-local-replacements"]|length == 1' \
   '.deployments[0]["requested-base-local-replacements"]|length == 1'
 assert_replaced_local_pkg bar-1.0-1.x86_64 bar-0.9-1.x86_64
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/without_foo_and_bar
+vm_ostree_commit_layered_as_base vmcheck_tmp/without_foo_and_bar vmcheck
 vm_rpmostree upgrade
 vm_assert_status_jq \
   '.deployments[0]["base-local-replacements"]|length == 0' \
   '.deployments[0]["requested-base-local-replacements"]|length == 1' \
   '.deployments[0]["requested-base-local-replacements"]|index("bar-0.9-1.x86_64") >= 0'
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo_and_bar
+vm_ostree_commit_layered_as_base vmcheck_tmp/with_foo_and_bar vmcheck
 vm_rpmostree upgrade
 vm_assert_status_jq \
   '.deployments[0]["base-local-replacements"]|length == 1' \
@@ -165,7 +165,7 @@ assert_replaced_local_pkg bar-1.0-1.x86_64 bar-0.9-1.x86_64
 echo "ok active -> inactive -> active override replace"
 
 # make sure we can reset it while it's inactive
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/without_foo_and_bar
+vm_ostree_commit_layered_as_base vmcheck_tmp/without_foo_and_bar vmcheck
 vm_rpmostree upgrade
 vm_assert_status_jq \
   '.deployments[0]["base-local-replacements"]|length == 0' \
@@ -182,7 +182,7 @@ vm_rpmostree cleanup -p
 # try both local package layering and local replacements to make sure fd sending
 # doesn't get mixed up; and also remove a package at the same time
 vm_build_rpm baz
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo_and_bar
+vm_ostree_commit_layered_as_base vmcheck_tmp/with_foo_and_bar vmcheck
 vm_rpmostree upgrade
 vm_rpmostree override replace $YUMREPO/bar-0.9-1.x86_64.rpm \
                        --install $YUMREPO/baz-1.0-1.x86_64.rpm \

--- a/tests/vmcheck/test-override-replace-2.sh
+++ b/tests/vmcheck/test-override-replace-2.sh
@@ -76,7 +76,7 @@ vm_cmd ostree refs $(vm_get_deployment_info 0 checksum) \
 vm_rpmostree cleanup -p
 
 # upgrade to new commit with foo in the base layer
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo_and_bar
+vm_ostree_commit_layered_as_base vmcheck_tmp/with_foo_and_bar vmcheck
 vm_rpmostree upgrade
 vm_reboot
 echo "ok setup"

--- a/tests/vmcheck/test-reset.sh
+++ b/tests/vmcheck/test-reset.sh
@@ -29,7 +29,7 @@ vm_build_rpm foo
 vm_rpmostree install foo
 vm_cmd ostree refs $(vm_get_pending_csum) --create vmcheck_tmp/with_foo
 vm_rpmostree cleanup -p
-vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo
+vm_ostree_commit_layered_as_base vmcheck_tmp/with_foo vmcheck
 vm_rpmostree upgrade
 
 # now do some layering, overrides, and initramfs


### PR DESCRIPTION
This allows rpm-ostree to avoid checking out the tree to finalize which overlays and overrides are valid. E.g.:

```
# rpm-ostree install glibc-2.27-30.fc28.x86_64.rpm
error: Package 'glibc-2.27-30.fc28.x86_64' is already in the base
```

(Notice no `Checking out ...` message.)

Also makes the issue described in #1287 a bit more bearable, i.e. changes purely to the origin don't require a checkout anymore:

```
# rpm-ostree install tmux --allow-inactive
Inactive requests:
  tmux (already provided by tmux-2.7-1.fc28.x86_64)
Copying /etc changes: 19 modified, 0 removed, 53 added
Transaction complete; bootconfig swap: yes; deployment count change: 1
Freed: 1.3 MB (pkgcache branches: 1)
Run "systemctl reboot" to start a reboot
```