### PR TITLE
build-sys: Hard require Rust

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -130,8 +130,6 @@ env:
 # since https://github.com/projectatomic/rpm-ostree/pull/875
 tests:
   - docker run --privileged --rm
-    -e CONFIGOPTS=--enable-rust
-    -e CI_PKGS=cargo
     -e RPMOSTREE_COMPOSE_TEST_FILTER
     -e RPMOSTREE_COMPOSE_TEST_USE_REPOS=/etc/yum.repos.d.host
     -v /etc/yum.repos.d:/etc/yum.repos.d.host:ro

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -72,9 +72,8 @@ rpm_ostree_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-fvisibility=hidden -DPKGLIBDIR=\"$(pkglibdir)\" $(PKGDEP_RPMOSTREE_CFLAGS)
 rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la librpmostree-1.la librpmostreed.la
 # https://github.com/ostreedev/ostree/commit/1f832597fc83fda6cb8daf48c4495a9e1590774c
-if ENABLE_RUST
+# https://github.com/rust-lang/rust/issues/47714
 rpm_ostree_LDADD += -ldl
-endif
 
 privdatadir=$(pkglibdir)
 privdata_DATA = src/app/rpm-ostree-0-integration.conf
@@ -86,7 +85,6 @@ if BUILDOPT_NEW_NAME
 INSTALL_DATA_HOOKS += install-bin-hook
 endif
 
-if ENABLE_RUST
 librpmostree_rust_path = @abs_top_builddir@/target/@RUST_TARGET_SUBDIR@/librpmostree_rust.a
 # If the target directory exists, use --frozen; we don't
 # want to (by default) touch the Internet during builds here.
@@ -105,6 +103,5 @@ rpm_ostree_SOURCES += rust/include/librpmostree-rust.h
 rpm_ostree_LDADD += $(librpmostree_rust_path)
 rustfmt:
 	rustfmt $(LIBRPMOSTREE_RUST_SRCS)
-endif # ENABLE_RUST
 # Outside the ifdef, otherwise automake complains
 .PHONY: rustfmt

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,6 @@ TYPELIBS = $(GIRS:.gir=.typelib)
 # but have been adapted to non-recursive Automake, and additionally
 # the "cargo vendor" bits for us live in packaging/Makefile.dist-packaging.
 .PHONY: check-local-cargo clean-local-cargo use-git-not-dist-hook
-if ENABLE_RUST
 if RUST_DEBUG
 CARGO_RELEASE_ARGS=
 else
@@ -94,8 +93,6 @@ use-git-not-dist-hook:
 
 DIST_HOOKS += use-git-not-dist-hook
 GITIGNOREFILES += target/
-
-endif # end ENABLE_RUST
 
 include libglnx/Makefile-libglnx.am.inc
 noinst_LTLIBRARIES += libglnx.la

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -24,6 +24,7 @@ fi
 pkg_upgrade
 pkg_install_builddeps rpm-ostree
 # Temporary until spec file changes are upstreamed
+pkg_install cargo
 pkg_install_if_os fedora python3-sphinx python3-devel
 # Mostly dependencies for tests
 pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML \

--- a/configure.ac
+++ b/configure.ac
@@ -194,38 +194,32 @@ AS_IF([test x$enable_staged = xyes], [
   AC_DEFINE(BUILDOPT_STAGE_DEPLOYMENTS, 1, [Define if we are staging deployments])
 ])
 
-AC_ARG_ENABLE(rust,
-              AS_HELP_STRING([--enable-rust],
-                             [Compile Rust features (e.g. compose tree --yaml)]),,
-              [enable_rust=no; rust_debug_release=no])
+AC_PATH_PROG([cargo], [cargo])
+AS_IF([test -z "$cargo"], [AC_MSG_ERROR([cargo is required for --enable-rust])])
+AC_PATH_PROG([rustc], [rustc])
+AS_IF([test -z "$rustc"], [AC_MSG_ERROR([rustc is required for --enable-rust])])
+AC_DEFINE(HAVE_RUST, 1, [Define if we are building with Rust])
 
-AS_IF([test x$enable_rust = xyes], [
-    AC_PATH_PROG([cargo], [cargo])
-    AS_IF([test -z "$cargo"], [AC_MSG_ERROR([cargo is required for --enable-rust])])
-    AC_PATH_PROG([rustc], [rustc])
-    AS_IF([test -z "$rustc"], [AC_MSG_ERROR([rustc is required for --enable-rust])])
-    AC_DEFINE(HAVE_RUST, 1, [Define if we are building with Rust])
+dnl These bits based on gnome:librsvg/configure.ac
+dnl By default, we build in public release mode.
+AC_ARG_ENABLE(rust-debug,
+  AC_HELP_STRING([--enable-rust-debug],
+    [Build Rust code with debugging information [default=no]]),
+    [rust_debug_release=$enableval],
+    [rust_debug_release=release])
 
-   dnl These bits based on gnome:librsvg/configure.ac
-
-   dnl By default, we build in public release mode.
-   AC_ARG_ENABLE(rust-debug,
-      AC_HELP_STRING([--enable-rust-debug],
-       [Build Rust code with debugging information [default=no]]),
-       [rust_debug_release=$enableval],
-       [rust_debug_release=release])
-
-   AC_MSG_CHECKING(whether to build Rust code with debugging information)
-   if test "x$rust_debug_release" = "xyes" ; then
-      rust_debug_release=debug
-      AC_MSG_RESULT(yes)
-   else
-      AC_MSG_RESULT(no)
-   fi
-   RUST_TARGET_SUBDIR=${rust_debug_release}
-   AC_SUBST([RUST_TARGET_SUBDIR])
-])
+  AC_MSG_CHECKING(whether to build Rust code with debugging information)
+  if test "x$rust_debug_release" = "xyes" ; then
+    rust_debug_release=debug
+    AC_MSG_RESULT(yes)
+  else
+    AC_MSG_RESULT(no)
+  fi
+  RUST_TARGET_SUBDIR=${rust_debug_release}
+  AC_SUBST([RUST_TARGET_SUBDIR])
 AM_CONDITIONAL(RUST_DEBUG, [test "x$rust_debug_release" = "xdebug"])
+# Unconditional now
+enable_rust=yes
 AM_CONDITIONAL(ENABLE_RUST, [test x$enable_rust = xyes])
 if test x$enable_rust != xno; then RPM_OSTREE_FEATURES="$RPM_OSTREE_FEATURES rust"; fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -198,7 +198,6 @@ AC_PATH_PROG([cargo], [cargo])
 AS_IF([test -z "$cargo"], [AC_MSG_ERROR([cargo is required for --enable-rust])])
 AC_PATH_PROG([rustc], [rustc])
 AS_IF([test -z "$rustc"], [AC_MSG_ERROR([rustc is required for --enable-rust])])
-AC_DEFINE(HAVE_RUST, 1, [Define if we are building with Rust])
 
 dnl These bits based on gnome:librsvg/configure.ac
 dnl By default, we build in public release mode.
@@ -208,29 +207,27 @@ AC_ARG_ENABLE(rust-debug,
     [rust_debug_release=$enableval],
     [rust_debug_release=release])
 
-  AC_MSG_CHECKING(whether to build Rust code with debugging information)
-  if test "x$rust_debug_release" = "xyes" ; then
-    rust_debug_release=debug
-    AC_MSG_RESULT(yes)
-  else
-    AC_MSG_RESULT(no)
-  fi
-  RUST_TARGET_SUBDIR=${rust_debug_release}
-  AC_SUBST([RUST_TARGET_SUBDIR])
-AM_CONDITIONAL(RUST_DEBUG, [test "x$rust_debug_release" = "xdebug"])
-# Unconditional now
-enable_rust=yes
-AM_CONDITIONAL(ENABLE_RUST, [test x$enable_rust = xyes])
-if test x$enable_rust != xno; then RPM_OSTREE_FEATURES="$RPM_OSTREE_FEATURES rust"; fi
-
-dnl Try to automatically determine cmake type from CFLAGS
+AC_MSG_CHECKING(whether to build in debug mode)
+debug_release=no
 if $(echo $CFLAGS |grep -q -E "(-O0|-Og)"); then
-  cmake_args="-DCMAKE_BUILD_TYPE=Debug"
-  export cmake_args
-else
-  cmake_args=-DCMAKE_BUILD_TYPE=RelWithDebugInfo
-  export cmake_args
+  debug_release=yes
 fi
+AC_MSG_RESULT($debug_release)
+RUST_TARGET_SUBDIR=release
+if test ${debug_release} = yes; then
+  RUST_TARGET_SUBDIR=debug
+fi
+AC_SUBST([RUST_TARGET_SUBDIR])
+AM_CONDITIONAL(RUST_DEBUG, [test "x$rust_debug_release" = "xdebug"])
+dnl Unconditional now.
+RPM_OSTREE_FEATURES="$RPM_OSTREE_FEATURES rust"
+
+dnl And propagate the release/debug type to cmake
+cmake_args=-DCMAKE_BUILD_TYPE=RelWithDebugInfo
+if test ${debug_release} = yes; then
+  cmake_args="-DCMAKE_BUILD_TYPE=Debug"
+fi
+export cmake_args
 
 dnl I picked /usr/libexec/rpm-ostree just because we need an
 dnl arbitrary path - we don't actually install there.
@@ -266,5 +263,5 @@ echo "
     introspection:                           $found_introspection
     bubblewrap:                              $with_bubblewrap
     gtk-doc:                                 $enable_gtk_doc
-    rust:                                    $enable_rust
+    rust:                                    (always enabled now)
 "


### PR DESCRIPTION
As something that manages your base operating system, we care
about reliability, predictability, as well as performance and
low-level access to native operating system facilities.  The
C programming language is great for the latter two, but fails
at providing a truly memory-safe environment.  Rust is fairly
unique in providing a language that doesn't carry a runtime,
so we can gradually "oxidize" and convert our C code without
imposing additional overhead.  It's also got a lot of modern
design niceties, like not having a null pointer.

Let's pull the trigger here and hard require Rust.  It's the
programming language I personally want to be primarily writing in for
years to come.

This is also in line with a recent trend of reducing our
experimental/optional matrix.
