### PR TITLE
libpriv/postprocess: Handle ENOTEMPTY from renameat

### DIFF
--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -117,7 +117,7 @@ rename_if_exists (int         src_dfd,
       if (renameat (src_dfd, from, dest_dfd, to) < 0)
         {
           /* Handle empty directory in legacy location */
-          if (errno == EEXIST)
+          if (G_IN_SET (errno, EEXIST, ENOTEMPTY))
             {
               if (!glnx_unlinkat (src_dfd, from, AT_REMOVEDIR, error))
                 return FALSE;


### PR DESCRIPTION
While debugging test failures in #1584, I was perplexed to find that the
ex-container tests didn't work on current git master. It turns out we
were only checking for one of the two possible error codes in the case
where we rename to a non-empty dir. So why is CI getting `EEXIST` while
locally I get `ENOTEMPTY`? Doing some diving kernel-side revealed it's
due to xfs vs tmpfs.