### PR TITLE
build-sys: Propagate verbosity into libdnf

### DIFF
--- a/Makefile-libdnf.am
+++ b/Makefile-libdnf.am
@@ -20,7 +20,7 @@
 # Recurse into libdnf
 ALL_LOCAL_HOOKS += libdnf-local
 libdnf-local:
-	cd libdnf-build && $(MAKE)
+	cd libdnf-build && $(MAKE) $(if $(subst 0,,$(V)),VERBOSE=1,)
 	ln -sf libdnf-build/libdnf/libdnf.so.1 .
 libdnf.so.1: libdnf-local
 CLEANFILES += libdnf.so.1


### PR DESCRIPTION
I'm trying to debug a libdnf build issue with the rpm-injected
`export LDFLAGS='-Wl,-z,relro ...`
and it's very helpful to have `--disable-silent-rules` or `make V=1`
do the right thing automatically for CMake too.
