### PR TITLE
core,scripts: When no cachedir is enabled in unified-core, disable FUSE

### DIFF
--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -42,6 +42,7 @@ struct _RpmOstreeContext {
   RpmOstreeContextDnfCachePolicy dnf_cache_policy;
   OstreeRepo *ostreerepo;
   OstreeRepo *pkgcache_repo;
+  gboolean enable_rofiles;
   OstreeRepoDevInoCache *devino_cache;
   gboolean unprivileged;
   OstreeSePolicy *sepolicy;

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -3310,6 +3310,15 @@ apply_rpmfi_overrides (RpmOstreeContext *self,
       rpm_mode_t mode = rpmfiFMode (fi);
       rpmfileAttrs fattrs = rpmfiFFlags (fi);
       const gboolean is_ghost = fattrs & RPMFILE_GHOST;
+      /* If we hardlinked from a bare-user repo, we won't have these higher bits
+       * set. The intention there is to avoid having transient suid binaries
+       * exposed, but in practice today for rpm-ostree we use the "inaccessible
+       * directory" pattern in repo/tmp.
+       *
+       * Another thing we could do down the line is to not chown things on disk
+       * and instead pass this data down into the commit modifier. That's in
+       * fact how gnome-continuous always worked.
+       */
       const gboolean has_non_bare_user_mode =
         (mode & (S_ISUID | S_ISGID | S_ISVTX)) > 0;
 

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -381,6 +381,7 @@ rpmostree_context_init (RpmOstreeContext *self)
 {
   self->tmprootfs_dfd = -1;
   self->dnf_cache_policy = RPMOSTREE_CONTEXT_DNF_CACHE_DEFAULT;
+  self->enable_rofiles = TRUE;
 }
 
 static void
@@ -555,9 +556,17 @@ void
 rpmostree_context_set_devino_cache (RpmOstreeContext *self,
                                     OstreeRepoDevInoCache *devino_cache)
 {
+  g_assert (self->enable_rofiles);
   if (self->devino_cache)
     ostree_repo_devino_cache_unref (self->devino_cache);
   self->devino_cache = devino_cache ? ostree_repo_devino_cache_ref (devino_cache) : NULL;
+}
+
+void
+rpmostree_context_disable_rofiles (RpmOstreeContext *self)
+{
+  g_assert (!self->devino_cache);
+  self->enable_rofiles = FALSE;
 }
 
 DnfContext *
@@ -2577,6 +2586,7 @@ checkout_package (OstreeRepo   *repo,
                   const char   *pkg_commit,
                   GHashTable   *files_skip,
                   OstreeRepoCheckoutOverwriteMode ovwmode,
+                  gboolean      force_copy_zerosized,
                   GCancellable *cancellable,
                   GError      **error)
 {
@@ -2591,6 +2601,8 @@ checkout_package (OstreeRepo   *repo,
 
   /* Always want hardlinks */
   opts.no_copy_fallback = TRUE;
+  /* Used in the no-rofiles-fuse path */
+  opts.force_copy_zerosized = force_copy_zerosized;
 
   if (files_skip && g_hash_table_size (files_skip) > 0)
     {
@@ -2632,6 +2644,7 @@ checkout_package_into_root (RpmOstreeContext *self,
 
   if (!checkout_package (pkgcache_repo, dfd, path,
                          devino_cache, pkg_commit, files_skip, ovwmode,
+                         !self->enable_rofiles,
                          cancellable, error))
     return glnx_prefix_error (error, "Checkout %s", dnf_package_get_nevra (pkg));
 
@@ -2887,7 +2900,7 @@ relabel_in_thread_impl (RpmOstreeContext *self,
   g_autoptr(OstreeRepoDevInoCache) cache = ostree_repo_devino_cache_new ();
 
   if (!checkout_package (repo, tmpdir_dfd, pkg_dirname, cache,
-                         commit_csum, NULL, OSTREE_REPO_CHECKOUT_OVERWRITE_NONE,
+                         commit_csum, NULL, OSTREE_REPO_CHECKOUT_OVERWRITE_NONE, FALSE,
                          cancellable, error))
     return FALSE;
 
@@ -3256,7 +3269,7 @@ run_script_sync (RpmOstreeContext *self,
     return FALSE;
 
   if (!rpmostree_script_run_sync (pkg, hdr, kind, rootfs_dfd, var_lib_rpm_statedir,
-                                  out_n_run, cancellable, error))
+                                  self->enable_rofiles, out_n_run, cancellable, error))
     return FALSE;
 
   return TRUE;
@@ -3521,7 +3534,8 @@ run_all_transfiletriggers (RpmOstreeContext *self,
       Header hdr;
       while ((hdr = rpmdbNextIterator (mi)) != NULL)
         {
-          if (!rpmostree_transfiletriggers_run_sync (hdr, rootfs_dfd, out_n_run,
+          if (!rpmostree_transfiletriggers_run_sync (hdr, rootfs_dfd, self->enable_rofiles,
+                                                     out_n_run,
                                                      cancellable, error))
             return FALSE;
         }
@@ -3540,8 +3554,8 @@ run_all_transfiletriggers (RpmOstreeContext *self,
       if (!get_package_metainfo (self, path, &hdr, NULL, error))
         return FALSE;
 
-      if (!rpmostree_transfiletriggers_run_sync (hdr, rootfs_dfd, out_n_run,
-                                                 cancellable, error))
+      if (!rpmostree_transfiletriggers_run_sync (hdr, rootfs_dfd, self->enable_rofiles,
+                                                 out_n_run, cancellable, error))
         return FALSE;
     }
   return TRUE;

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -121,6 +121,7 @@ void rpmostree_context_set_repos (RpmOstreeContext *self,
                                   OstreeRepo       *pkgcache_repo);
 void rpmostree_context_set_devino_cache (RpmOstreeContext *self,
                                          OstreeRepoDevInoCache *devino_cache);
+void rpmostree_context_disable_rofiles (RpmOstreeContext *self);
 void rpmostree_context_set_sepolicy (RpmOstreeContext *self,
                                      OstreeSePolicy   *sepolicy);
 

--- a/src/libpriv/rpmostree-importer.c
+++ b/src/libpriv/rpmostree-importer.c
@@ -662,9 +662,16 @@ compose_filter_cb (OstreeRepo         *repo,
         }
     }
 
+  /* Special case exemptions */
+  if (g_str_has_prefix (path, "/usr/etc/selinux") &&
+      g_str_has_suffix (path, ".LOCK"))
+    {
+      /* These empty lock files cause problems;
+       * https://github.com/projectatomic/rpm-ostree/pull/1002
+       */
+      return OSTREE_REPO_COMMIT_FILTER_SKIP;
+    }
   /* convert /run and /var entries to tmpfiles.d */
-  if (g_str_has_prefix (path, "/" VAR_SELINUX_TARGETED_PATH))
-    ; /* Handled by pathname translation */
   else if (g_str_has_prefix (path, "/run/") ||
            g_str_has_prefix (path, "/var/"))
     {

--- a/src/libpriv/rpmostree-scripts.h
+++ b/src/libpriv/rpmostree-scripts.h
@@ -63,6 +63,7 @@ rpmostree_script_run_sync (DnfPackage    *pkg,
                            RpmOstreeScriptKind kind,
                            int            rootfs_fd,
                            GLnxTmpDir    *var_lib_rpm_statedir,
+                           gboolean       enable_rofiles,
                            guint         *out_n_run,
                            GCancellable  *cancellable,
                            GError       **error);
@@ -70,6 +71,7 @@ rpmostree_script_run_sync (DnfPackage    *pkg,
 gboolean
 rpmostree_transfiletriggers_run_sync (Header         hdr,
                                       int            rootfs_fd,
+                                      gboolean       enable_rofiles,
                                       guint         *out_n_run,
                                       GCancellable  *cancellable,
                                       GError       **error);

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -549,3 +549,16 @@ EOF
                     post "semodule -n -i ${install_dir}/${name}.pp" \
                     files "${install_dir}/${name}.pp"
 }
+
+files_are_hardlinked() {
+    inode1=$(stat -c %i $1)
+    inode2=$(stat -c %i $2)
+    test -n "${inode1}" && test -n "${inode2}"
+    [ "${inode1}" == "${inode2}" ]
+}
+
+assert_files_hardlinked() {
+    if ! files_are_hardlinked "$1" "$2"; then
+        fatal "Files '$1' and '$2' are not hardlinked"
+    fi
+}


### PR DESCRIPTION
This is prep for running inside (unprivileged) Kube containers
as they exist today: https://github.com/projectatomic/rpm-ostree/issues/1329

Sadly FUSE today uses a suid binary that ends up wanting CAP_SYS_ADMIN.
I think there's some work on FUSE-in-containers but I'm not sure of
the current status.

What rofiles-fuse here is doing here is protecting is the hardlinked
repo imports.  But if `--cachedir` isn't specified, that repository
gets thrown away anyways.  So there's no real value to using FUSE
here.

Also since nothing is cached, disable the devino cache.

Down the line ideally we gain the capability to detect if either
unprivileged overlayfs/FUSE are available.  Then if `--cachedir`
is specified we can make things work.
