### PR TITLE
Add `recommends` to treefile (default on)

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -60,6 +60,8 @@ It supports the following parameters:
  * `bootstrap_packages`: Array of strings, optional: Deprecated; you should
     now just include this set in the main `packages` array.
 
+ * `recommends`: boolean, optional: Install `Recommends`, defaults to `true`.
+
  * `units`: Array of strings, optional: Systemd units to enable by default
 
  * `default_target`: String, optional: Set the default systemd target

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -261,6 +261,8 @@ pub struct TreeComposeConfig {
 
     // Content installation opts
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommends: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub documentation: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "install-langs")]

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -230,6 +230,22 @@ get_enabled_rpmmd_repos (DnfContext *dnfctx, DnfRepoEnabled enablement)
   return g_steal_pointer (&ret);
 }
 
+/* Get a bool from @keyfile, adding it to @builder */
+static void
+tf_bind_boolean (GKeyFile *keyfile,
+                 GVariantBuilder *builder,
+                 const char *name,
+                 gboolean default_value)
+{
+  gboolean v = default_value;
+  g_autofree char *value_str = g_key_file_get_value (keyfile, "tree", name, NULL);
+
+  if (value_str)
+    v = g_key_file_get_boolean (keyfile, "tree", name, NULL);
+
+  g_variant_builder_add (builder, "{sv}", name, g_variant_new_boolean (v));
+}
+
 RpmOstreeTreespec *
 rpmostree_treespec_new_from_keyfile (GKeyFile   *keyfile,
                                      GError    **error)
@@ -273,14 +289,8 @@ rpmostree_treespec_new_from_keyfile (GKeyFile   *keyfile,
   if (g_key_file_get_boolean (keyfile, "tree", "skip-sanity-check", NULL))
     g_variant_builder_add (&builder, "{sv}", "skip-sanity-check", g_variant_new_boolean (TRUE));
 
-  { gboolean documentation = TRUE;
-    g_autofree char *value = g_key_file_get_value (keyfile, "tree", "documentation", NULL);
-
-    if (value)
-      documentation = g_key_file_get_boolean (keyfile, "tree", "documentation", NULL);
-
-    g_variant_builder_add (&builder, "{sv}", "documentation", g_variant_new_boolean (documentation));
-  }
+  tf_bind_boolean (keyfile, &builder, "documentation", TRUE);
+  tf_bind_boolean (keyfile, &builder, "recommends", TRUE);
 
   ret->spec = g_variant_builder_end (&builder);
   ret->dict = g_variant_dict_new (ret->spec);
@@ -1837,11 +1847,17 @@ rpmostree_context_prepare (RpmOstreeContext *self,
   if (!self->rojig_pure)
     {
       HyGoal goal = dnf_context_get_goal (dnfctx);
+      DnfGoalActions actions = DNF_INSTALL | DNF_ALLOW_UNINSTALL;
+
+      gboolean recommends;
+      g_assert (g_variant_dict_lookup (self->spec->dict, "recommends", "b", &recommends));
+      if (!recommends)
+        actions |= DNF_IGNORE_WEAK_DEPS;
 
       rpmostree_output_task_begin ("Resolving dependencies");
 
       /* XXX: consider a --allow-uninstall switch? */
-      if (!dnf_goal_depsolve (goal, DNF_INSTALL | DNF_ALLOW_UNINSTALL, error) ||
+      if (!dnf_goal_depsolve (goal, actions, error) ||
           !check_goal_solution (self, removed_pkgnames, replaced_nevras, error))
         {
           rpmostree_output_task_end ("failed");

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -238,9 +238,7 @@ tf_bind_boolean (GKeyFile *keyfile,
                  gboolean default_value)
 {
   gboolean v = default_value;
-  g_autofree char *value_str = g_key_file_get_value (keyfile, "tree", name, NULL);
-
-  if (value_str)
+  if (g_key_file_has_key (keyfile, "tree", name, NULL))
     v = g_key_file_get_boolean (keyfile, "tree", name, NULL);
 
   g_variant_builder_add (builder, "{sv}", name, g_variant_new_boolean (v));

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -68,5 +68,8 @@ echo "ok no leftover files"
 ostree --repo=${repobuild} show ${treeref} \
   --print-metadata-key rpmostree.rpmdb.pkglist > pkglist.txt
 assert_file_has_content pkglist.txt 'systemd'
+# This is currently a Recommends: package.  If you change this, please
+# also change the corresponding test in misc-tweaks.sh.
+assert_file_has_content pkglist.txt 'systemd-bootchart'
 echo "ok compose pkglist"
 }

--- a/tests/compose-tests/test-misc-tweaks.sh
+++ b/tests/compose-tests/test-misc-tweaks.sh
@@ -14,6 +14,7 @@ pysetjsonmember "documentation" "False"
 # $ rpm -qlv systemd|grep -F 'system/default.target '
 # lrwxrwxrwx    1 root    root                       16 May 11 06:59 /usr/lib/systemd/system/default.target -> graphical.target
 pysetjsonmember "default_target" '"multi-user.target"'
+pysetjsonmember "recommends" 'False'
 pysetjsonmember "units" '["tuned.service"]'
 # And test adding/removing files
 pysetjsonmember "add-files" '[["foo.txt", "/usr/etc/foo.txt"],
@@ -82,3 +83,11 @@ echo "ok remove-from-packages"
 ostree --repo=${repobuild} ls  ${treeref} /tmp > ls.txt
 assert_file_has_content ls.txt 'd01777 0 0      0 /tmp'
 echo "ok /tmp"
+
+ostree --repo=${repobuild} show ${treeref} \
+       --print-metadata-key rpmostree.rpmdb.pkglist > pkglist.txt
+# This is currently a Recommends: package.  If you change this, please
+# also change the corresponding test in libbasic-test.sh.
+assert_file_has_content_literal pkglist.txt 'systemd-'
+assert_not_file_has_content pkglist.txt 'systemd-bootchart'
+echo "ok recommends"


### PR DESCRIPTION
This is for: https://github.com/projectatomic/rpm-ostree/issues/718
But I'm not going to close that issue as this only does the server
side, and I think we should support it client side too.

Since I wrote that issue, we ended up skipping the `dnf_transaction_depsolve()`
API, and hence we don't need to block on a libdnf change.  So
this was quite simple.
