### PR TITLE
vmcheck/misc-1: skip the overlay check when needed

### DIFF
--- a/tests/vmcheck/test-misc-1.sh
+++ b/tests/vmcheck/test-misc-1.sh
@@ -51,7 +51,7 @@ vm_assert_status_jq \
   '.deployments[0]["layered-commit-meta"]|not'
 echo "ok empty pkg arrays, and commit meta correct in status json"
 
-if test -z "${RPMOSTREE_TEST_NO_OVERLAY}"; then
+if test -z "${RPMOSTREE_TEST_NO_OVERLAY:-}"; then
   vm_assert_status_jq \
     '.deployments[0]["base-commit-meta"]["ostree.source-title"]|contains("overlay")' \
   echo "ok overlay found in commit meta"

--- a/tests/vmcheck/test-misc-1.sh
+++ b/tests/vmcheck/test-misc-1.sh
@@ -48,9 +48,14 @@ vm_assert_status_jq \
   '.deployments[0]["requested-local-packages"]' \
   '.deployments[0]["base-removals"]' \
   '.deployments[0]["requested-base-removals"]' \
-  '.deployments[0]["base-commit-meta"]["ostree.source-title"]|contains("overlay")' \
   '.deployments[0]["layered-commit-meta"]|not'
 echo "ok empty pkg arrays, and commit meta correct in status json"
+
+if test -z "${RPMOSTREE_TEST_NO_OVERLAY}"; then
+  vm_assert_status_jq \
+    '.deployments[0]["base-commit-meta"]["ostree.source-title"]|contains("overlay")' \
+  echo "ok overlay found in commit meta"
+fi
 
 vm_rpmostree status --jsonpath '$.deployments[0].booted' > jsonpath.txt
 assert_file_has_content_literal jsonpath.txt '[true]'

--- a/tests/vmcheck/test-misc-1.sh
+++ b/tests/vmcheck/test-misc-1.sh
@@ -53,7 +53,7 @@ echo "ok empty pkg arrays, and commit meta correct in status json"
 
 if test -z "${RPMOSTREE_TEST_NO_OVERLAY:-}"; then
   vm_assert_status_jq \
-    '.deployments[0]["base-commit-meta"]["ostree.source-title"]|contains("overlay")' \
+    '.deployments[0]["base-commit-meta"]["ostree.source-title"]|contains("overlay")'
   echo "ok overlay found in commit meta"
 fi
 


### PR DESCRIPTION
It's possible to run the `vmcheck` tests against an existing host that
has `rpm-ostree` already present.  We don't overlay the built binaries
in this situation, so we should not check for the presence of the
overlay in the commit meta.

