### PR TITLE
passwd-util/test: add conversion to sysusers entry

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -46,11 +46,16 @@ tests_check_test_kargs_CPPFLAGS = $(testbin_cppflags)
 tests_check_test_kargs_CFLAGS = $(testbin_cflags)
 tests_check_test_kargs_LDADD = $(testbin_ldadd) libtest.la
 
+tests_check_test_sysusers_CPPFLAGS = $(testbin_cppflags)
+tests_check_test_sysusers_CFLAGS = $(testbin_cflags)
+tests_check_test_sysusers_LDADD = $(testbin_ldadd) libtest.la
+
 uninstalled_test_programs = \
 	tests/check/jsonutil			\
 	tests/check/postprocess			\
 	tests/check/test-utils			\
-	tests/check/test-kargs 			\
+	tests/check/test-kargs			\
+	tests/check/test-sysusers		\
 	$(NULL)
 
 uninstalled_test_scripts = \

--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -299,6 +299,29 @@ rpmostree_groupents2sysusers (GPtrArray  *group_ents,
   return TRUE;
 }
 
+gboolean
+rpmostree_passwd_sysusers2char (GPtrArray *sysusers_entries,
+                                char      **out_content,
+                                GError    **error)
+{
+
+  GString* sysuser_content = g_string_new (NULL);
+  for (int counter = 0; counter < sysusers_entries->len; counter++)
+    {
+      struct sysuser_ent *sysent = sysusers_entries->pdata[counter];
+      const char *shell = sysent->shell ?: "-";
+      const char *gecos = sysent->gecos ?: "-";
+      const char *dir = sysent->dir ?: "-";
+      g_autofree gchar* line_content = g_strjoin (" ", sysent->type, sysent->name,
+                                                  sysent->id, gecos, dir, shell, NULL);
+      g_string_append_printf (sysuser_content, "%s\n", line_content);
+    }
+  if (out_content)
+    *out_content = g_string_free(sysuser_content, FALSE);
+
+  return TRUE;
+}
+
 /* See "man 5 passwd" We just make sure the name and uid/gid match,
    and that none are missing. don't care about GECOS/dir/shell.
 */

--- a/src/libpriv/rpmostree-passwd-util.c
+++ b/src/libpriv/rpmostree-passwd-util.c
@@ -136,6 +136,9 @@ conv_passwd_ent_free (void *vptr)
   struct conv_passwd_ent *ptr = vptr;
 
   g_free (ptr->name);
+  g_free (ptr->pw_gecos);
+  g_free (ptr->pw_dir);
+  g_free (ptr->pw_shell);
   g_free (ptr);
 }
 
@@ -156,8 +159,9 @@ rpmostree_passwd_data2passwdents (const char *data)
       convent->name = g_strdup (ent->pw_name);
       convent->uid  = ent->pw_uid;
       convent->gid  = ent->pw_gid;
-      /* Want to add anymore, like dir? */
-
+      convent->pw_gecos = g_strdup (ent->pw_gecos);
+      convent->pw_dir = g_strdup (ent->pw_dir);
+      convent->pw_shell = g_strdup (ent->pw_shell);
       g_ptr_array_add (ret, convent);
     }
 

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -117,3 +117,8 @@ rpmostree_passwd_data2passwdents (const char *data);
 
 GPtrArray *
 rpmostree_passwd_data2groupents (const char *data);
+
+gboolean
+rpmostree_passwdents2sysusers (GPtrArray *passwd_ents,
+                               GPtrArray **out_sysusers_entries,
+                               GError **error);

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -122,3 +122,7 @@ gboolean
 rpmostree_passwdents2sysusers (GPtrArray *passwd_ents,
                                GPtrArray **out_sysusers_entries,
                                GError **error);
+gboolean
+rpmostree_groupents2sysusers (GPtrArray  *group_ents,
+                              GPtrArray **out_sysusers_entries,
+                              GError    **error);

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -126,3 +126,7 @@ gboolean
 rpmostree_groupents2sysusers (GPtrArray  *group_ents,
                               GPtrArray **out_sysusers_entries,
                               GError    **error);
+gboolean
+rpmostree_passwd_sysusers2char (GPtrArray *sysusers_entries,
+                                char      **out_content,
+                                GError    **error);

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -89,10 +89,22 @@ gboolean
 rpmostree_passwd_complete_rpm_layering (int       rootfs_dfd,
                                         GError  **error);
 
+struct sysuser_ent {
+  const char *type; /* type of sysuser entry, can be 1: u (user) 2: g (group) 3: m (mixed) 4: r (ranged ids) */
+  char *name;
+  char *id;         /* id used by sysuser entry, can be in the form of 1: uid 2:gid 3:uid:gid */
+  char *gecos;      /* user information */
+  char *dir;        /* home directory */
+  char *shell;      /* login shell, default to /sbin/nologin */
+};
+
 struct conv_passwd_ent {
   char *name;
   uid_t uid;
   gid_t gid;
+  char *pw_gecos;   /* user information */
+  char *pw_dir;     /* home directory */
+  char *pw_shell;   /* login shell */
 };
 
 struct conv_group_ent {

--- a/tests/check/test-sysusers.c
+++ b/tests/check/test-sysusers.c
@@ -1,0 +1,77 @@
+#include "config.h"
+#include "libglnx.h"
+#include "rpmostree-util.h"
+#include "rpmostree-json-parsing.h"
+#include "rpmostree-passwd-util.h"
+
+static const gchar *test_passwd[] = {
+  "chrony:x:994:992::/var/lib/chrony:/sbin/nologin",
+  "tcpdump:x:72:72::/:/sbin/nologin",
+  "systemd-timesync:x:993:991:a:/:/sbin/nologin",
+  "cockpit-ws:x:988:987:b:/:/sbin/nologin",
+  NULL
+};
+
+static const gchar *expected_sysuser_passwd_content[] ={
+  "u chrony 994:992 - /var/lib/chrony /sbin/nologin",
+  "u tcpdump 72 - / /sbin/nologin",
+  "u systemd-timesync 993:991 \"a\" / /sbin/nologin",
+  "u cockpit-ws 988:987 \"b\" / /sbin/nologin",
+  NULL
+};
+
+static void
+verify_sysuser_ent_content (GPtrArray       *sysusers_entries,
+                            const gchar     **expected_content)
+{
+  /* Now we do the comparison between the converted output and the expected */
+  for (int counter = 0; counter < sysusers_entries->len; counter++)
+    {
+      g_autofree gchar** sysent_list = g_strsplit (expected_content[counter], " ", -1);
+      struct sysuser_ent *sysuser_ent = sysusers_entries->pdata[counter];
+      const char *shell = sysuser_ent->shell ?: "-";
+      const char *gecos = sysuser_ent->gecos ?: "-";
+      const char *dir = sysuser_ent->dir ?: "-";
+      g_assert (g_str_equal (sysuser_ent->type, (char **)sysent_list[0]));
+      g_assert (g_str_equal (sysuser_ent->name, (char **)sysent_list[1]));
+      g_assert (g_str_equal (sysuser_ent->id, (char **)sysent_list[2]));
+      g_assert (g_str_equal (shell, (char **)sysent_list[5]));
+      g_assert (g_str_equal (gecos, (char **)sysent_list[3]));
+      g_assert (g_str_equal (dir, (char **)sysent_list[4]));
+    }
+}
+
+static void
+setup_sysuser_passwd(const gchar  **test_content,
+                     GPtrArray    **out_entries,
+                     GError       **error)
+{
+  gboolean ret;
+  g_autofree char* passwd_data = g_strjoinv ("\n", (char **)test_content);
+  g_autoptr(GPtrArray) passwd_ents = rpmostree_passwd_data2passwdents (passwd_data);
+  ret = rpmostree_passwdents2sysusers (passwd_ents, out_entries, error);
+  g_assert(ret);
+}
+
+static void
+test_passwd_conversion(void)
+{
+  g_autoptr(GPtrArray) sysusers_entries = NULL;
+  g_autoptr(GError) error = NULL;
+
+  setup_sysuser_passwd (test_passwd, &sysusers_entries, &error);
+  /* Check the pointer array entries after the set up */
+  g_assert (sysusers_entries);
+
+  verify_sysuser_ent_content (sysusers_entries, expected_sysuser_passwd_content);
+}
+
+int
+main (int argc,
+      char *argv[])
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/sysusers/passwd_conversion", test_passwd_conversion);
+  return g_test_run ();
+}


### PR DESCRIPTION
This is a prep PR for #1376, the first 7 commits from there are taken. There should not be any functional changes brought by this commit as the conversion logic for sysusers is not integrated into compose yet. 

The only change happened to the existing logic is some extra fields(`gecos, dir,shell`) are added to `conv_passwd_ent`. 

To briefly summarize, what this PR does so far includes the following:
- sysuser conversion for user entries
- sysuser conversion for group entries
- sorting logic for sysusers entries.
- Unit tests to test for above case.

~**Note**: Mark this as WIP first, will read over the logic once more this afternoon to double check.~