### PR TITLE
compose: Support not specifying a ref

### DIFF
--- a/tests/compose-tests/test-installroot.sh
+++ b/tests/compose-tests/test-installroot.sh
@@ -9,7 +9,7 @@ prepare_compose_test "installroot"
 # This is used to test postprocessing with treefile vs not
 pysetjsonmember "boot_location" '"new"'
 instroot_tmp=$(mktemp -d /var/tmp/rpm-ostree-instroot.XXXXXX)
-rpm-ostree compose install ${compose_base_argv} ${treefile} ${instroot_tmp}
+rpm-ostree compose install --repo="${repobuild}" ${treefile} ${instroot_tmp}
 instroot=${instroot_tmp}/rootfs
 assert_not_has_dir ${instroot}/usr/lib/ostree-boot
 assert_not_has_dir ${instroot}/etc

--- a/tests/compose-tests/test-machineid-compat.sh
+++ b/tests/compose-tests/test-machineid-compat.sh
@@ -22,6 +22,10 @@ echo "ok conflict with units"
 # In this test we also want to test that include:
 # correctly handles machineid-compat.
 prepare_compose_test "machineid-compat"
+# Also test having no ref
+pyeditjson 'del jd["ref"]' < ${treefile} > ${treefile}.new
+mv ${treefile}{.new,}
+treeref=""
 pysetjsonmember "machineid-compat" 'False'
 cat > composedata/fedora-machineid-compat-includer.yaml <<EOF
 include: fedora-machineid-compat.json
@@ -30,6 +34,10 @@ export treefile=composedata/fedora-machineid-compat-includer.yaml
 runcompose
 echo "ok compose"
 
-ostree --repo=${repobuild} ls ${treeref} /usr/etc > ls.txt
+ostree --repo="${repobuild}" refs >refs.txt
+diff -u /dev/null refs.txt
+echo "ok no refs written"
+
+ostree --repo=${repobuild} ls ${commit} /usr/etc > ls.txt
 assert_not_file_has_content ls.txt 'machine-id'
 echo "ok machineid-compat"

--- a/tests/compose-tests/test-write-commitid.sh
+++ b/tests/compose-tests/test-write-commitid.sh
@@ -6,8 +6,8 @@ dn=$(cd $(dirname $0) && pwd)
 . ${dn}/libcomposetest.sh
 
 prepare_compose_test "write-commitid"
-runcompose --write-commitid-to $(pwd)/commitid.txt \
-           --write-composejson-to $(pwd)/composemeta.json
+treeref=""
+runcompose --write-commitid-to $(pwd)/commitid.txt
 wc -c < commitid.txt > wc.txt
 assert_file_has_content_literal wc.txt 64
 echo "ok compose"
@@ -19,11 +19,10 @@ fi
 echo "ok ref not written"
 
 commitid_txt=$(cat commitid.txt)
-json_commit=$(jq -r '.["ostree-commit"]' composemeta.json)
-assert_streq "${json_commit}" "${commitid_txt}"
+assert_streq "${commit}" "${commitid_txt}"
 # And verify we have other keys
 for key in ostree-version rpm-ostree-inputhash ostree-content-bytes-written; do
-    jq -r '.["'${key}'"]' composemeta.json >/dev/null
+    jq -r '.["'${key}'"]' ${composejson} >/dev/null
 done
 
 echo "ok composejson"

--- a/tests/composedata/fedora-base.json
+++ b/tests/composedata/fedora-base.json
@@ -1,5 +1,4 @@
 {
-    "ref": "fedora/stable/${basearch}",
     "rojig": {
         "name": "fedora-atomic-host",
         "license": "MIT",


### PR DESCRIPTION
Split out of supporting "pure rojig" work.  We also want
to support this for doing "oscontainers" as is planned for
Red Hat CoreOS.  The user experience in both cases is oriented
around versioning of the external wrapper, not the inner ref/commit.

Note for users/builders who want to make use of this feature:
You probably want to mirror the changes in our test suite here to
use the compose JSON and parse the resulting `ostree-commit` out of that.
