### PR TITLE
Stabilize `stage` automatic update policy

### DIFF
--- a/man/rpm-ostreed.conf.xml
+++ b/man/rpm-ostreed.conf.xml
@@ -71,11 +71,15 @@ Boston, MA 02111-1307, USA.
         <term><varname>AutomaticUpdatePolicy=</varname></term>
 
         <listitem>
-        <para>Controls the automatic update policy. Currently "none" or "check".
+        <para>Controls the automatic update policy. Currently "none", "check", or "stage".
         "none" disables automatic updates. "check" downloads just enough metadata to check
         for updates and display them in <command>rpm-ostree status</command>. Defaults to
         "none". The <citerefentry><refentrytitle>rpm-ostreed-automatic.timer</refentrytitle><manvolnum>8</manvolnum></citerefentry>
         unit determines the actual frequency of updates.</para>
+        <para>Finally, the "stage" policy downloads and unpacks the update, performing
+        any package layering.  Only a small amount of work is left to be performed at
+        shutdown time via the <literal>ostree-finalize-staged.service</literal> systemd unit.
+        </para>
         </listitem>
       </varlistentry>
       <varlistentry>

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -112,7 +112,7 @@ rpmostree_builtin_upgrade (int             argc,
                                 cancellable, &os_proxy, error))
     return FALSE;
 
-  /* Print a notice if ex-stage updates are enabled and the user
+  /* Print a notice if stage updates are enabled and the user
    * has requested an update manually - in that case we've
    * already doing basically all of `upgrade` here automatically in
    * the background.
@@ -120,7 +120,7 @@ rpmostree_builtin_upgrade (int             argc,
   if (!opt_automatic)
     {
       const char *policy = rpmostree_sysroot_get_automatic_update_policy (sysroot_proxy);
-      if (policy && g_str_equal (policy, "ex-stage"))
+      if (policy && g_str_equal (policy, "stage"))
         g_print ("note: automatic updates (%s) are enabled\n", policy);
     }
 

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -56,7 +56,7 @@
     <method name="ReloadConfig">
     </method>
 
-    <!-- none, check, ex-stage -->
+    <!-- none, check, stage -->
     <property name="AutomaticUpdatePolicy" type="s" access="read"/>
 
     <method name="CreateOSName">

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -1003,7 +1003,7 @@ rpmostree_auto_update_policy_to_str (RpmostreedAutomaticUpdatePolicy policy,
     case RPMOSTREED_AUTOMATIC_UPDATE_POLICY_CHECK:
       return "check";
     case RPMOSTREED_AUTOMATIC_UPDATE_POLICY_STAGE:
-      return "ex-stage";
+      return "stage";
     default:
       return glnx_null_throw (error, "Invalid policy value %u", policy);
     }
@@ -1019,7 +1019,7 @@ rpmostree_str_to_auto_update_policy (const char *str,
     *out_policy = RPMOSTREED_AUTOMATIC_UPDATE_POLICY_NONE;
   else if (g_str_equal (str, "check"))
     *out_policy = RPMOSTREED_AUTOMATIC_UPDATE_POLICY_CHECK;
-  else if (g_str_equal (str, "ex-stage"))
+  else if (g_str_equal (str, "stage") || g_str_equal (str, "ex-stage"))
     *out_policy = RPMOSTREED_AUTOMATIC_UPDATE_POLICY_STAGE;
   else
     return glnx_throw (error, "Invalid value for AutomaticUpdatePolicy: '%s'", str);

--- a/tests/vmcheck/test-autoupdate-stage.sh
+++ b/tests/vmcheck/test-autoupdate-stage.sh
@@ -34,9 +34,13 @@ vm_rpmostree cleanup -m
 
 vm_rpmostree status > status.txt
 assert_file_has_content status.txt 'AutomaticUpdates: disabled'
+vm_change_update_policy stage
+vm_rpmostree status > status.txt
+assert_file_has_content_literal status.txt 'AutomaticUpdates: stage; rpm-ostreed-automatic.timer: inactive'
+# And test that we still support "ex-stage"
 vm_change_update_policy ex-stage
 vm_rpmostree status > status.txt
-assert_file_has_content_literal status.txt 'AutomaticUpdates: ex-stage; rpm-ostreed-automatic.timer: inactive'
+assert_file_has_content_literal status.txt 'AutomaticUpdates: stage; rpm-ostreed-automatic.timer: inactive'
 
 vm_rpmostree upgrade --trigger-automatic-update-policy
 vm_assert_status_jq ".deployments[1][\"booted\"]" \
@@ -45,7 +49,7 @@ vm_assert_status_jq ".deployments[1][\"booted\"]" \
 vm_rpmostree status -v > status.txt
 assert_file_has_content status.txt "Staged: yes"
 vm_rpmostree upgrade > upgrade.txt
-assert_file_has_content_literal upgrade.txt 'note: automatic updates (ex-stage) are enabled'
+assert_file_has_content_literal upgrade.txt 'note: automatic updates (stage) are enabled'
 # And ensure that we have new content in /etc after staging
 vm_cmd echo new-content-in-etc \> /etc/somenewfile
 vm_reboot


### PR DESCRIPTION
Now that staging is the default, there's no reason for this
policy not to be stable too.
