### PR TITLE
initramfs: Fix conflicting information printed by initramfs command

### DIFF
--- a/src/app/rpmostree-builtin-initramfs.c
+++ b/src/app/rpmostree-builtin-initramfs.c
@@ -85,8 +85,9 @@ rpmostree_builtin_initramfs (int             argc,
 
   if (!(opt_enable || opt_disable))
     {
-      GVariantIter iter;
       g_autoptr(GVariant) deployments = rpmostree_sysroot_dup_deployments (sysroot_proxy);
+      gboolean cur_regenerate = FALSE;
+      g_autofree char **initramfs_args = NULL;
 
       if (opt_reboot)
         {
@@ -95,42 +96,28 @@ rpmostree_builtin_initramfs (int             argc,
           return FALSE;
         }
 
-      g_variant_iter_init (&iter, deployments);
-
-      while (TRUE)
+      if (g_variant_n_children (deployments) > 1)
         {
-          gboolean cur_regenerate;
-          g_autoptr(GVariant) child = g_variant_iter_next_value (&iter);
-          g_autoptr(GVariantDict) dict = NULL;
-          g_autofree char **initramfs_args = NULL;
-          gboolean is_booted;
+          g_autoptr(GVariant) pending = g_variant_get_child_value (deployments, 0);
+          g_auto(GVariantDict) dict;
+          g_variant_dict_init (&dict, pending);
 
-          if (child == NULL)
-            break;
-
-          dict = g_variant_dict_new (child);
-
-          if (!g_variant_dict_lookup (dict, "booted", "b", &is_booted))
-            continue;
-          if (!is_booted)
-            continue;
-
-          if (!g_variant_dict_lookup (dict, "regenerate-initramfs", "b", &cur_regenerate))
+          if (!g_variant_dict_lookup (&dict, "regenerate-initramfs", "b", &cur_regenerate))
             cur_regenerate = FALSE;
           if (cur_regenerate)
             {
-              g_variant_dict_lookup (dict, "initramfs-args", "^a&s", &initramfs_args);
-            }
-
-          g_print ("Initramfs regeneration: %s\n", cur_regenerate ? "enabled" : "disabled");
-          if (initramfs_args)
-            {
-              g_print ("Initramfs args: ");
-              for (char **iter = initramfs_args; iter && *iter; iter++)
-                g_print ("%s ", *iter);
-              g_print ("\n");
+              g_variant_dict_lookup (&dict, "initramfs-args", "^a&s", &initramfs_args);
             }
         }
+
+        g_print ("Initramfs regeneration: %s\n", cur_regenerate ? "enabled" : "disabled");
+        if (initramfs_args)
+          {
+            g_print ("Initramfs args: ");
+            for (char **iter = initramfs_args; iter && *iter; iter++)
+              g_print ("%s ", *iter);
+            g_print ("\n");
+          }
     }
   else if (opt_enable && opt_disable)
     {

--- a/src/app/rpmostree-builtin-initramfs.c
+++ b/src/app/rpmostree-builtin-initramfs.c
@@ -116,14 +116,14 @@ rpmostree_builtin_initramfs (int             argc,
             }
         }
 
-        g_print ("Initramfs regeneration: %s\n", cur_regenerate ? "enabled" : "disabled");
-        if (initramfs_args)
-          {
-            g_print ("Initramfs args: ");
-            for (char **iter = initramfs_args; iter && *iter; iter++)
-              g_print ("%s ", *iter);
-            g_print ("\n");
-          }
+      g_print ("Initramfs regeneration: %s\n", cur_regenerate ? "enabled" : "disabled");
+      if (initramfs_args)
+        {
+          g_print ("Initramfs args: ");
+          for (char **iter = initramfs_args; iter && *iter; iter++)
+            g_print ("%s ", *iter);
+          g_print ("\n");
+        }
     }
   else if (opt_enable && opt_disable)
     {

--- a/src/app/rpmostree-builtin-initramfs.c
+++ b/src/app/rpmostree-builtin-initramfs.c
@@ -95,6 +95,12 @@ rpmostree_builtin_initramfs (int             argc,
                                "--reboot must be used with --enable or --disable");
           return FALSE;
         }
+      if (opt_add_arg)
+        {
+          g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                               "--arg must be used with --enable");
+          return FALSE;
+        }
 
       if (g_variant_n_children (deployments) > 1)
         {

--- a/tests/vmcheck/test-initramfs.sh
+++ b/tests/vmcheck/test-initramfs.sh
@@ -42,7 +42,11 @@ fi
 assert_file_has_content err.txt "reboot.*used with.*enable"
 echo "ok initramfs state"
 
-vm_rpmostree initramfs --enable
+vm_rpmostree initramfs --enable > initramfs.txt
+assert_file_has_content initramfs.txt "Initramfs regeneration.*enabled"
+vm_rpmostree initramfs > initramfs.txt
+assert_file_has_content initramfs.txt "Initramfs regeneration.*enabled"
+
 vm_assert_status_jq \
   '.deployments[1].booted' \
   '.deployments[0]["regenerate-initramfs"]' \
@@ -64,7 +68,11 @@ fi
 assert_file_has_content err.txt "already.*enabled"
 echo "ok initramfs enabled"
 
-vm_rpmostree initramfs --disable
+vm_rpmostree initramfs --disable > initramfs.txt
+assert_file_has_content initramfs.txt "Initramfs regeneration.*disabled"
+vm_rpmostree initramfs > initramfs.txt
+assert_file_has_content initramfs.txt "Initramfs regeneration.*disabled"
+
 vm_reboot
 vm_assert_status_jq \
   '.deployments[0].booted' \

--- a/tests/vmcheck/test-initramfs.sh
+++ b/tests/vmcheck/test-initramfs.sh
@@ -39,7 +39,11 @@ assert_file_has_content err.txt "already.*disabled"
 if vm_rpmostree initramfs --reboot 2>err.txt; then
     assert_not_reached "reboot worked?"
 fi
-assert_file_has_content err.txt "reboot.*used with.*enable"
+assert_file_has_content err.txt "reboot.*used with.*enable.*disable"
+if vm_rpmostree initramfs --arg=foo 2>err.txt; then
+    assert_not_reached "arg worked?"
+fi
+assert_file_has_content err.txt "arg.*used with.*enable"
 echo "ok initramfs state"
 
 vm_rpmostree initramfs --enable > initramfs.txt
@@ -101,6 +105,8 @@ osname=$(vm_get_booted_deployment_info osname)
 for file in first second; do
     vm_cmd touch /etc/rpmostree-initramfs-testing-$file
     vm_rpmostree initramfs --enable --arg="-I" --arg="/etc/rpmostree-initramfs-testing-$file"
+    vm_rpmostree initramfs > initramfs.txt
+    assert_file_has_content initramfs.txt "Initramfs.*args.*-I.*/etc/rpmostree-initramfs-testing-$file"
     vm_reboot
     vm_assert_status_jq \
         '.deployments[0].booted' \


### PR DESCRIPTION
The initramfs regeneration status had previously been showing as disabled after `rpm-ostree initramfs --enable`, because the status for only the current (booted) deployment was printed. Now, the loop will not `continue` upon hitting a booted deployment - it will finish the iteration and print the regeneration status for it.

As I understand, initramfs regeneration is only enabled for the next deployment, and it will trigger a regeneration of the initramfs every time a new package is layered (through `rpm-ostree install` onto the new deployment). Currently, rpm-ostree is operating this way. If this is the correct operation, it seems only a change on the front end where `Initramfs regeneration:` is printed is needed.

This fixes: #1526 