### PR TITLE
rust: Use debug=true for release builds

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,3 +28,4 @@ crate-type = ["staticlib"]
 [profile.release]
 panic = "abort"
 lto = true
+debug = true


### PR DESCRIPTION
Because our primary delivery vechicle uses RPM which
supports separate debuginfo, there's no reason not to build release
builds with debuginfo, so that one can use gdb on them just
like we do with C.
