### PR TITLE
app/main: Give an immediate error if no /run/ostree-booted

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -22,10 +22,18 @@ cluster:
   hosts:
     - name: vmcheck1
       distro: fedora/28/atomic
+      # XXX: use updates branch until stable FAH receives:
+      # https://bodhi.fedoraproject.org/updates/FEDORA-2018-16c78b3d92
+      ostree:
+        branch: fedora/28/x86_64/updates/atomic-host
     - name: vmcheck2
       distro: fedora/28/atomic
+      ostree:
+        branch: fedora/28/x86_64/updates/atomic-host
     - name: vmcheck3
       distro: fedora/28/atomic
+      ostree:
+        branch: fedora/28/x86_64/updates/atomic-host
   container:
     image: registry.fedoraproject.org/fedora:28
 


### PR DESCRIPTION
Let's be more graceful here for people who `yum install rpm-ostree`
and expect magical[1] things to happen.

Closes: https://github.com/projectatomic/rpm-ostree/issues/1537

[1] Understandably if one doesn't know lots of background
