### PR TITLE
vmcheck: Store temporary files in /var/tmp instead

### DIFF
--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -110,7 +110,7 @@ vm_rpmostree() {
 vm_send_test_repo() {
   mode=${1:-nogpgcheck}
   # note we use -c here because we might be called twice within a second
-  vm_raw_rsync -c --delete ${test_tmpdir}/yumrepo $VM:/tmp/vmcheck
+  vm_raw_rsync -c --delete ${test_tmpdir}/yumrepo $VM:/var/tmp/vmcheck
 
   if [[ $mode == skip ]]; then
     return
@@ -119,7 +119,7 @@ vm_send_test_repo() {
   cat > vmcheck.repo << EOF
 [test-repo]
 name=test-repo
-baseurl=file:///tmp/vmcheck/yumrepo
+baseurl=file:///var/tmp/vmcheck/yumrepo
 EOF
 
   if [[ $mode == gpgcheck ]]; then

--- a/tests/vmcheck/test-db.sh
+++ b/tests/vmcheck/test-db.sh
@@ -27,7 +27,7 @@ set -x
 # SUMMARY: check that `db` commands work correctly. Right now, we're only
 # testing `db diff`.
 
-YUMREPO=/tmp/vmcheck/yumrepo/packages/x86_64
+YUMREPO=/var/tmp/vmcheck/yumrepo/packages/x86_64
 
 check_diff() {
   arg1=$1; shift

--- a/tests/vmcheck/test-download-only.sh
+++ b/tests/vmcheck/test-download-only.sh
@@ -58,14 +58,14 @@ vm_cmd ostree remote add --no-gpg-verify vmcheck_remote file://$remote_repo
 
 go_offline() {
   vm_cmd mv ${remote_repo}{,.bak}
-  vm_cmd mv /tmp/vmcheck/yumrepo{,.bak}
-  YUMREPO=/tmp/vmcheck/yumrepo.bak/packages/x86_64
+  vm_cmd mv /var/tmp/vmcheck/yumrepo{,.bak}
+  YUMREPO=/var/tmp/vmcheck/yumrepo.bak/packages/x86_64
 }
 
 go_online() {
-  vm_cmd mv /tmp/vmcheck/yumrepo{.bak,}
+  vm_cmd mv /var/tmp/vmcheck/yumrepo{.bak,}
   vm_cmd mv ${remote_repo}{.bak,}
-  YUMREPO=/tmp/vmcheck/yumrepo/packages/x86_64
+  YUMREPO=/var/tmp/vmcheck/yumrepo/packages/x86_64
 }
 
 # sanity check

--- a/tests/vmcheck/test-layering-basic-1.sh
+++ b/tests/vmcheck/test-layering-basic-1.sh
@@ -176,9 +176,9 @@ if ! vm_cmd "findmnt / -no PROPAGATION" | grep shared; then
 fi
 
 # test pkg-remove and simultaneously check that it's done without reaching repos
-vm_cmd mv /tmp/vmcheck/yumrepo{,.bak}
+vm_cmd mv /var/tmp/vmcheck/yumrepo{,.bak}
 vm_rpmostree pkg-remove foo-1.0
-vm_cmd mv /tmp/vmcheck/yumrepo{.bak,}
+vm_cmd mv /var/tmp/vmcheck/yumrepo{.bak,}
 echo "ok pkg-remove foo"
 
 vm_reboot

--- a/tests/vmcheck/test-layering-basic-2.sh
+++ b/tests/vmcheck/test-layering-basic-2.sh
@@ -107,7 +107,7 @@ vm_build_rpm test-uninstall-all-pkg2
 vm_build_rpm test-uninstall-all-pkg3
 # do one from repo and one local for funsies
 vm_rpmostree install test-uninstall-all-pkg1 \
-  /tmp/vmcheck/yumrepo/packages/x86_64/test-uninstall-all-pkg2-1.0-1.x86_64.rpm
+  /var/tmp/vmcheck/yumrepo/packages/x86_64/test-uninstall-all-pkg2-1.0-1.x86_64.rpm
 vm_assert_status_jq \
   '.deployments[0]["packages"]|length == 1' \
   '.deployments[0]["requested-packages"]|length == 1' \

--- a/tests/vmcheck/test-layering-local.sh
+++ b/tests/vmcheck/test-layering-local.sh
@@ -28,7 +28,7 @@ vm_assert_layered_pkg foo absent
 
 vm_cmd ostree refs $(vm_get_deployment_info 0 checksum) --create vmcheck_tmp/without_foo
 vm_build_rpm foo version 1.2 release 3
-vm_rpmostree install /tmp/vmcheck/yumrepo/packages/x86_64/foo-1.2-3.x86_64.rpm
+vm_rpmostree install /var/tmp/vmcheck/yumrepo/packages/x86_64/foo-1.2-3.x86_64.rpm
 echo "ok install foo locally"
 
 vm_reboot
@@ -70,7 +70,7 @@ vm_cmd ostree refs $(vm_get_deployment_info 0 checksum) --create vmcheck_tmp/wit
 vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/with_foo
 vm_rpmostree uninstall foo
 vm_rpmostree upgrade # upgrades to new base which has foo
-if vm_rpmostree install /tmp/vmcheck/yumrepo/packages/x86_64/foo-1.2-3.x86_64.rpm; then
+if vm_rpmostree install /var/tmp/vmcheck/yumrepo/packages/x86_64/foo-1.2-3.x86_64.rpm; then
   assert_not_reached "didn't error out when trying to install same pkg"
 fi
 echo "ok error on layering same pkg in base"
@@ -79,5 +79,5 @@ echo "ok error on layering same pkg in base"
 vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck_tmp/without_foo
 vm_rpmostree upgrade
 vm_cmd rm -rf /etc/yum.repos.d/
-vm_rpmostree install /tmp/vmcheck/yumrepo/packages/x86_64/foo-1.2-3.x86_64.rpm
+vm_rpmostree install /var/tmp/vmcheck/yumrepo/packages/x86_64/foo-1.2-3.x86_64.rpm
 echo "ok layer local foo without repos"

--- a/tests/vmcheck/test-layering-unified.sh
+++ b/tests/vmcheck/test-layering-unified.sh
@@ -28,10 +28,10 @@ vm_assert_layered_pkg foo absent
 vm_assert_layered_pkg bar absent
 
 vm_build_rpm foo
-foo_rpm=/tmp/vmcheck/yumrepo/packages/x86_64/foo-1.0-1.x86_64.rpm
+foo_rpm=/var/tmp/vmcheck/yumrepo/packages/x86_64/foo-1.0-1.x86_64.rpm
 
 vm_build_rpm bar
-bar_rpm=/tmp/vmcheck/yumrepo/packages/x86_64/bar-1.0-1.x86_64.rpm
+bar_rpm=/var/tmp/vmcheck/yumrepo/packages/x86_64/bar-1.0-1.x86_64.rpm
 
 # We cheat a bit here and don't actually reboot the system. Instead, we just
 # check that then pending deployment looks sane.

--- a/tests/vmcheck/test-livefs.sh
+++ b/tests/vmcheck/test-livefs.sh
@@ -35,7 +35,7 @@ vm_rpmostree reload
 vm_assert_layered_pkg foo absent
 
 vm_build_rpm foo
-vm_rpmostree install /tmp/vmcheck/yumrepo/packages/x86_64/foo-1.0-1.x86_64.rpm
+vm_rpmostree install /var/tmp/vmcheck/yumrepo/packages/x86_64/foo-1.0-1.x86_64.rpm
 vm_assert_status_jq '.deployments|length == 2'
 echo "ok install foo locally"
 
@@ -89,7 +89,7 @@ vm_cmd rm -rf /etc/test-livefs-with-etc \
               /etc/test-livefs-with-etc.conf \
               /etc/opt/test-livefs-with-etc-opt.conf
 
-vm_rpmostree install /tmp/vmcheck/yumrepo/packages/x86_64/test-livefs-{with-etc,service}-1.0-1.x86_64.rpm
+vm_rpmostree install /var/tmp/vmcheck/yumrepo/packages/x86_64/test-livefs-{with-etc,service}-1.0-1.x86_64.rpm
 assert_livefs_ok
 vm_rpmostree ex livefs
 vm_cmd rpm -q foo test-livefs-{with-etc,service} > rpmq.txt
@@ -127,7 +127,7 @@ reset() {
 reset
 
 # If the admin created a config file before, we need to keep it
-vm_rpmostree install /tmp/vmcheck/yumrepo/packages/x86_64/test-livefs-with-etc-1.0-1.x86_64.rpm
+vm_rpmostree install /var/tmp/vmcheck/yumrepo/packages/x86_64/test-livefs-with-etc-1.0-1.x86_64.rpm
 vm_cmd cat /etc/test-livefs-with-etc.conf || true
 vm_cmd echo custom \> /etc/test-livefs-with-etc.conf
 vm_cmd cat /etc/test-livefs-with-etc.conf
@@ -143,7 +143,7 @@ vm_rpmostree deploy $(vm_get_booted_deployment_info checksum)
 echo "ok livefs redeploy booted commit"
 
 reset
-vm_rpmostree install /tmp/vmcheck/yumrepo/packages/x86_64/foo-1.0-1.x86_64.rpm
+vm_rpmostree install /var/tmp/vmcheck/yumrepo/packages/x86_64/foo-1.0-1.x86_64.rpm
 vm_rpmostree ex livefs
 # Picked a file that should be around, but harmless to change for testing.  The
 # first is available on Fedora, the second on CentOS (and newer too).

--- a/tests/vmcheck/test-override-local-replace.sh
+++ b/tests/vmcheck/test-override-local-replace.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 
 set -x
 
-YUMREPO=/tmp/vmcheck/yumrepo/packages/x86_64
+YUMREPO=/var/tmp/vmcheck/yumrepo/packages/x86_64
 
 # create a new vmcheck commit which has foo and bar in it already
 

--- a/tests/vmcheck/test-override-remove.sh
+++ b/tests/vmcheck/test-override-remove.sh
@@ -74,7 +74,7 @@ echo "ok setup"
 # reach the repo. This implicitly tests that `override remove/reset` operate in
 # cache-only mode.
 vm_rpmostree cleanup --repomd
-vm_cmd mv /tmp/vmcheck/yumrepo{,.bak}
+vm_cmd mv /var/tmp/vmcheck/yumrepo{,.bak}
 
 # funky jq syntax: see test-override-local-replace.sh for an explanation of how
 # this works. the only difference here is the [.0] which we use to access the
@@ -177,7 +177,7 @@ echo "ok reset inactive override remove"
 vm_rpmostree cleanup -p
 
 # Restore the local yum repo.
-vm_cmd mv /tmp/vmcheck/yumrepo{.bak,}
+vm_cmd mv /var/tmp/vmcheck/yumrepo{.bak,}
 echo "ok override remove/reset operate offline"
 
 # a few error checks
@@ -205,7 +205,7 @@ if vm_rpmostree install foo; then
 fi
 # the check blocking this isn't related to overrides, though for consistency
 # let's make sure this fails here too
-if vm_rpmostree install /tmp/vmcheck/yumrepo/packages/x86_64/foo-1.0-1.x86_64.rpm; then
+if vm_rpmostree install /var/tmp/vmcheck/yumrepo/packages/x86_64/foo-1.0-1.x86_64.rpm; then
   assert_not_reached "tried to layer local pkg removed by override"
 fi
 vm_rpmostree cleanup -p

--- a/tests/vmcheck/test-override-replace-2.sh
+++ b/tests/vmcheck/test-override-replace-2.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 
 set -x
 
-YUMREPO=/tmp/vmcheck/yumrepo/packages/x86_64
+YUMREPO=/var/tmp/vmcheck/yumrepo/packages/x86_64
 
 vm_assert_status_jq \
   '.deployments[0]["base-checksum"]|not' \

--- a/tests/vmcheck/test-reset.sh
+++ b/tests/vmcheck/test-reset.sh
@@ -37,8 +37,8 @@ vm_build_rpm foo version 2.0
 vm_build_rpm bar
 vm_build_rpm baz
 vm_rpmostree override replace --install bar \
-  --install /tmp/vmcheck/yumrepo/packages/x86_64/baz-1.0-1.x86_64.rpm \
-  /tmp/vmcheck/yumrepo/packages/x86_64/foo-2.0-1.x86_64.rpm
+  --install /var/tmp/vmcheck/yumrepo/packages/x86_64/baz-1.0-1.x86_64.rpm \
+  /var/tmp/vmcheck/yumrepo/packages/x86_64/foo-2.0-1.x86_64.rpm
 vm_rpmostree initramfs --enable
 
 vm_reboot


### PR DESCRIPTION
Since `/tmp` might be on tmpfs, so we'd lose it on reboot. But we have
tests that need it to persist across reboots.