### PR TITLE
ci: Add rust-min-version-check

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -167,3 +167,28 @@ tests:
 
 artifacts:
   - ex-container-logs
+
+---
+
+branches:
+  - master
+  - auto
+  - try
+  - pr/rust-check
+
+context: rust-min-version-check
+timeout: 30m
+
+required: true
+container:
+  image: registry.fedoraproject.org/fedora:28
+
+env:
+  # this corresponds to the DTS rustc version we want to support
+  RUST_MIN_VERSION: 1.26.2
+
+tests:
+  - ci/installdeps.sh
+  - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_MIN_VERSION -y
+  - PATH=$HOME/.cargo/bin:$PATH sh -c 'cd rust && rustc --version && cargo build' |& tee out.txt
+  - grep $RUST_MIN_VERSION out.txt

--- a/.papr.yml
+++ b/.papr.yml
@@ -174,7 +174,6 @@ branches:
   - master
   - auto
   - try
-  - pr/rust-check
 
 context: rust-min-version-check
 timeout: 30m

--- a/.papr.yml
+++ b/.papr.yml
@@ -189,6 +189,7 @@ env:
 
 tests:
   - ci/installdeps.sh
+  - yum remove -y cargo
   - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_MIN_VERSION -y
   - PATH=$HOME/.cargo/bin:$PATH sh -c 'cd rust && rustc --version && cargo build' |& tee out.txt
   - grep $RUST_MIN_VERSION out.txt

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -23,8 +23,6 @@ fi
 
 pkg_upgrade
 pkg_install_builddeps rpm-ostree
-# Temporary until spec file changes are upstreamed
-pkg_install cargo
 # Mostly dependencies for tests
 pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML \
     libubsan libasan libtsan elfutils fuse sudo python-gobject-base \

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,39 +1,12 @@
 #!/usr/bin/bash
-# Install build dependencies, run unit tests and installed tests.
+# Install build dependencies and then build.
 
 set -xeuo pipefail
 
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
 
-# Use the latest ostree by default
-id=$(. /etc/os-release && echo $ID)
-version_id=$(. /etc/os-release && echo $VERSION_ID)
-if [ "$id" == fedora ] && [ "$version_id" == 28 ]; then
-    echo -e '[fahc]\nmetadata_expire=1m\nbaseurl=https://ci.centos.org/artifacts/sig-atomic/fahc/rdgo/build/\ngpgcheck=0\n' > /etc/yum.repos.d/fahc.repo
-    # Until we fix https://github.com/rpm-software-management/libdnf/pull/149
-    excludes='exclude=ostree ostree-libs ostree-grub2 rpm-ostree'
-    for repo in /etc/yum.repos.d/fedora*.repo; do
-        cat ${repo} | (while read line; do if echo "$line" | grep -qE -e '^enabled=1'; then echo "${excludes}"; fi; echo $line; done) > ${repo}.new
-        mv ${repo}.new ${repo}
-    done
-elif [ "$id" == centos ]; then
-    echo -e '[cahc]\nmetdata_expire=1m\nbaseurl=https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/build\ngpgcheck=0\n' > /etc/yum.repos.d/cahc.repo
-fi
-
-pkg_upgrade
-pkg_install_builddeps rpm-ostree
-# Mostly dependencies for tests
-pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML \
-    libubsan libasan libtsan elfutils fuse sudo python-gobject-base \
-    selinux-policy-devel selinux-policy-targeted python2-createrepo_c \
-    rpm-python # provided by python2-rpm on Fedora
-# For ex-container tests and clang build
-pkg_install_if_os fedora parallel clang
-
-if [ -n "${CI_PKGS:-}" ]; then
-  pkg_install ${CI_PKGS}
-fi
+${dn}/installdeps.sh
 
 # create an unprivileged user for testing
 adduser testuser

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+# Install build dependencies
+
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/libbuild.sh
+
+# Use the latest ostree by default
+id=$(. /etc/os-release && echo $ID)
+version_id=$(. /etc/os-release && echo $VERSION_ID)
+if [ "$id" == fedora ] && [ "$version_id" == 28 ]; then
+    echo -e '[fahc]\nmetadata_expire=1m\nbaseurl=https://ci.centos.org/artifacts/sig-atomic/fahc/rdgo/build/\ngpgcheck=0\n' > /etc/yum.repos.d/fahc.repo
+    # Until we fix https://github.com/rpm-software-management/libdnf/pull/149
+    excludes='exclude=ostree ostree-libs ostree-grub2 rpm-ostree'
+    for repo in /etc/yum.repos.d/fedora*.repo; do
+        cat ${repo} | (while read line; do if echo "$line" | grep -qE -e '^enabled=1'; then echo "${excludes}"; fi; echo $line; done) > ${repo}.new
+        mv ${repo}.new ${repo}
+    done
+elif [ "$id" == centos ]; then
+    echo -e '[cahc]\nmetdata_expire=1m\nbaseurl=https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/build\ngpgcheck=0\n' > /etc/yum.repos.d/cahc.repo
+fi
+
+pkg_upgrade
+pkg_install_builddeps rpm-ostree
+# Mostly dependencies for tests
+pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML \
+    libubsan libasan libtsan elfutils fuse sudo python-gobject-base \
+    selinux-policy-devel selinux-policy-targeted python2-createrepo_c \
+    rpm-python # provided by python2-rpm on Fedora
+# For ex-container tests and clang build
+pkg_install_if_os fedora parallel clang
+
+if [ -n "${CI_PKGS:-}" ]; then
+  pkg_install ${CI_PKGS}
+fi


### PR DESCRIPTION
Add a check to make sure we stay within the minimum version required to
build with DTS, which is updated frequently, but may still lag behind in
comparison to Fedora stable.