### PR TITLE
treefile: Support inline `postprocess` element (for inheritance)

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -173,6 +173,16 @@ It supports the following parameters:
 
    Note this does not alter the RPM database, so `rpm -V` will complain.
 
+   If you want to depend on network access, or tools not in the target host,
+   you can use the split-up `rpm-ostree compose install`
+   and `rpm-ostree compose postprocess/commit` commands.
+
+ * `postprocess`: array of string, optional: This is an *inline* script
+   variant of `postprocess-script` that is also an array, so it works
+   correctly with inheritance.  If both `postprocess-script` and `postprocess`
+   are provided, then `postprocess-script` will be executed after all
+   other `postprocess`.
+
  * `include`: string, optional: Path to another treefile which will be
    used as an inheritance base.  The semantics for inheritance are:
    Non-array values in child values override parent values.  Array

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -318,7 +318,11 @@ pub struct TreeComposeConfig {
     // Content manipulation
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "postprocess-script")]
+    // This one references an external filename
     pub postprocess_script: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    // This one is inline, and supports multiple (hence is useful for inheritance)
+    pub postprocess: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "add-files")]
     pub add_files: Option<Vec<String>>,

--- a/tests/compose-tests/test-misc-tweaks.sh
+++ b/tests/compose-tests/test-misc-tweaks.sh
@@ -21,9 +21,16 @@ pysetjsonmember "add-files" '[["foo.txt", "/usr/etc/foo.txt"],
                               ["baz.txt", "/usr/share/baz.txt"],
                               ["bar.txt", "/etc/bar.txt"]]'
 pysetjsonmember "postprocess-script" \"$PWD/postprocess.sh\"
+pysetjsonmember "postprocess" '["""#!/bin/bash
+touch /usr/share/postprocess-testing""",
+"""#!/bin/bash
+rm /usr/share/postprocess-testing
+touch /usr/share/postprocess-testing-done"""]'
 cat > postprocess.sh << EOF
 #!/bin/bash
 set -xeuo pipefail
+# Ordering should be after postprocess
+rm /usr/share/postprocess-testing-done
 echo misc-tweaks-postprocess-done > /usr/share/misc-tweaks-postprocess-done.txt
 cp -a /usr/etc/foo.txt /usr/share/misc-tweaks-foo.txt
 EOF


### PR DESCRIPTION
I'm trying to have a more opinionated model where custom builds
use inheritance, and currently one can only have a single
`postprocess-script`.

Further, in YAML it's very convenient to use inline vs external
data.
