### PR TITLE
compose: Add the timestamp to JSON metadata as ISO8601

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1306,6 +1306,18 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
     }
   g_print ("Wrote commit: %s\n", new_revision);
   g_variant_builder_add (&composemeta_builder, "{sv}", "ostree-commit", g_variant_new_string (new_revision));
+  /* Since JavaScript doesn't have 64 bit integers and hence neither does JSON,
+   * store this as a string:
+   * https://stackoverflow.com/questions/10286204/the-right-json-date-format
+   * */
+  { guint64 commit_ts = ostree_commit_get_timestamp (new_commit);
+    g_autoptr(GDateTime) timestamp = g_date_time_new_from_unix_utc (commit_ts);
+    /* If this fails...something went badly wrong */
+    g_assert (timestamp);
+    g_autofree char *commit_ts_iso_8601 = g_date_time_format (timestamp, "%FT%H:%M:%SZ");
+    g_assert (commit_ts_iso_8601);
+    g_variant_builder_add (&composemeta_builder, "{sv}", "ostree-timestamp", g_variant_new_string (commit_ts_iso_8601));
+  }
   const char *commit_version = NULL;
   (void)g_variant_lookup (new_commit_inline_meta, OSTREE_COMMIT_META_KEY_VERSION, "&s", &commit_version);
   if (commit_version)


### PR DESCRIPTION
In coreos-assembler I want to sort our builds by timestamp,
and having the ostree timestamp in the metadata is convenient.
