### PR TITLE
build: Fix building rust in debug mode

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -71,12 +71,10 @@ rpm_ostree_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/src/app -I$(srcdir)/src/daemon \
 	-I$(srcdir)/src/lib -I$(srcdir)/src/libpriv -I$(libglnx_srcpath) \
 	-fvisibility=hidden -DPKGLIBDIR=\"$(pkglibdir)\" $(PKGDEP_RPMOSTREE_CFLAGS)
 rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la librpmostree-1.la librpmostreed.la
-# https://github.com/ostreedev/ostree/commit/1f832597fc83fda6cb8daf48c4495a9e1590774c
-# https://github.com/rust-lang/rust/issues/47714
-rpm_ostree_LDADD += -ldl
-if RUST_DEBUG
-rpm_ostree_LDADD += -lm
-endif
+# -ldl: https://github.com/ostreedev/ostree/commit/1f832597fc83fda6cb8daf48c4495a9e1590774c
+# -ldl: https://github.com/rust-lang/rust/issues/47714
+# -lm: needed for rand crate in debug mode
+rpm_ostree_LDADD += -ldl -lm
 
 privdatadir=$(pkglibdir)
 privdata_DATA = src/app/rpm-ostree-0-integration.conf

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -74,6 +74,9 @@ rpm_ostree_LDADD = $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la librpmostree-1.l
 # https://github.com/ostreedev/ostree/commit/1f832597fc83fda6cb8daf48c4495a9e1590774c
 # https://github.com/rust-lang/rust/issues/47714
 rpm_ostree_LDADD += -ldl
+if RUST_DEBUG
+rpm_ostree_LDADD += -lm
+endif
 
 privdatadir=$(pkglibdir)
 privdata_DATA = src/app/rpm-ostree-0-integration.conf

--- a/configure.ac
+++ b/configure.ac
@@ -199,24 +199,25 @@ AS_IF([test -z "$cargo"], [AC_MSG_ERROR([cargo is required for --enable-rust])])
 AC_PATH_PROG([rustc], [rustc])
 AS_IF([test -z "$rustc"], [AC_MSG_ERROR([rustc is required for --enable-rust])])
 
+AC_MSG_CHECKING(whether to build in debug mode)
+debug_release=release
+if $(echo $CFLAGS |grep -q -E "(-O0|-Og)"); then
+  debug_release=debug
+fi
+AC_MSG_RESULT($debug_release)
+
 dnl These bits based on gnome:librsvg/configure.ac
 dnl By default, we build in public release mode.
 AC_ARG_ENABLE(rust-debug,
   AC_HELP_STRING([--enable-rust-debug],
     [Build Rust code with debugging information [default=no]]),
     [rust_debug_release=$enableval],
-    [rust_debug_release=release])
+    [rust_debug_release=$debug_release])
+dnl Canonicalize yes/no to debug/release
+AS_IF([test x$rust_debug_release = xno ], [rust_debug_release=release])
+AS_IF([test x$rust_debug_release = xyes ], [rust_debug_release=debug])
 
-AC_MSG_CHECKING(whether to build in debug mode)
-debug_release=no
-if $(echo $CFLAGS |grep -q -E "(-O0|-Og)"); then
-  debug_release=yes
-fi
-AC_MSG_RESULT($debug_release)
-RUST_TARGET_SUBDIR=release
-if test ${debug_release} = yes; then
-  RUST_TARGET_SUBDIR=debug
-fi
+RUST_TARGET_SUBDIR=${rust_debug_release}
 AC_SUBST([RUST_TARGET_SUBDIR])
 AM_CONDITIONAL(RUST_DEBUG, [test "x$rust_debug_release" = "xdebug"])
 dnl Unconditional now.
@@ -224,7 +225,7 @@ RPM_OSTREE_FEATURES="$RPM_OSTREE_FEATURES rust"
 
 dnl And propagate the release/debug type to cmake
 cmake_args=-DCMAKE_BUILD_TYPE=RelWithDebugInfo
-if test ${debug_release} = yes; then
+if test ${debug_release} = debug; then
   cmake_args="-DCMAKE_BUILD_TYPE=Debug"
 fi
 export cmake_args
@@ -263,5 +264,5 @@ echo "
     introspection:                           $found_introspection
     bubblewrap:                              $with_bubblewrap
     gtk-doc:                                 $enable_gtk_doc
-    rust:                                    (always enabled now)
+    rust:                                    $rust_debug_release
 "


### PR DESCRIPTION
When building in `debug` mode, `RUST_DEBUG` was still turned off because
`rust_debug_release` was set to `yes`, not `debug`.

Fix this by tweaking how `--enable-rust-debug` works: when it's *not*
provided, we default to the `$CFLAGS` detection logic. Otherwise, it
overrides it.