### PR TITLE
status: Omit pkglist from JSON

### DIFF
--- a/tests/vmcheck/test-misc-1.sh
+++ b/tests/vmcheck/test-misc-1.sh
@@ -61,6 +61,9 @@ vm_rpmostree status --jsonpath '$.deployments[0].booted' > jsonpath.txt
 assert_file_has_content_literal jsonpath.txt '[true]'
 echo "ok jsonpath"
 
+vm_rpmostree status --json-short >json-short.txt
+jq '.deployments[0]["base-commit-meta"]["rpmostree.rpmdb.pkglist"]|not' < json-short.txt
+
 vm_rpmostree --version > version.yaml
 python -c 'import yaml; v=yaml.safe_load(open("version.yaml")); assert("Version" in v["rpm-ostree"])'
 echo "ok yaml version"


### PR DESCRIPTION
Sometimes I eyeball the json to get some data, and yeah, probably
should be using a toolbox container and jq, but still it's
convenient.

The addition of the pkglist to the JSON made that totally illegible;
this also came up with atomic-host-tests which was using it.

So let's add an option that drops it; requires some small GVariant
surgery.
