### PR TITLE
app: Add support for passing URLs to RPMs

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -98,9 +98,9 @@ $(librpmostree_rust_path): Makefile $(LIBRPMOSTREE_RUST_SRCS)
 	  $(cargo) build --verbose $${frozen} $(CARGO_RELEASE_ARGS)
 EXTRA_DIST += $(LIBRPMOSTREE_RUST_SRCS) rust/Cargo.lock
 
-rpm_ostree_CFLAGS += -Irust/include
+rpm_ostree_CFLAGS += -Irust/include $(PKGDEP_RPMOSTREE_RS_CFLAGS)
 rpm_ostree_SOURCES += rust/include/librpmostree-rust.h
-rpm_ostree_LDADD += $(librpmostree_rust_path)
+rpm_ostree_LDADD += $(librpmostree_rust_path) $(PKGDEP_RPMOSTREE_RS_LIBS)
 rustfmt:
 	rustfmt $(LIBRPMOSTREE_RUST_SRCS)
 # Outside the ifdef, otherwise automake complains

--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,13 @@ PKG_CHECK_MODULES(PKGDEP_RPMOSTREE, [gio-unix-2.0 >= 2.50.0 json-glib-1.0
 				     polkit-gobject-1
 				     rpm librepo libsolv
 				     libarchive])
+
+# We just keep rust-specific deps separate for better tracking
+# The `libcurl` one is redundant since we already require it for libostree. `openssl`
+# is required by libcurl anyway, but we need to link to it directly too because
+# curl-rust uses it.
+PKG_CHECK_MODULES(PKGDEP_RPMOSTREE_RS, [libcurl openssl])
+
 dnl bundled libdnf
 PKGDEP_RPMOSTREE_CFLAGS="-I $(pwd)/libdnf -I $(pwd)/libdnf-build $PKGDEP_RPMOSTREE_CFLAGS"
 PKGDEP_RPMOSTREE_LIBS="-L$(pwd)/libdnf-build/libdnf -ldnf $PKGDEP_RPMOSTREE_LIBS"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,6 +14,7 @@ gio-sys = "0.6.0"
 glib = "0.5.0"
 tempfile = "3.0.3"
 openat = "0.1.15"
+curl = "0.4.14"
 
 [lib]
 name = "rpmostree_rust"

--- a/rust/include/rpmostree-rust.h
+++ b/rust/include/rpmostree-rust.h
@@ -33,3 +33,5 @@ const char *rpmostree_rs_treefile_get_rojig_spec_path (RpmOstreeRsTreefile *tf);
 
 void rpmostree_rs_treefile_free (RpmOstreeRsTreefile *tf);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RpmOstreeRsTreefile, rpmostree_rs_treefile_free);
+
+int rpmostree_rs_download_to_fd (const char *url, GError **error);

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+use std::{fs, io};
+use std::io::prelude::*;
+use tempfile;
+
+use curl::easy::Easy;
+
+pub fn download_url_to_tmpfile(url: &str) -> io::Result<fs::File> {
+    let mut tmpf = tempfile::tempfile()?;
+    {
+        let mut output = io::BufWriter::new(&mut tmpf);
+        let mut handle = Easy::new();
+        handle.fail_on_error(true)?;
+        handle.url(url)?;
+
+        let mut transfer = handle.transfer();
+        transfer.write_function(|data| {
+            output.write_all(data).and(Ok(data.len())).or(Ok(0))
+        })?;
+        transfer.perform()?;
+    }
+
+    tmpf.seek(io::SeekFrom::Start(0))?;
+    Ok(tmpf)
+}

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -27,6 +27,7 @@ pub fn download_url_to_tmpfile(url: &str) -> io::Result<fs::File> {
     {
         let mut output = io::BufWriter::new(&mut tmpf);
         let mut handle = Easy::new();
+        handle.follow_location(true)?;
         handle.fail_on_error(true)?;
         handle.url(url)?;
 

--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -1049,7 +1049,10 @@ rpmostree_sort_pkgs_strv (const char *const* pkgs,
           g_print ("Downloading '%s'... ", *pkg);
           glnx_autofd int fd = rpmostree_rs_download_to_fd (*pkg, error);
           if (fd < 0)
-            return FALSE;
+            {
+              g_print ("failed!\n");
+              return FALSE;
+            }
           g_print ("done!\n");
 
           int idx = g_unix_fd_list_append (fd_list, fd, error);

--- a/tests/vmcheck/test-override-kernel.sh
+++ b/tests/vmcheck/test-override-kernel.sh
@@ -32,18 +32,15 @@ fi
 
 # Test that we can override the kernel.  For ease of testing
 # I just picked the "gold" F28 kernel.
-vm_cmd 'curl -sS -L \
-  -O https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/k/kernel-4.16.3-301.fc28.x86_64.rpm \
-  -O https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/k/kernel-core-4.16.3-301.fc28.x86_64.rpm \
-  -O https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/k/kernel-modules-4.16.3-301.fc28.x86_64.rpm \
-  -O https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/k/kernel-modules-extra-4.16.3-301.fc28.x86_64.rpm'
 current=$(vm_get_booted_csum)
 vm_cmd rpm-ostree db list "${current}" > current-dblist.txt
 assert_not_file_has_content current-dblist.txt 'kernel-4.16.3-301.fc28'
 grep -E '^ kernel-4' current-dblist.txt  | sed -e 's,^ *,,' > orig-kernel.txt
 assert_streq "$(wc -l < orig-kernel.txt)" "1"
 orig_kernel=$(cat orig-kernel.txt)
-vm_rpmostree override replace ./kernel*4.16.3*.rpm
+URL_ROOT="https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/k"
+vm_rpmostree override replace \
+  "$URL_ROOT/kernel{,-core,-modules{,-extra}}-4.16.3-301.fc28.x86_64.rpm"
 new=$(vm_get_pending_csum)
 vm_cmd rpm-ostree db list "${new}" > new-dblist.txt
 assert_file_has_content_literal new-dblist.txt 'kernel-4.16.3-301.fc28'


### PR DESCRIPTION
This allows one to use URLs wherever RPM filenames were supported before, e.g.

```
$ rpm-ostree install \
    https://kojipkgs.fedoraproject.org//packages/ltrace/0.7.91/24.fc27/x86_64/ltrace-0.7.91-24.fc27.x86_64.rpm
Downloading 'https://kojipkgs.fedoraproject.org//packages/ltrace/0.7.91/24.fc27/x86_64/ltrace-0.7.91-24.fc27.x86_64.rpm'... done!
Checking out tree 106a709... done
...
```

or

```
$ rpm-ostree override replace \
    https://kojipkgs.fedoraproject.org//packages/podman/0.7.4/4.git80612fb.fc28/x86_64/podman-0.7.4-4.git80612fb.fc28.x86_64.rpm
...
```

What's neat about this is that we download to an `O_TMPFILE | O_EXCL` and then directly pass on ownership of that fd to the daemon.