### PR TITLE
status: Detect if staging failed in previous boot

### DIFF
--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -92,23 +92,23 @@ if !HAVE_EXTERNAL_CBINDGEN
 rpmostree-bindgen: bindgen/Cargo.toml bindgen/src/main.rs
 	cd $(top_srcdir)/bindgen && \
 	export CARGO_TARGET_DIR=@abs_top_builddir@/bindgen-target && \
+	if test -d "$${CARGO_TARGET_DIR}" && [ "$$(stat -c '%u' ${target_subdir})" != "$$(id -u)" ]; then echo "mismatched uids on build"; exit 1; fi && \
 	$(cargo_build) && \
 	ln -sf $${CARGO_TARGET_DIR}/debug/rpmostree-bindgen $(abs_top_builddir)/rpmostree-bindgen
 endif
 endif
 
 librpmostree_rust_path = @abs_top_builddir@/target/@RUST_TARGET_SUBDIR@/librpmostree_rust.a
-# If the target directory exists, and isn't owned by our uid,
-# we use --frozen this happens with the `make && sudo make install`
-# pattern.  If we did `sudo cargo`, then we'd be using a different cargo
-# cache, etc.
+# If the target directory exists, and isn't owned by our uid, then
+# we exit with a fatal error, since someone probably did `make && sudo make install`,
+# and in this case cargo will download into ~/.root which we don't want.
 LIBRPMOSTREE_RUST_SRCS = $(wildcard rust/src/*.rs) rust/cbindgen.toml
 $(librpmostree_rust_path): Makefile $(LIBRPMOSTREE_RUST_SRCS)
 	cd $(top_srcdir)/rust && \
 	  export CARGO_TARGET_DIR=@abs_top_builddir@/target && \
     target_subdir=@abs_top_builddir@/target/@RUST_TARGET_SUBDIR@; \
-	  if test -d "{target_subdir}" && [ "$(stat -c '%u' ${target_subdir})" != "$(id -u)" ]; then frozen=--frozen; fi && \
-	  $(cargo_build) $${frozen} $(CARGO_RELEASE_ARGS)
+	  if test -d "$${target_subdir}" && [ "$$(stat -c '%u' $${target_subdir})" != "$$(id -u)" ]; then echo "mismatched uids on build"; exit 1; fi && \
+	  $(cargo_build) $(CARGO_RELEASE_ARGS)
 EXTRA_DIST += $(LIBRPMOSTREE_RUST_SRCS) rust/Cargo.lock
 
 # Generate bindings from Rust to C

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rpmostree-rust"
 version = "0.1.0"
-authors = ["Colin Walters <walters@verbum.org>"]
+authors = ["Colin Walters <walters@verbum.org>", "Jonathan Lebon <jonathan@jlebon.com>"]
 
 [dependencies]
 serde = "1.0.78"
@@ -16,6 +16,11 @@ tempfile = "3.0.3"
 openat = "0.1.15"
 curl = "0.4.14"
 c_utf8 = "0.1.0"
+systemd = "0.3.0"
+
+# Until https://github.com/jmesmon/rust-systemd/pull/54 gets merged
+[patch.crates-io]
+systemd =  { git = "https://github.com/jlebon/rust-systemd", branch = "pr/add-monotonic" }
 
 [lib]
 name = "rpmostree_rust"

--- a/rust/src/journal.rs
+++ b/rust/src/journal.rs
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+extern crate systemd;
+
+use self::systemd::id128::Id128;
+use self::systemd::journal;
+use std::io;
+
+static OSTREE_FINALIZE_STAGED_SERVICE: &'static str = "ostree-finalize-staged.service";
+static OSTREE_DEPLOYMENT_FINALIZING_MSG_ID: &'static str = "e8646cd63dff4625b77909a8e7a40994";
+static OSTREE_DEPLOYMENT_COMPLETE_MSG_ID: &'static str = "dd440e3e549083b63d0efc7dc15255f1";
+
+/// Look for a failure from ostree-finalized-stage.service in the journal of the previous boot.
+pub fn journal_find_staging_failure() -> io::Result<bool> {
+    let mut j = journal::Journal::open(journal::JournalFiles::System, false, true)?;
+
+    // first, go to the first entry of the current boot
+    let boot_id = Id128::from_boot()?;
+    j.match_add("_BOOT_ID", boot_id.to_string().as_str())?;
+    j.seek(journal::JournalSeek::Head)?;
+    j.match_flush()?;
+
+    // Now, go backwards until we hit the first entry from the previous boot. In theory that should
+    // just be a single `sd_journal_previous()` call, but we need a loop here, see:
+    // https://github.com/systemd/systemd/commit/dc00966228ff90c554fd034e588ea55eb605ec52
+    let mut previous_boot_id: Id128 = boot_id.clone();
+    while previous_boot_id == boot_id {
+        match j.previous_record()? {
+            Some(_) => previous_boot_id = j.monotonic_timestamp()?.1,
+            None => return Ok(false), // no previous boot!
+        }
+    }
+    // we just need it as a string from now on
+    let previous_boot_id = previous_boot_id.to_string();
+
+    // look for OSTree's finalization msg
+    j.match_add("MESSAGE_ID", OSTREE_DEPLOYMENT_FINALIZING_MSG_ID)?;
+    j.match_add("_SYSTEMD_UNIT", OSTREE_FINALIZE_STAGED_SERVICE)?;
+    j.match_add("_BOOT_ID", previous_boot_id.as_str())?;
+    if j.previous_record()? == None {
+        return Ok(false); // didn't run (or staged deployment was cleaned up)
+    }
+
+    // and now check if it actually completed the transaction
+    j.match_flush()?;
+    j.match_add("MESSAGE_ID", OSTREE_DEPLOYMENT_COMPLETE_MSG_ID)?;
+    j.match_add("_SYSTEMD_UNIT", OSTREE_FINALIZE_STAGED_SERVICE)?;
+    j.match_add("_BOOT_ID", previous_boot_id.as_str())?;
+
+    Ok(j.next_record()? == None)
+}

--- a/rust/src/journal.rs
+++ b/rust/src/journal.rs
@@ -26,8 +26,15 @@ static OSTREE_FINALIZE_STAGED_SERVICE: &'static str = "ostree-finalize-staged.se
 static OSTREE_DEPLOYMENT_FINALIZING_MSG_ID: &'static str = "e8646cd63dff4625b77909a8e7a40994";
 static OSTREE_DEPLOYMENT_COMPLETE_MSG_ID: &'static str = "dd440e3e549083b63d0efc7dc15255f1";
 
+pub enum JournalStagingFailure {
+    Unknown,
+    OstreeError,
+    SystemdMsg(String),
+    OstreeErrorMsg(String),
+}
+
 /// Look for a failure from ostree-finalized-stage.service in the journal of the previous boot.
-pub fn journal_find_staging_failure() -> io::Result<bool> {
+pub fn journal_find_staging_failure() -> io::Result<Option<JournalStagingFailure>> {
     let mut j = journal::Journal::open(journal::JournalFiles::System, false, true)?;
 
     // first, go to the first entry of the current boot
@@ -43,19 +50,23 @@ pub fn journal_find_staging_failure() -> io::Result<bool> {
     while previous_boot_id == boot_id {
         match j.previous_record()? {
             Some(_) => previous_boot_id = j.monotonic_timestamp()?.1,
-            None => return Ok(false), // no previous boot!
+            None => return Ok(None), // no previous boot!
         }
     }
     // we just need it as a string from now on
     let previous_boot_id = previous_boot_id.to_string();
+    let final_cursor_from_previous_boot = j.cursor()?;
 
     // look for OSTree's finalization msg
     j.match_add("MESSAGE_ID", OSTREE_DEPLOYMENT_FINALIZING_MSG_ID)?;
     j.match_add("_SYSTEMD_UNIT", OSTREE_FINALIZE_STAGED_SERVICE)?;
     j.match_add("_BOOT_ID", previous_boot_id.as_str())?;
     if j.previous_record()? == None {
-        return Ok(false); // didn't run (or staged deployment was cleaned up)
+        return Ok(None); // didn't run (or staged deployment was cleaned up)
     }
+
+    // now we're at the finalizing msg, remember its position
+    let finalizing_cursor = j.cursor()?;
 
     // and now check if it actually completed the transaction
     j.match_flush()?;
@@ -63,5 +74,62 @@ pub fn journal_find_staging_failure() -> io::Result<bool> {
     j.match_add("_SYSTEMD_UNIT", OSTREE_FINALIZE_STAGED_SERVICE)?;
     j.match_add("_BOOT_ID", previous_boot_id.as_str())?;
 
-    Ok(j.next_record()? == None)
+    if j.next_record()? != None {
+        return Ok(None); // finished successfully!
+    }
+
+    // OK, there was a failure; go back to finalizing msg before digging deeper
+    j.match_flush()?;
+    j.seek(journal::JournalSeek::Cursor {
+        cursor: finalizing_cursor,
+    })?;
+
+    // Try to find the 'Failed with result' msg from systemd. This is a bit brittle right now until
+    // we get a proper structured msg (see https://github.com/systemd/systemd/issues/10265).
+    j.match_add("UNIT", OSTREE_FINALIZE_STAGED_SERVICE)?;
+    j.match_add("_COMM", "systemd")?;
+    j.match_add("_BOOT_ID", previous_boot_id.as_str())?;
+
+    let mut exited = false;
+    while let Some(rec) = j.next_record()? {
+        if let Some(msg) = rec.get("MESSAGE") {
+            if msg.contains("Failed with result") {
+                if !msg.contains("exit-code") {
+                    /* just proxy that msg; e.g. could be timeout, signal, core-dump */
+                    return Ok(Some(JournalStagingFailure::SystemdMsg(msg.clone())));
+                }
+                exited = true;
+                break;
+            }
+        }
+    }
+
+    if !exited {
+        /* even systemd doesn't know what happened? OK, just stick with unknown */
+        return Ok(Some(JournalStagingFailure::Unknown));
+    }
+
+    // go back again to finalizing msg
+    j.match_flush()?;
+    j.seek(journal::JournalSeek::Cursor {
+        cursor: final_cursor_from_previous_boot,
+    })?;
+
+    // just find the last msg from ostree, it's probably an error msg
+    j.match_add("_SYSTEMD_UNIT", OSTREE_FINALIZE_STAGED_SERVICE)?;
+    j.match_add("_BOOT_ID", previous_boot_id.as_str())?;
+
+    if let Some(rec) = j.previous_record()? {
+        if let Some(msg) = rec.get("MESSAGE") {
+            // only proxy the msg if it starts with 'error:', otherwise some other really weird
+            // thing happened that might span multiple lines?
+            if msg.starts_with("error:") {
+                return Ok(Some(JournalStagingFailure::OstreeErrorMsg(msg.clone())));
+            }
+            return Ok(Some(JournalStagingFailure::OstreeError));
+        }
+    }
+
+    // just fall back to unknown
+    Ok(Some(JournalStagingFailure::Unknown))
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -41,6 +41,8 @@ mod glibutils;
 use glibutils::*;
 mod treefile;
 use treefile::*;
+mod journal;
+use journal::*;
 mod utils;
 
 /* Wrapper functions for translating from C to Rust */
@@ -190,6 +192,24 @@ pub extern "C" fn ror_download_to_fd(
         Err(e) => {
             error_to_glib(&e, gerror);
             -1 as libc::c_int
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ror_journal_find_staging_failure(
+    did_fail: *mut libc::c_int,
+    gerror: *mut *mut glib_sys::GError,
+) -> libc::c_int {
+    assert!(!did_fail.is_null());
+    match journal_find_staging_failure() {
+        Ok(b) => {
+            unsafe { *did_fail = if b { 1 } else { 0 } };
+            1 as libc::c_int
+        },
+        Err(e) => {
+            error_to_glib(&e, gerror);
+            0 as libc::c_int
         }
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -37,6 +37,8 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::{fs, io, ptr};
 
+use c_utf8::CUtf8Buf;
+
 mod glibutils;
 use glibutils::*;
 mod treefile;
@@ -199,17 +201,40 @@ pub extern "C" fn ror_download_to_fd(
 #[no_mangle]
 pub extern "C" fn ror_journal_find_staging_failure(
     did_fail: *mut libc::c_int,
+    buf: *mut libc::c_char,
+    bufsize: libc::size_t,
     gerror: *mut *mut glib_sys::GError,
 ) -> libc::c_int {
     assert!(!did_fail.is_null());
+    assert!(bufsize > 0);
     match journal_find_staging_failure() {
-        Ok(b) => {
-            unsafe { *did_fail = if b { 1 } else { 0 } };
+        Ok(None) => {
+            unsafe { *did_fail = 0 };
             1
-        },
+        }
         Err(e) => {
             error_to_glib(&e, gerror);
             0
+        }
+        Ok(Some(f)) => {
+            unsafe { *did_fail = 1 };
+            match f {
+                JournalStagingFailure::Unknown | JournalStagingFailure::OstreeError => {
+                    unsafe {
+                        let ptr = buf as *mut libc::c_char;
+                        *ptr = '\0' as libc::c_char;
+                    }
+                }
+                JournalStagingFailure::SystemdMsg(m) | JournalStagingFailure::OstreeErrorMsg(m) => {
+                    let cbuf = CUtf8Buf::from(m);
+                    unsafe {
+                        ptr::copy_nonoverlapping(cbuf.as_ptr(), buf, bufsize);
+                        let ptr = buf.offset((bufsize as isize)-1) as *mut libc::c_char;
+                        *ptr = '\0' as libc::c_char;
+                    }
+                }
+            }
+            1
         }
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -188,10 +188,10 @@ pub extern "C" fn ror_download_to_fd(
 ) -> libc::c_int {
     let url = str_from_nullable(url).unwrap();
     match utils::download_url_to_tmpfile(url) {
-        Ok(f) => f.into_raw_fd() as libc::c_int,
+        Ok(f) => f.into_raw_fd(),
         Err(e) => {
             error_to_glib(&e, gerror);
-            -1 as libc::c_int
+            -1
         }
     }
 }
@@ -205,11 +205,11 @@ pub extern "C" fn ror_journal_find_staging_failure(
     match journal_find_staging_failure() {
         Ok(b) => {
             unsafe { *did_fail = if b { 1 } else { 0 } };
-            1 as libc::c_int
+            1
         },
         Err(e) => {
             error_to_glib(&e, gerror);
-            0 as libc::c_int
+            0
         }
     }
 }

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -297,22 +297,11 @@ print_daemon_state (RPMOSTreeSysroot *sysroot_proxy,
 
   g_print ("State: %s\n", txn_proxy ? "busy" : "idle");
 
-   /* completely arbitrary, but really, we wouldn't want to render things much longer */
-  char buf[256];
-  gboolean staging_failure;
-  if (!ror_journal_find_staging_failure (&staging_failure, buf, sizeof(buf), error))
+  /* this is a bit of a hack; it's just to avoid duplicating this logic Rust side */
+  g_print ("%s%s", get_red_start (), get_bold_start ());
+  if (!ror_journal_print_staging_failure (error))
     return glnx_prefix_error (error, "While querying journal");
-
-  if (staging_failure)
-    {
-      g_print ("%s%sWarning: failed to finalize previous deployment\n",
-               get_red_start (), get_bold_start ());
-      if (strlen (buf) > 0)
-        g_print (  "         %s\n", buf);
-      g_print (    "         check `journalctl -b -1 -u %s`%s%s\n",
-               OSTREE_FINALIZE_STAGED_SERVICE_UNIT,
-               get_bold_end (), get_red_end ());
-    }
+  g_print ("%s%s", get_bold_end (), get_red_end ());
 
   g_print ("AutomaticUpdates: ");
   if (g_str_equal (policy, "none"))

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -299,8 +299,10 @@ print_daemon_state (RPMOSTreeSysroot *sysroot_proxy,
 
   /* this is a bit of a hack; it's just to avoid duplicating this logic Rust side */
   g_print ("%s%s", get_red_start (), get_bold_start ());
-  if (!ror_journal_print_staging_failure (error))
-    return glnx_prefix_error (error, "While querying journal");
+  g_autoptr(GError) local_error = NULL;
+  if (!ror_journal_print_staging_failure (&local_error))
+    /* let's not make it fatal if somehow this fails */
+    g_print ("Warning: failed to query journal: %s\n", local_error->message);
   g_print ("%s%s", get_bold_end (), get_red_end ());
 
   g_print ("AutomaticUpdates: ");

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -297,15 +297,19 @@ print_daemon_state (RPMOSTreeSysroot *sysroot_proxy,
 
   g_print ("State: %s\n", txn_proxy ? "busy" : "idle");
 
+   /* completely arbitrary, but really, we wouldn't want to render things much longer */
+  char buf[256];
   gboolean staging_failure;
-  if (!ror_journal_find_staging_failure (&staging_failure, error))
+  if (!ror_journal_find_staging_failure (&staging_failure, buf, sizeof(buf), error))
     return glnx_prefix_error (error, "While querying journal");
 
   if (staging_failure)
     {
-      g_print ("%s%sWarning: failed to finalize previous deployment\n"
-                   "         check `journalctl -b -1 -u %s`%s%s\n",
-               get_red_start (), get_bold_start (),
+      g_print ("%s%sWarning: failed to finalize previous deployment\n",
+               get_red_start (), get_bold_start ());
+      if (strlen (buf) > 0)
+        g_print (  "         %s\n", buf);
+      g_print (    "         check `journalctl -b -1 -u %s`%s%s\n",
                OSTREE_FINALIZE_STAGED_SERVICE_UNIT,
                get_bold_end (), get_red_end ());
     }

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -47,7 +47,7 @@ vm_rpmostree cleanup -p
 # Add metadata string containing EnfOfLife attribtue
 META_ENDOFLIFE_MESSAGE="this is a test for metadata message"
 commit=$(vm_cmd ostree commit -b vmcheck \
-            --tree=ref=vmcheck --add-metadata-string=ostree.endoflife=\"${META_ENDOFLIFE_MESSAGE}\")
+            --tree=ref=vmcheck --add-metadata-string=ostree.endoflife="'${META_ENDOFLIFE_MESSAGE}'")
 vm_rpmostree upgrade
 vm_assert_status_jq ".deployments[0][\"endoflife\"] == \"${META_ENDOFLIFE_MESSAGE}\""
 echo "ok endoflife metadata gets parsed correctly"
@@ -216,3 +216,24 @@ if ! vm_rpmostree install refresh-md-new-pkg --dry-run; then
 fi
 vm_stop_httpd vmcheck
 echo "ok refresh-md"
+
+# check that a failed staging shows up in status
+
+# first create a staged deployment
+vm_build_rpm test-stage-fail
+vm_rpmostree install test-stage-fail
+vm_pending_is_staged
+
+# OK, now make sure we'll fail. One nuclear way to do this is to just delete the
+# deployment root it expects to exist. I played with overriding the service file
+# so we just do e.g. /usr/bin/false, but the issue is we still want the "start"
+# journal msg to be emitted.
+vm_cmd rm -rf $(vm_get_deployment_root 0)
+
+# and now check that we notice there was a failure in `status`
+vm_reboot
+vm_cmd journalctl -b -1 -u ostree-finalize-staged.service > svc.txt
+assert_file_has_content svc.txt "error: opendir"
+vm_rpmostree status > status.txt
+assert_file_has_content status.txt "failed to finalize previous deployment"
+echo "ok previous staged failure in status"

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -232,8 +232,7 @@ vm_cmd rm -rf $(vm_get_deployment_root 0)
 
 # and now check that we notice there was a failure in `status`
 vm_reboot
-vm_cmd journalctl -b -1 -u ostree-finalize-staged.service > svc.txt
-assert_file_has_content svc.txt "error: opendir"
 vm_rpmostree status > status.txt
 assert_file_has_content status.txt "failed to finalize previous deployment"
+assert_file_has_content status.txt "error: opendir"
 echo "ok previous staged failure in status"


### PR DESCRIPTION
Sample output:

```
$ rpm-ostree status
State: idle
Warning: failed to finalize previous deployment
         check `journalctl -b -1 -u ostree-finalize-staged.service`
AutomaticUpdates: disabled
...
```

(Though open to tweaking it).

I also played with directly invoking `journalctl` for the user, but that
can get really spammy with e.g. `os-prober` output and such.

I wrote this in Rust using journal API wrappers because I also plan to
implement the `history` command in Rust and will also enhance that new
`journal` module there for that.

Requires: https://github.com/ostreedev/ostree/pull/1750
Requires: https://github.com/jmesmon/rust-systemd/pull/54
(Though I've pointed the manifest at my branch for now for CI).

Closes: #1567