### PR TITLE
libpriv/scripts: Add rpmdb query sanity checks

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -1332,7 +1332,7 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
                            &deployment_dfd, error))
         return FALSE;
 
-      if (!rpmostree_deployment_sanitycheck (deployment_dfd, cancellable, error))
+      if (!rpmostree_deployment_sanitycheck_true (deployment_dfd, cancellable, error))
         return FALSE;
     }
   else

--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -75,6 +75,13 @@ rpmostree_transfiletriggers_run_sync (Header         hdr,
                                       GError       **error);
 
 gboolean
-rpmostree_deployment_sanitycheck (int           rootfs_fd,
-                                  GCancellable *cancellable,
-                                  GError      **error);
+rpmostree_deployment_sanitycheck_true (int           rootfs_fd,
+                                       GCancellable *cancellable,
+                                       GError      **error);
+
+gboolean
+rpmostree_deployment_sanitycheck_rpmdb (int           rootfs_fd,
+                                        GPtrArray     *overlays,
+                                        GPtrArray     *overrides,
+                                        GCancellable *cancellable,
+                                        GError      **error);


### PR DESCRIPTION
Make sure we can open and query the rpmdb when creating new deployments.
This should help filter out cases where somehow librpm failed to
actually write the rpmdb but didn't error out.

See: #1566