### PR TITLE
ci: Stop installing python-{sphinx,devel}

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -25,7 +25,6 @@ pkg_upgrade
 pkg_install_builddeps rpm-ostree
 # Temporary until spec file changes are upstreamed
 pkg_install cargo
-pkg_install_if_os fedora python3-sphinx python3-devel
 # Mostly dependencies for tests
 pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML \
     libubsan libasan libtsan elfutils fuse sudo python-gobject-base \


### PR DESCRIPTION
We should no longer need it. Just noticed this while I was in the file recently.
