### PR TITLE
bwrap: Add APIs to set up bind mounts

### DIFF
--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -46,7 +46,8 @@ RpmOstreeBwrap *rpmostree_bwrap_new (int rootfs,
                                      ...) G_GNUC_NULL_TERMINATED;
 
 void rpmostree_bwrap_set_inherit_stdin (RpmOstreeBwrap *bwrap);
-void rpmostree_bwrap_append_bwrap_argv (RpmOstreeBwrap *bwrap, ...) G_GNUC_NULL_TERMINATED;
+void rpmostree_bwrap_bind_read (RpmOstreeBwrap *bwrap, const char *src, const char *dest);
+void rpmostree_bwrap_bind_readwrite (RpmOstreeBwrap *bwrap, const char *src, const char *dest);
 void rpmostree_bwrap_append_child_argv (RpmOstreeBwrap *bwrap, ...) G_GNUC_NULL_TERMINATED;
 void rpmostree_bwrap_append_child_argva (RpmOstreeBwrap *bwrap, int argc, char **argv);
 

--- a/src/libpriv/rpmostree-kernel.c
+++ b/src/libpriv/rpmostree-kernel.c
@@ -520,24 +520,20 @@ rpmostree_run_dracut (int     rootfs_dfd,
       bwrap = rpmostree_bwrap_new_base (rootfs_dfd, error);
       if (!bwrap)
         return FALSE;
-      rpmostree_bwrap_append_bwrap_argv (bwrap,
-                                         "--ro-bind", "/etc", "/etc",
-                                         "--ro-bind", "usr", "/usr",
-                                         NULL);
+      rpmostree_bwrap_bind_read (bwrap, "/etc", "/etc");
+      rpmostree_bwrap_bind_read (bwrap, "usr", "/usr");
     }
   else
     {
       bwrap = rpmostree_bwrap_new_base (rootfs_dfd, error);
       if (!bwrap)
         return FALSE;
-      rpmostree_bwrap_append_bwrap_argv (bwrap,
-                                        "--ro-bind", "usr/etc", "/etc",
-                                        "--ro-bind", "usr", "/usr",
-                                        NULL);
+      rpmostree_bwrap_bind_read (bwrap, "usr/etc", "/etc");
+      rpmostree_bwrap_bind_read (bwrap, "usr", "/usr");
     }
 
   if (dracut_host_tmpdir)
-    rpmostree_bwrap_append_bwrap_argv (bwrap, "--bind", dracut_host_tmpdir->path, "/tmp/dracut", NULL);
+    rpmostree_bwrap_bind_readwrite (bwrap, dracut_host_tmpdir->path, "/tmp/dracut");
 
   /* Set up argv and run */
   rpmostree_bwrap_append_child_argv (bwrap, (char*)glnx_basename (rpmostree_dracut_wrapper_path), NULL);

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -364,7 +364,7 @@ run_script_in_bwrap_container (int rootfs_fd,
     goto out;
 
   if (var_lib_rpm_statedir)
-    rpmostree_bwrap_append_bwrap_argv (bwrap, "--bind", var_lib_rpm_statedir->path, "/var/lib/rpm-state", NULL);
+    rpmostree_bwrap_bind_readwrite (bwrap, var_lib_rpm_statedir->path, "/var/lib/rpm-state");
 
   const gboolean debugging_script = g_strcmp0 (g_getenv ("RPMOSTREE_SCRIPT_DEBUG"), pkg_script) == 0;
 


### PR DESCRIPTION
This is prep for adding a "backend" to this that uses just plain
`chroot` - we want things to avoid talking to bwrap's commandline
directly.
