### PR TITLE
compose-tests: Use yaml.safe_dump

### DIFF
--- a/tests/compose-tests/libcomposetest.sh
+++ b/tests/compose-tests/libcomposetest.sh
@@ -56,7 +56,7 @@ ifn="${treefile}"
 ofn=ifn.replace('.json', '.yaml')
 jd=json.load(open(ifn))
 with open(ofn, "w") as f:
-  f.write(yaml.dump(jd))
+  yaml.safe_dump(jd, f)
 EOF
         export treefile=composedata/fedora-${name}.yaml
     fi

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -38,7 +38,7 @@ python <<EOF
 import json, yaml
 jd=json.load(open("$treefile"))
 with open("$treefile.yaml", "w") as f:
-  f.write(yaml.dump(jd))
+  yaml.safe_dump(jd, f)
 EOF
 export treefile=$treefile.yaml
 runcompose


### PR DESCRIPTION
Otherwise we end up with weird `!!python/unicode` stuff:
https://stackoverflow.com/questions/20352794/pyyaml-is-producing-undesired-python-unicode-output/20369984
