### PR TITLE
 bwrap: Also drop constructor direct bwrap arguments

### DIFF
--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -42,10 +42,10 @@ RpmOstreeBwrap *rpmostree_bwrap_new_base (int rootfs, GError **error);
 
 RpmOstreeBwrap *rpmostree_bwrap_new (int rootfs,
                                      RpmOstreeBwrapMutability mutable,
-                                     GError **error,
-                                     ...) G_GNUC_NULL_TERMINATED;
+                                     GError **error);
 
 void rpmostree_bwrap_set_inherit_stdin (RpmOstreeBwrap *bwrap);
+void rpmostree_bwrap_var_tmp_tmpfs (RpmOstreeBwrap *bwrap);
 void rpmostree_bwrap_bind_read (RpmOstreeBwrap *bwrap, const char *src, const char *dest);
 void rpmostree_bwrap_bind_readwrite (RpmOstreeBwrap *bwrap, const char *src, const char *dest);
 void rpmostree_bwrap_append_child_argv (RpmOstreeBwrap *bwrap, ...) G_GNUC_NULL_TERMINATED;


### PR DESCRIPTION

Following on to the previous change which added an explicit bind
mount API and also removed the API to append bwrap arguments, let's
also change the constructor to disallow the latter.

There was just one non-bind-mount argument being used
for "ro /var + tmpfs /var/tmp" - change that to an explicit new
API.

Looking at all of this, perhaps what we really want is to move
the "mutability" for `/var` underneath our API too, but let's
do this smaller incremental step first.