### PR TITLE
postprocess: Don't copy base rpmdb when layering

### DIFF
--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -104,8 +104,7 @@ get_checksum_from_deployment (OstreeRepo       *repo,
   g_autofree char *checksum = NULL;
   if (opt_base)
     {
-      if (!rpmostree_deployment_get_layered_info (repo, deployment, NULL, &checksum,
-                                                  NULL, NULL, NULL, error))
+      if (!rpmostree_deployment_get_base_layer (repo, deployment, &checksum, error))
         return FALSE;
     }
 

--- a/src/daemon/rpmostree-sysroot-core.c
+++ b/src/daemon/rpmostree-sysroot-core.c
@@ -80,9 +80,7 @@ generate_baselayer_refs (OstreeSysroot            *sysroot,
       {
         OstreeDeployment *deployment = deployments->pdata[i];
         g_autofree char *base_rev = NULL;
-
-        if (!rpmostree_deployment_get_layered_info (repo, deployment, NULL, &base_rev, NULL,
-                                                    NULL, NULL, error))
+        if (!rpmostree_deployment_get_base_layer (repo, deployment, &base_rev, error))
           return FALSE;
 
         if (base_rev)
@@ -181,11 +179,9 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
     {
       OstreeDeployment *deployment = deployments->pdata[i];
       const char *current_checksum = ostree_deployment_get_csum (deployment);
-      gboolean is_layered;
+
       g_autofree char *base_commit = NULL;
-      if (!rpmostree_deployment_get_layered_info (repo, deployment, &is_layered,
-                                                  &base_commit, NULL,
-                                                  NULL, NULL, error))
+      if (!rpmostree_deployment_get_base_layer (repo, deployment, &base_commit, error))
         return FALSE;
 
       g_autoptr(RpmOstreeOrigin) origin = rpmostree_origin_parse_deployment (deployment, error);
@@ -197,7 +193,7 @@ generate_pkgcache_refs (OstreeSysroot            *sysroot,
        * packages are layered. But it's harmless to have nonexistent refs in the
        * set.
        */
-      if (is_layered)
+      if (base_commit)
         {
           g_autofree char *deployment_dirpath =
             ostree_sysroot_get_deployment_dirpath (sysroot, deployment);

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -168,15 +168,11 @@ rpmostree_sysroot_upgrader_initable_init (GInitable        *initable,
    * one or both if we upgrade.  But we also want to support redeploying
    * without changing them.
    */
-  gboolean is_layered;
-  if (!rpmostree_deployment_get_layered_info (self->repo,
-                                              self->origin_merge_deployment,
-                                              &is_layered, &self->base_revision,
-                                              NULL, NULL, NULL, error))
+  if (!rpmostree_deployment_get_base_layer (self->repo, self->origin_merge_deployment,
+                                            &self->base_revision, error))
     return FALSE;
 
-  if (is_layered)
-    /* base layer is already populated above */
+  if (self->base_revision)
     self->final_revision = g_strdup (merge_deployment_csum);
   else
     self->base_revision = g_strdup (merge_deployment_csum);

--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -265,9 +265,10 @@ rpmostreed_deployment_generate_variant (OstreeSysroot *sysroot,
   g_auto(GStrv) layered_pkgs = NULL;
   g_autoptr(GVariant) removed_base_pkgs = NULL;
   g_autoptr(GVariant) replaced_base_pkgs = NULL;
-  if (!rpmostree_deployment_get_layered_info (repo, deployment, &is_layered, &base_checksum,
-                                              &layered_pkgs, &removed_base_pkgs,
-                                              &replaced_base_pkgs, error))
+  if (!rpmostree_deployment_get_layered_info (repo, deployment, &is_layered, NULL,
+                                              &base_checksum, &layered_pkgs,
+                                              &removed_base_pkgs, &replaced_base_pkgs,
+                                              error))
     return NULL;
 
   g_autoptr(GVariant) base_commit = NULL;

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1041,7 +1041,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
       g_autoptr(GVariant) removed = NULL;
       g_autoptr(GVariant) replaced = NULL;
       if (!rpmostree_deployment_get_layered_info (repo, merge_deployment, NULL, NULL, NULL,
-                                                  &removed, &replaced, error))
+                                                  NULL, &removed, &replaced, error))
         return FALSE;
 
       g_autoptr(GHashTable) nevra_to_name = g_hash_table_new (g_str_hash, g_str_equal);

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -4201,7 +4201,7 @@ rpmostree_context_commit (RpmOstreeContext      *self,
         /* be nice to our future selves */
         g_variant_builder_add (&metadata_builder, "{sv}",
                                "rpmostree.clientlayer_version",
-                               g_variant_new_uint32 (3));
+                               g_variant_new_uint32 (4));
       }
     else if (assemble_type == RPMOSTREE_ASSEMBLE_TYPE_SERVER_BASE)
       {

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -483,6 +483,7 @@ gboolean
 rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
                                        OstreeDeployment  *deployment,
                                        gboolean          *out_is_layered,
+                                       guint             *out_layer_version,
                                        char             **out_base_layer,
                                        char            ***out_layered_pkgs,
                                        GVariant         **out_removed_base_pkgs,
@@ -564,6 +565,8 @@ rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
 
   if (out_is_layered != NULL)
     *out_is_layered = is_layered;
+  if (out_layer_version != NULL)
+    *out_layer_version = clientlayer_version;
   if (out_base_layer != NULL)
     *out_base_layer = g_steal_pointer (&base_layer);
   if (out_layered_pkgs != NULL)
@@ -597,8 +600,8 @@ rpmostree_deployment_get_base_layer (OstreeRepo        *repo,
                                      char             **out_base_layer,
                                      GError           **error)
 {
-  return rpmostree_deployment_get_layered_info (repo, deployment, NULL, out_base_layer,
-                                                NULL, NULL, NULL, error);
+  return rpmostree_deployment_get_layered_info (repo, deployment, NULL, NULL,
+                                                out_base_layer, NULL, NULL, NULL, error);
 }
 
 static gboolean

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -590,6 +590,17 @@ rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
   return TRUE;
 }
 
+/* Returns the base layer checksum if layered, NULL otherwise. */
+gboolean
+rpmostree_deployment_get_base_layer (OstreeRepo        *repo,
+                                     OstreeDeployment  *deployment,
+                                     char             **out_base_layer,
+                                     GError           **error)
+{
+  return rpmostree_deployment_get_layered_info (repo, deployment, NULL, out_base_layer,
+                                                NULL, NULL, NULL, error);
+}
+
 static gboolean
 do_pkgcache_migration (OstreeRepo    *repo,
                        OstreeRepo    *pkgcache,

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -148,6 +148,13 @@ rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
                                        GVariant         **out_replaced_base_pkgs,
                                        GError           **error);
 
+/* simpler version of the above */
+gboolean
+rpmostree_deployment_get_base_layer (OstreeRepo        *repo,
+                                     OstreeDeployment  *deployment,
+                                     char             **out_base_layer,
+                                     GError           **error);
+
 gboolean
 rpmostree_migrate_pkgcache_repo (OstreeRepo   *repo,
                                  GCancellable *cancellable,

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -138,10 +138,12 @@ gboolean
 rpmostree_str_ptrarray_contains (GPtrArray  *strs,
                                  const char *str);
 
+/* XXX: just return a struct out of these */
 gboolean
 rpmostree_deployment_get_layered_info (OstreeRepo        *repo,
                                        OstreeDeployment  *deployment,
                                        gboolean          *out_is_layered,
+                                       guint             *out_layer_version,
                                        char             **out_base_layer,
                                        char            ***out_layered_pkgs,
                                        GVariant         **out_removed_base_pkgs,


### PR DESCRIPTION
We only want to copy our own rpmdb to the base rpmdb location in the
server-side paths. OTOH, when creating layered commits client-side, we
want to make sure that we *don't* touch the base rpmdb location.
Accordingly, move the logic that does the hardlinking into
`postprocess_final`.

This can cause issues if we want to make use of the base rpmdb (as in a
forthcoming patch) of commits that were not created by a recent enough
rpm-ostree which inject the base rpmdb. When layering on such base
commits, we would unwittingly copy the new rpmdb (with the layered
packages) into the base rpmdb location. This then of course throws off
any logic that assumes the rpmdb at that location is from the base
layer.

There's a slight compatibility issue here: there are still older layered
commits out there where we did this and which might throw off new logic
that relies on this. We bump the clientlayer version so that we can just
check for that version to know whether it's safe to use the base rpmdb.

---

I've also included some prep commits for #1502.