### PR TITLE
compose: Add --write-composejson-to

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1445,8 +1445,9 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
   g_autofree char *inputhash = NULL;
   if (!inputhash_from_commit (self->repo, new_revision, &inputhash, error))
     return FALSE;
-  g_assert (inputhash); /* All new commits should have it */
-  g_variant_builder_add (&composemeta_builder, "{sv}", "rpm-ostree-inputhash", g_variant_new_string (inputhash));
+  /* We may not have the inputhash in the split-up installroot case */
+  if (inputhash)
+    g_variant_builder_add (&composemeta_builder, "{sv}", "rpm-ostree-inputhash", g_variant_new_string (inputhash));
   if (parent_revision)
     g_variant_builder_add (&composemeta_builder, "{sv}", "ostree-parent-commit", g_variant_new_string (parent_revision));
 

--- a/tests/compose-tests/test-write-commitid.sh
+++ b/tests/compose-tests/test-write-commitid.sh
@@ -21,5 +21,9 @@ echo "ok ref not written"
 commitid_txt=$(cat commitid.txt)
 json_commit=$(jq -r '.["ostree-commit"]' composemeta.json)
 assert_streq "${json_commit}" "${commitid_txt}"
+# And verify we have other keys
+for key in ostree-version rpm-ostree-inputhash ostree-content-bytes-written; do
+    jq -r '.["'${key}'"]' composemeta.json >/dev/null
+done
 
 echo "ok composejson"

--- a/tests/compose-tests/test-write-commitid.sh
+++ b/tests/compose-tests/test-write-commitid.sh
@@ -6,7 +6,8 @@ dn=$(cd $(dirname $0) && pwd)
 . ${dn}/libcomposetest.sh
 
 prepare_compose_test "write-commitid"
-runcompose --write-commitid-to $(pwd)/commitid.txt
+runcompose --write-commitid-to $(pwd)/commitid.txt \
+           --write-composejson-to $(pwd)/composemeta.json
 wc -c < commitid.txt > wc.txt
 assert_file_has_content_literal wc.txt 64
 echo "ok compose"
@@ -16,3 +17,9 @@ if ostree --repo=${repobuild} rev-parse ${treeref}; then
     fatal "Found ${treeref} ?"
 fi
 echo "ok ref not written"
+
+commitid_txt=$(cat commitid.txt)
+json_commit=$(jq -r '.["ostree-commit"]' composemeta.json)
+assert_streq "${json_commit}" "${commitid_txt}"
+
+echo "ok composejson"


### PR DESCRIPTION
For higher level tools driving rpm-ostree, the command line arguments
are mostly OK as inputs, but the addition of `--write-commitid-to`
shows that we really want structured data that these tools can parse.
JSON is a good enough interchange format, let's use that.

Most notably this does a pkgdiff in the JSON which several higher
level tools do too.
