### PR TITLE
app/db-diff: Diff against rollback if no pending

### DIFF
--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -176,9 +176,10 @@ rpmostree_db_builtin_diff (int argc, char **argv,
 
       if (argc < 2)
         {
-          /* diff booted against pending deployment */
+          /* diff booted against pending or rollback deployment */
           g_autoptr(OstreeDeployment) pending = NULL;
-          ostree_sysroot_query_deployments_for (sysroot, NULL, &pending, NULL);
+          g_autoptr(OstreeDeployment) rollback = NULL;
+          ostree_sysroot_query_deployments_for (sysroot, NULL, &pending, &rollback);
           if (pending)
             {
               return print_deployment_diff (repo,
@@ -186,7 +187,14 @@ rpmostree_db_builtin_diff (int argc, char **argv,
                                             "pending deployment", pending,
                                             cancellable, error);
             }
-          return glnx_throw (error, "No pending deployment to diff against");
+          if (rollback)
+            {
+              return print_deployment_diff (repo,
+                                            "rollback deployment", rollback,
+                                            "booted deployment", booted,
+                                            cancellable, error);
+            }
+          return glnx_throw (error, "No pending or rollback deployment to diff against");
         }
       else
         {

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -115,6 +115,27 @@ get_checksum_from_deployment (OstreeRepo       *repo,
   return TRUE;
 }
 
+static gboolean
+print_deployment_diff (OstreeRepo        *repo,
+                       const char        *old_desc,
+                       OstreeDeployment  *old,
+                       const char        *new_desc,
+                       OstreeDeployment  *new,
+                       GCancellable      *cancellable,
+                       GError           **error)
+{
+  g_autofree char *old_checksum = NULL;
+  if (!get_checksum_from_deployment (repo, old, &old_checksum, error))
+    return FALSE;
+
+  g_autofree char *new_checksum = NULL;
+  if (!get_checksum_from_deployment (repo, new, &new_checksum, error))
+    return FALSE;
+
+  return print_diff (repo, old_desc, old_checksum, new_desc, new_checksum,
+                     cancellable, error);
+}
+
 gboolean
 rpmostree_db_builtin_diff (int argc, char **argv,
                            RpmOstreeCommandInvocation *invocation,
@@ -153,23 +174,26 @@ rpmostree_db_builtin_diff (int argc, char **argv,
       if (!booted)
         return glnx_throw (error, "Not booted into any deployment");
 
-      old_desc = "booted deployment";
-      if (!get_checksum_from_deployment (repo, booted, &old_checksum, error))
-        return FALSE;
-
       if (argc < 2)
         {
           /* diff booted against pending deployment */
-          new_desc = "pending deployment";
           g_autoptr(OstreeDeployment) pending = NULL;
           ostree_sysroot_query_deployments_for (sysroot, NULL, &pending, NULL);
-          if (!pending)
-            return glnx_throw (error, "No pending deployment to diff against");
-          if (!get_checksum_from_deployment (repo, pending, &new_checksum, error))
-            return FALSE;
+          if (pending)
+            {
+              return print_deployment_diff (repo,
+                                            "booted deployment", booted,
+                                            "pending deployment", pending,
+                                            cancellable, error);
+            }
+          return glnx_throw (error, "No pending deployment to diff against");
         }
       else
         {
+          old_desc = "booted deployment";
+          if (!get_checksum_from_deployment (repo, booted, &old_checksum, error))
+            return FALSE;
+
           /* diff against the booted deployment */
           new_desc = argv[1];
           if (!ostree_repo_resolve_rev (repo, new_desc, FALSE, &new_checksum, error))

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -163,7 +163,7 @@ rpmostree_db_builtin_diff (int argc, char **argv,
           new_desc = "pending deployment";
           g_autoptr(OstreeDeployment) pending = NULL;
           ostree_sysroot_query_deployments_for (sysroot, NULL, &pending, NULL);
-          if (!pending || ostree_deployment_equal (pending, booted))
+          if (!pending)
             return glnx_throw (error, "No pending deployment to diff against");
           if (!get_checksum_from_deployment (repo, pending, &new_checksum, error))
             return FALSE;

--- a/tests/vmcheck/test-layering-basic-1.sh
+++ b/tests/vmcheck/test-layering-basic-1.sh
@@ -137,7 +137,15 @@ vm_rpmostree install foo-1.0 --unchanged-exit-77 > foo-install.txt
 assert_file_has_content_literal foo-install.txt 'Checking out packages (1/1) 100%'
 echo "ok install not on a tty"
 
+# check that by default we diff booted vs pending
+vm_rpmostree db diff --format=diff > out.txt
+assert_file_has_content out.txt +foo-1.0
+
 vm_reboot
+
+# and check that now by default we diff rollback vs booted
+vm_rpmostree db diff --format=diff > out.txt
+assert_file_has_content out.txt +foo-1.0
 
 # Test `rpm-ostree status --pending-exit-77`, with no actual pending deployment
 rc=0


### PR DESCRIPTION
Often, after rebooting from an upgrade, I want to check what was just
updated. This patch makes `db diff` do the right thing in those cases.
Specifically, before `db diff` without arguments would default to
diff'ing the pending deployment with the booted deployment and error out
otherwise. This patch extends the logic so that if there's a rollback
deployment, we default to diff'ing against that.