### PR TITLE
daemon: Make inactive requests a hard error

### DIFF
--- a/man/rpm-ostree.xml
+++ b/man/rpm-ostree.xml
@@ -235,10 +235,11 @@ Boston, MA 02111-1307, USA.
           </para>
 
           <para>
-            Note that currently, you may specify a package that is
-            already in the base layer, though you should use the
-            <command>--allow-inactive</command> option to avoid a
-            warning. This option will become mandatory in the future.
+            Note that by default, specifying a package that is already
+            in the base layer is an error unless the
+            <command>--allow-inactive</command> option is provided.
+            This can be useful when anticipating the removal of a base
+            package.
           </para>
 
           <para>

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -986,8 +986,8 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
                   g_string_append_printf (pkgnames, " %s", dnf_package_get_nevra (p));
                 }
               return glnx_throw (error, "\"%s\" is already provided by:%s. Use "
-                                        "--allow-inactive to disable this check.",
-                                        pkg, pkgnames->str);
+                                        "--allow-inactive to explicitly "
+                                        "require it.", pkg, pkgnames->str);
             }
         }
 

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -977,7 +977,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
           const char *pkg = *it;
           g_autoptr(GPtrArray) pkgs =
             rpmostree_get_matching_packages (base_rsack->sack, pkg);
-          if (pkgs->len > 0)
+          if (pkgs->len > 0 && !allow_inactive)
             {
               g_autoptr(GString) pkgnames = g_string_new ("");
               for (guint i = 0; i < pkgs->len; i++)
@@ -985,15 +985,9 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
                   DnfPackage *p = pkgs->pdata[i];
                   g_string_append_printf (pkgnames, " %s", dnf_package_get_nevra (p));
                 }
-              if (!allow_inactive)
-                {
-                  /* XXX: awkward CLI mention here */
-                  rpmostree_output_message (
-                      "warning: deprecated: \"%s\" is already provided by:%s. Use "
-                      "--allow-inactive to squash this warning. A future release will make "
-                      "this a requirement. See rpm-ostree(1) for details.",
-                      pkg, pkgnames->str);
-                }
+              return glnx_throw (error, "\"%s\" is already provided by:%s. Use "
+                                        "--allow-inactive to disable this check.",
+                                        pkg, pkgnames->str);
             }
         }
 

--- a/tests/vmcheck/test-layering-basic-2.sh
+++ b/tests/vmcheck/test-layering-basic-2.sh
@@ -89,11 +89,12 @@ vm_cmd ostree show --print-metadata-key rpmostree.rpmdb.pkglist \
 assert_file_has_content pkglist.txt 'test-pkgcache-migrate-pkg'
 echo "ok layered pkglist"
 
-vm_rpmostree install glibc &>out.txt
-assert_file_has_content out.txt "warning: .* Use --allow-inactive to squash this warning."
+if vm_rpmostree install glibc &>out.txt; then
+  assert_not_reached "Successfully requested glibc without --allow-inactive?"
+fi
+assert_file_has_content out.txt "Use --allow-inactive to disable this check."
 vm_rpmostree cleanup -p
 vm_rpmostree install glibc --allow-inactive &>out.txt
-assert_not_file_has_content out.txt "warning:"
 vm_rpmostree cleanup -p
 echo "ok --allow-inactive"
 

--- a/tests/vmcheck/test-layering-basic-2.sh
+++ b/tests/vmcheck/test-layering-basic-2.sh
@@ -92,7 +92,7 @@ echo "ok layered pkglist"
 if vm_rpmostree install glibc &>out.txt; then
   assert_not_reached "Successfully requested glibc without --allow-inactive?"
 fi
-assert_file_has_content out.txt "Use --allow-inactive to disable this check."
+assert_file_has_content out.txt "Use --allow-inactive to explicitly require it."
 vm_rpmostree cleanup -p
 vm_rpmostree install glibc --allow-inactive &>out.txt
 vm_rpmostree cleanup -p


### PR DESCRIPTION
Flip the switch and make `rpm-ostree install glibc` a hard error if
`--allow-inactive` is not provided.