### PR TITLE
compose: Fix omission of --cache-only to always fetch metadata again

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -272,13 +272,13 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
   if (opt_cachedir && !opt_unified_core)
     dnf_context_set_keep_cache (dnfctx, TRUE);
   /* For compose, always try to refresh metadata; we're used in build servers
-   * where fetching should be cheap. Otherwise, if --cache-only is set, it's
-   * likely an offline developer laptop case, so never refresh.
+   * where fetching should be cheap.  We also have --cache-only which is
+   * used by coreos-assembler.  Today we don't expose the default, but we
+   * could add --cache-default or something if someone wanted it.
    */
-  if (!opt_cache_only)
-    dnf_context_set_cache_age (dnfctx, 0);
-  else
-    dnf_context_set_cache_age (dnfctx, G_MAXUINT);
+  rpmostree_context_set_dnf_caching (self->corectx,
+                                     opt_cache_only ? RPMOSTREE_CONTEXT_DNF_CACHE_FOREVER :
+                                     RPMOSTREE_CONTEXT_DNF_CACHE_NEVER);
   /* Without specifying --cachedir we'd just toss the data we download, so let's
    * catch that.
    */

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -39,6 +39,7 @@ struct _RpmOstreeContext {
 
   gboolean pkgcache_only;
   DnfContext *dnfctx;
+  RpmOstreeContextDnfCachePolicy dnf_cache_policy;
   OstreeRepo *ostreerepo;
   OstreeRepo *pkgcache_repo;
   OstreeRepoDevInoCache *devino_cache;

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -80,6 +80,15 @@ RpmOstreeContext *rpmostree_context_new_tree (int basedir_dfd,
 void rpmostree_context_set_pkgcache_only (RpmOstreeContext *self,
                                           gboolean          pkgcache_only);
 
+typedef enum {
+      RPMOSTREE_CONTEXT_DNF_CACHE_FOREVER,
+      RPMOSTREE_CONTEXT_DNF_CACHE_DEFAULT,
+      RPMOSTREE_CONTEXT_DNF_CACHE_NEVER,
+} RpmOstreeContextDnfCachePolicy;
+
+void rpmostree_context_set_dnf_caching (RpmOstreeContext *self,
+                                        RpmOstreeContextDnfCachePolicy policy);
+
 DnfContext * rpmostree_context_get_dnf (RpmOstreeContext *self);
 
 RpmOstreeTreespec *rpmostree_treespec_new_from_keyfile (GKeyFile *keyfile, GError  **error);


### PR DESCRIPTION
PR: https://github.com/projectatomic/rpm-ostree/pull/1562
AKA commit: a7bbf5bc142d9dac5b1bfb86d0466944d38baa24
introduced a regression for `compose tree`.  The intention is
the default there is to *always* immediately check for updated
rpm-md - a bit like `yum clean expire-cache`.  However due
to bugs in the stack we end up downloading it again anyways, but
that's not the topic here.

When we made that change we basically stopped using `DnfContext`'s
`cache_age`, which is what `compose tree` was setting.

Introduce a new explicit API to do what we want for `compose tree`.

Note that `--cache-only` has never actually done that, it basically
just makes `compose tree` use the default `metadata_expire`.  Fixing
that would need new libdnf API.
