### PR TITLE
packaging: Don't vendor bundled libcurl

### DIFF
--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -xeuo pipefail
 
 srcdir=$1
 shift
@@ -9,9 +10,6 @@ shift
 
 TARFILE=${PKG_VER}.tar
 TARFILE_TMP=$(pwd)/${TARFILE}.tmp
-
-set -x
-set -e
 
 test -n "${srcdir}"
 test -n "${PKG_VER}"

--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -43,6 +43,12 @@ mkdir ${tmpd} && touch ${tmpd}/.tmp
  cargo vendor -q --sync ${TOP}/rust/Cargo.toml vendor
  cp ${TOP}/rust/Cargo.lock .
  cp ${TOP}/rust/cargo-vendor-config .cargo/config
+ # Filter out bundled libcurl from curl-sys; we always want the system libcurl
+ rm -rf vendor/curl-sys/curl/
+ python -c '
+import json, sys; j = json.load(open(sys.argv[1]))
+j["files"] = {f:c for f, c in j["files"].items() if not f.startswith("curl/")}
+open(sys.argv[1], "w").write(json.dumps(j))' vendor/curl-sys/.cargo-checksum.json
  tar --transform="s,^,${PKG_VER}/rust/," -rf ${TARFILE_TMP} * .cargo/
  )
 mv ${TARFILE_TMP} ${TARFILE}


### PR DESCRIPTION
The `curl-sys` crate includes with it a bundled copy of libcurl which is
used if `pkgconfig` doesn't find libcurl configuration files. In our
case, we always want to use the system libcurl. So filter it out. This
also drops our *compressed* tarball by 2.5M.

One tricky bit is that cargo crates include a checksum JSON that's read
by `cargo build` later on to validate the crate. So we need to do some
JSON surgery.

What made me look into this was that Koji builds were failing due to the
`%configure` macro including hardening bits that sub out e.g. all
`config.sub` and `ltmain.sh` files which then caused the checksum to
fail validation. This completely sidesteps that issue.