### PR TITLE
scripts: Workaround Lua in fedora-release-coreos too

### DIFF
--- a/src/libpriv/rpmostree-importer.c
+++ b/src/libpriv/rpmostree-importer.c
@@ -653,8 +653,17 @@ compose_filter_cb (OstreeRepo         *repo,
   else if (g_str_has_prefix (path, "/run/") ||
            g_str_has_prefix (path, "/var/"))
     {
-      append_tmpfiles_d (self, path, file_info,
-                         user ?: "root", group ?: "root");
+      /* HACK: Avoid generating tmpfiles.d entries for the `rpm` package's
+       * /var/lib/rpm entries in --unified-core composes.  A much more
+       * rigorous approach here would be to maintain our built-in tmpfiles.d
+       * entries as a struct and ensure we're not writing any overrides for
+       * those here.
+       */
+      if (!g_str_has_prefix (path, "/var/lib/rpm"))
+        {
+          append_tmpfiles_d (self, path, file_info,
+                             user ?: "root", group ?: "root");
+        }
       return OSTREE_REPO_COMMIT_FILTER_SKIP;
     }
   else if (!error_was_set)

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -102,15 +102,21 @@ typedef struct {
 } RpmOstreeLuaReplacement;
 
 static const RpmOstreeLuaReplacement lua_replacements[] = {
-  /* These three don't have bugs...the release packages are implemented Lua for
+  /* The release packages are implemented Lua for
    * unnecessary reasons.  This doesn't fully generalize obviously arbitrarly
-   * release packages, but anyone doing an exampleos-release package can just implement
-   * `ln` in shell script in their package.
+   * release packages, but anyone doing an exampleos-release package and that
+   * wants to use rpm-ostree can just do `ln` in shell script in their package
+   * too.
    */
   { "fedora-release-atomichost.post",
     "/usr/bin/sh",
     "set -euo pipefail\n"
     "ln -sf os.release.d/os-release-atomichost /usr/lib/os-release\n"
+  },
+  { "fedora-release-coreos.post",
+    "/usr/bin/sh",
+    "set -euo pipefail\n"
+    "ln -sf os.release.d/os-release-coreos /usr/lib/os-release\n"
   },
   { "fedora-release-workstation.post",
     "/usr/bin/sh",

--- a/tests/compose-tests/test-basic-unified.sh
+++ b/tests/compose-tests/test-basic-unified.sh
@@ -29,6 +29,10 @@ assert_file_has_content_literal autovar.txt 'd /var/cache 0755 root root - -'
 ostree --repo=${repobuild} cat ${treeref} /usr/lib/tmpfiles.d/pkg-chrony.conf > autovar.txt
 # And this one has a non-root uid
 assert_file_has_content_literal autovar.txt 'd /var/log/chrony 0755 chrony chrony - -'
+# see rpmostree-importer.c
+if ostree --repo=${repobuild} cat ${treeref} /usr/lib/tmpfiles.d/pkg-rpm.conf > rpm.txt 2>/dev/null; then
+    assert_not_file_has_content rpm.txt 'd /var/lib/rpm'
+fi
 echo "ok autovar"
 
 # And redo it to trigger relabeling


### PR DESCRIPTION
Just like the other ones from commit: 716b60b7d71d2af974441af91eca538dae2e25cf

Yes, we probably should just patch the package but then
we'd have to wait for all of the koji/bodhi pain.
