### PR TITLE
compose+rust: Parse includes via Rust too

### DIFF
--- a/Makefile-lib.am
+++ b/Makefile-lib.am
@@ -34,7 +34,7 @@ librpmostree_1_la_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/libglnx -I$(srcdir)/src/libp
 	-fvisibility=hidden '-D_RPMOSTREE_EXTERN=__attribute((visibility("default"))) extern' \
 	$(PKGDEP_RPMOSTREE_CFLAGS)
 librpmostree_1_la_LDFLAGS = $(AM_LDFLAGS) -version-number 1:0:0 -Bsymbolic-functions
-librpmostree_1_la_LIBADD =  $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la
+librpmostree_1_la_LIBADD =  $(PKGDEP_RPMOSTREE_LIBS) librpmostreepriv.la $(librpmostree_rust_path)
 
 # bundled libdnf
 INTROSPECTION_SCANNER_ENV = env LD_LIBRARY_PATH=$(top_builddir)/libdnf-build/libdnf

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -272,7 +272,7 @@ impl Treefile {
         workdir: openat::Dir,
     ) -> io::Result<Box<Treefile>> {
         let parsed = treefile_parse_recurse(filename, arch, 0)?;
-        let dfd = openat::Dir::open(filename.parent().unwrap_or_else(|| Path::new("/")))?;
+        let dfd = openat::Dir::open(filename.parent().unwrap())?;
         let rojig_spec = if let &Some(ref rojig) = &parsed.config.rojig {
             Some(Treefile::write_rojig_spec(&workdir, rojig)?)
         } else {

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -172,10 +172,11 @@ fn merge_basic_field<T>(dest: &mut Option<T>, src: &mut Option<T>) {
 /// Merge a vector field by appending. This semantic was originally designed for
 /// the `packages` key.
 fn merge_vec_field<T>(dest: &mut Option<Vec<T>>, src: &mut Option<Vec<T>>) {
-    if let Some(ref mut srcv) = src.take() {
-        let mut v = dest.take().map_or_else(|| vec![], |v| v);
-        v.append(srcv);
-        *dest = Some(v)
+    if let Some(mut srcv) = src.take() {
+        if let Some(ref mut destv) = dest {
+            srcv.append(destv);
+        }
+        *dest = Some(srcv);
     }
 }
 
@@ -195,6 +196,7 @@ fn treefile_merge(dest: &mut TreeComposeConfig, src: &mut TreeComposeConfig) {
     merge_vec_field(&mut dest.initramfs_args, &mut src.initramfs_args);
     merge_basic_field(&mut dest.boot_location, &mut src.boot_location);
     merge_basic_field(&mut dest.tmp_is_dir, &mut src.tmp_is_dir);
+    merge_basic_field(&mut dest.default_target, &mut src.default_target);
     merge_vec_field(&mut dest.units, &mut src.units);
     merge_basic_field(&mut dest.machineid_compat, &mut src.machineid_compat);
     merge_basic_field(&mut dest.releasever, &mut src.releasever);

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -23,13 +23,14 @@
 #include <ostree.h>
 
 #include "rpmostree-core.h"
+#include "rpmostree-rust.h"
 
 G_BEGIN_DECLS
 
 gboolean
 rpmostree_composeutil_checksum (GBytes            *serialized_treefile,
                                 HyGoal             goal,
-                                GFile             *contextdir,
+                                RORTreefile       *tf,
                                 JsonArray         *add_files,
                                 char             **out_checksum,
                                 GError           **error);
@@ -39,8 +40,8 @@ rpmostree_composeutil_legacy_prep_dev (int         rootfs_dfd,
                                        GError    **error);
 
 gboolean
-rpmostree_composeutil_sanity_checks (JsonObject   *treedata,
-                                     GFile        *contextdir,
+rpmostree_composeutil_sanity_checks (RORTreefile  *tf,
+                                     JsonObject   *treefile,
                                      GCancellable *cancellable,
                                      GError      **error);
 

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -22,6 +22,7 @@
 
 #include <ostree.h>
 #include "rpmostree-json-parsing.h"
+#include "rpmostree-rust.h"
 
 /* "public" for unit tests */
 char *
@@ -30,7 +31,7 @@ rpmostree_postprocess_replace_nsswitch (const char *buf,
 
 gboolean
 rpmostree_treefile_postprocessing (int            rootfs_fd,
-                                   GFile         *context_directory,
+                                   RORTreefile   *treefile_rs,
                                    GBytes        *serialized_treefile,
                                    JsonObject    *treefile,
                                    const char    *next_version,

--- a/tests/compose-tests/test-misc-tweaks.sh
+++ b/tests/compose-tests/test-misc-tweaks.sh
@@ -24,6 +24,8 @@ pysetjsonmember "postprocess-script" \"$PWD/postprocess.sh\"
 pysetjsonmember "postprocess" '["""#!/bin/bash
 touch /usr/share/postprocess-testing""",
 """#!/bin/bash
+set -xeuo pipefail
+touch /usr/share/included-postprocess-test
 rm /usr/share/postprocess-testing
 touch /usr/share/postprocess-testing-done"""]'
 cat > postprocess.sh << EOF
@@ -44,6 +46,18 @@ echo bar > composedata/bar.txt
 echo baz > composedata/baz.txt
 # Test tmp-is-dir
 pysetjsonmember "tmp-is-dir" 'True'
+
+new_treefile=composedata/fedora-misc-tweaks-includer.yaml
+cat > ${new_treefile} <<EOF
+include: $(basename ${treefile})
+postprocess:
+ - |
+   #!/bin/bash
+   set -xeuo pipefail
+   test -f /usr/share/included-postprocess-test
+EOF
+export treefile=${new_treefile}
+
 
 # Do the compose
 runcompose


### PR DESCRIPTION

The core bug here is that previously if we had multiple YAML files
in `include`, we ended up overwriting `self->treefile_rs` for the
last one.  Handling inheritance worked, but it broke `rojig` since
we generate the specfile Rust side.

Fix this by moving more of the parsing into Rust.  There are a
lot of advantages to this - the include handling was ugly un-typesafe C code
with no unit tests, now it's memory safe Rust with unit tests.

The downside here is I ended up spelling out the list of fields
again - there's probably a way to unify this via macros but
for now I think this is OK.