### PR TITLE
compose: Remove support for `ex-rojig-spec` in treefile

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -229,7 +229,3 @@ version of `rpm-ostree`.
 
  * `rojig`: Object, optional.  Sub-keys are `name`, `summary`, `license`,
    and `description`.  Of those, `name` and `license` are mandatory.
- * `ex-rojig-spec`: string, optional:  If specified, will also cause
-   a run of `rpm-ostree ex commit2rojig` on changes.  Also requires the
-   `--ex-rojig-output-rpm` commandline option.
-   Deprecated in favor of `rojig`.


### PR DESCRIPTION
In https://github.com/projectatomic/rpm-ostree/pull/1484
AKA commit https://github.com/projectatomic/rpm-ostree/commit/235e8f82da018d037472674c4da20a7acbc219fc
we introduced a new `rojig` treefile entry that is nicer and
more maintainable than a split spec file.

In prep for more "pure rojig" work, drop support for this key.
Note we can also only now do this because we hard require Rust, and
the new model is only implemented in Rust.

The only known user of this today is FAHC, but that is now
[pinned to an assembler build](https://pagure.io/fedora-atomic-host-continuous/c/cdcb6ae943bee643983d4bd22d00030f2eb930d2?branch=master).
