### PR TITLE
rust/treefile: Use the c_utf8 crate

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,6 +15,7 @@ glib = "0.5.0"
 tempfile = "3.0.3"
 openat = "0.1.15"
 curl = "0.4.14"
+c_utf8 = "0.1.0"
 
 [lib]
 name = "rpmostree_rust"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+extern crate c_utf8;
 extern crate curl;
 extern crate gio_sys;
 extern crate glib;


### PR DESCRIPTION
The advantage of this over CStr is that Rust knows it's UTF-8
too.  I also tweaked our path code to use String, and only
view it as a `Path`.  This avoids having to `unwrap()` later
back to a `str`.
