### PR TITLE
compose: Move "serialized treefile" into Rust ownership

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -135,6 +135,16 @@ pub extern "C" fn ror_treefile_get_add_file_fd(
 }
 
 #[no_mangle]
+pub extern "C" fn ror_treefile_get_passwd_fd(tf: *mut Treefile) -> libc::c_int {
+    tf_from_raw(tf).externals.passwd.as_ref().map_or(-1, |fd| fd.as_raw_fd())
+}
+
+#[no_mangle]
+pub extern "C" fn ror_treefile_get_group_fd(tf: *mut Treefile) -> libc::c_int {
+    tf_from_raw(tf).externals.group.as_ref().map_or(-1, |fd| fd.as_raw_fd())
+}
+
+#[no_mangle]
 pub extern "C" fn ror_treefile_get_json_string(tf: *mut Treefile) -> *const libc::c_char {
     tf_from_raw(tf).serialized.as_ptr()
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -131,19 +131,10 @@ pub extern "C" fn ror_treefile_get_add_file_fd(
 }
 
 #[no_mangle]
-pub extern "C" fn ror_treefile_to_json(
-    tf: *mut Treefile,
-    gerror: *mut *mut glib_sys::GError,
-) -> libc::c_int {
+pub extern "C" fn ror_treefile_get_json_string(tf: *mut Treefile) -> *const libc::c_char {
     assert!(!tf.is_null());
     let tf = unsafe { &mut *tf };
-    match tf.serialize_json_fd() {
-        Ok(f) => f.into_raw_fd() as libc::c_int,
-        Err(e) => {
-            error_to_glib(&e, gerror);
-            -1 as libc::c_int
-        }
-    }
+    tf.serialized.as_ptr()
 }
 
 #[no_mangle]

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -172,8 +172,8 @@ fn treefile_parse<P: AsRef<Path>>(
         externals: TreefileExternals {
             postprocess_script,
             add_files,
-            passwd: passwd,
-            group: group,
+            passwd,
+            group,
         },
     })
 }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -120,14 +120,17 @@ fn treefile_parse_stream<R: io::Read>(
 }
 
 // If a passwd/group file is provided explicitly, load it as a fd
-fn load_passwd_file<P: AsRef<Path>>(basedir: P, v: &Option<CheckPasswd>) -> io::Result<Option<fs::File>> {
+fn load_passwd_file<P: AsRef<Path>>(
+    basedir: P,
+    v: &Option<CheckPasswd>,
+) -> io::Result<Option<fs::File>> {
     if let &Some(ref v) = v {
         let basedir = basedir.as_ref();
         if let Some(ref path) = v.filename {
-            return Ok(Some(fs::File::open(basedir.join(path))?))
+            return Ok(Some(fs::File::open(basedir.join(path))?));
         }
     }
-    return Ok(None)
+    return Ok(None);
 }
 
 /// Given a treefile filename and an architecture, parse it and also

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1003,16 +1003,15 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
                                     cancellable, error))
     return FALSE;
 
-  if (self->treefile)
+  if (self->treefile_rs)
     {
-      g_autoptr(GFile) treefile_dirpath = g_file_get_parent (self->treefile_path);
-      if (!rpmostree_check_passwd (self->repo, self->rootfs_dfd, treefile_dirpath, self->treefile,
-                                   self->previous_checksum,
+      if (!rpmostree_check_passwd (self->repo, self->rootfs_dfd, self->treefile_rs,
+                                   self->treefile, self->previous_checksum,
                                    cancellable, error))
         return glnx_prefix_error (error, "Handling passwd db");
 
-      if (!rpmostree_check_groups (self->repo, self->rootfs_dfd, treefile_dirpath, self->treefile,
-                                   self->previous_checksum,
+      if (!rpmostree_check_groups (self->repo, self->rootfs_dfd, self->treefile_rs,
+                                   self->treefile, self->previous_checksum,
                                    cancellable, error))
         return glnx_prefix_error (error, "Handling group db");
     }

--- a/src/app/rpmostree-composeutil.c
+++ b/src/app/rpmostree-composeutil.c
@@ -47,8 +47,7 @@
 #include "libglnx.h"
 
 gboolean
-rpmostree_composeutil_checksum (GBytes            *serialized_treefile,
-                                HyGoal             goal,
+rpmostree_composeutil_checksum (HyGoal             goal,
                                 RORTreefile       *tf,
                                 JsonArray         *add_files,
                                 char             **out_checksum,
@@ -60,11 +59,7 @@ rpmostree_composeutil_checksum (GBytes            *serialized_treefile,
    * or adding a comment will cause a recompose, but let's be conservative
    * here.
    */
-  { gsize len;
-    const guint8* buf = g_bytes_get_data (serialized_treefile, &len);
-
-    g_checksum_update (checksum, buf, len);
-  }
+  g_checksum_update (checksum, (guint8*)ror_treefile_get_json_string (tf), -1);
 
   if (add_files)
     {

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -28,8 +28,7 @@
 G_BEGIN_DECLS
 
 gboolean
-rpmostree_composeutil_checksum (GBytes            *serialized_treefile,
-                                HyGoal             goal,
+rpmostree_composeutil_checksum (HyGoal             goal,
                                 RORTreefile       *tf,
                                 JsonArray         *add_files,
                                 char             **out_checksum,

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -24,10 +24,12 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include "rpmostree-rust.h"
+
 gboolean
 rpmostree_check_passwd (OstreeRepo      *repo,
                         int              rootfs_dfd,
-                        GFile           *treefile_path,
+                        RORTreefile     *treefile_rs,
                         JsonObject      *treedata,
                         const char      *previous_commit,
                         GCancellable    *cancellable,
@@ -36,7 +38,7 @@ rpmostree_check_passwd (OstreeRepo      *repo,
 gboolean
 rpmostree_check_groups (OstreeRepo      *repo,
                         int              rootfs_dfd,
-                        GFile           *treefile_path,
+                        RORTreefile     *treefile_rs,
                         JsonObject      *treedata,
                         const char      *previous_commit,
                         GCancellable    *cancellable,

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1484,7 +1484,6 @@ mutate_os_release (const char    *contents,
 gboolean
 rpmostree_treefile_postprocessing (int            rootfs_fd,
                                    RORTreefile   *treefile_rs,
-                                   GBytes        *serialized_treefile,
                                    JsonObject    *treefile,
                                    const char    *next_version,
                                    gboolean       unified_core_mode,
@@ -1554,14 +1553,11 @@ rpmostree_treefile_postprocessing (int            rootfs_fd,
   if (!glnx_shutil_mkdir_p_at (rootfs_fd, "usr/share/rpm-ostree", 0755, cancellable, error))
     return FALSE;
 
-  { gsize len;
-    const guint8 *buf = g_bytes_get_data (serialized_treefile, &len);
-
-    if (!glnx_file_replace_contents_at (rootfs_fd, "usr/share/rpm-ostree/treefile.json",
-                                        buf, len, GLNX_FILE_REPLACE_NODATASYNC,
-                                        cancellable, error))
-      return FALSE;
-  }
+  if (!glnx_file_replace_contents_at (rootfs_fd, "usr/share/rpm-ostree/treefile.json",
+                                      (guint8*)ror_treefile_get_json_string (treefile_rs), -1,
+                                      GLNX_FILE_REPLACE_NODATASYNC,
+                                      cancellable, error))
+    return FALSE;
 
   const char *default_target = NULL;
   if (!_rpmostree_jsonutil_object_get_optional_string_member (treefile, "default_target",

--- a/src/libpriv/rpmostree-postprocess.h
+++ b/src/libpriv/rpmostree-postprocess.h
@@ -32,7 +32,6 @@ rpmostree_postprocess_replace_nsswitch (const char *buf,
 gboolean
 rpmostree_treefile_postprocessing (int            rootfs_fd,
                                    RORTreefile   *treefile_rs,
-                                   GBytes        *serialized_treefile,
                                    JsonObject    *treefile,
                                    const char    *next_version,
                                    gboolean       unified_core_mode,

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -3,7 +3,21 @@ basic_test() {
 if ostree --repo=${repobuild} ls -R ${treeref} /usr/etc/passwd-; then
     assert_not_reached "Found /usr/etc/passwd- backup file in tree"
 fi
-echo "ok passwd"
+echo "ok passwd no backups"
+
+validate_passwd() {
+    f=$1
+    shift
+    ostree --repo=${repobuild} cat ${treeref} /usr/lib/$f |grep -v '^root' | sort > $f.tree
+    cat composedata/$f | while read line; do
+        if ! grep -q "$line" "$f.tree"; then
+            echo "Missing entry: %line"
+        fi
+    done
+}
+
+validate_passwd passwd
+validate_passwd group
 
 for path in /usr/share/rpm /usr/lib/sysimage/rpm-ostree-base-db; do
     ostree --repo=${repobuild} ls -R ${treeref} ${path} > db.txt


### PR DESCRIPTION
Now that we have `CUtf8`, let's just store the serialized JSON
as a string, owned by the Rust side.  This way we can drop the
`serialized_treefile` buffer we were passing around and simplify
various bits of code.  Most notably, we only serialize the JSON
once (via Serde) rather than also doing it again in the C side.
