### PR TITLE
Fix segmentation fault when checking passwd and group files in --force-nocache

### DIFF
--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -456,11 +456,20 @@ rpmostree_str_has_prefix_in_ptrarray (const char *str,
   return rpmostree_str_has_prefix_in_strv (str, (char**)prefixes->pdata, prefixes->len);
 }
 
-/* Like g_strv_contains() but for ptrarray */
+/**
+ * rpmostree_str_ptrarray_contains:
+ *
+ * Like g_strv_contains() but for ptrarray.
+ * Handles strs==NULL as an empty array.
+ */
 gboolean
 rpmostree_str_ptrarray_contains (GPtrArray  *strs,
                                  const char *str)
 {
+  g_assert (str);
+  if (!strs)
+    return FALSE;
+
   guint n = strs->len;
   for (guint i = 0; i < n; i++)
     {


### PR DESCRIPTION
This fixes #1494. WIP as the commits need to be squashed.

**Notes**
- could alternatively allocate array at initialization https://github.com/projectatomic/rpm-ostree/blob/master/src/libpriv/rpmostree-passwd-util.c#L234 - but did not do this in the case that there is an early return from `rpmostree_check_passwd_groups` - the allocation would not be needed
- need to verify things work as expected when the `ignore-removed-*` fields and `check-*` fields are set (with different check settings) (done)
- will squash the two commits before merging - the first commit is an initial implementation that checks for NULL  in rpmostree_str_ptrarray_contains