### PR TITLE
compose: Also port one passwd bit to using Rust treefile

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -419,7 +419,6 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
     }
 
   /* Before we install packages, inject /etc/{passwd,group} if configured. */
-  g_autoptr(GFile) treefile_dirpath = g_file_get_parent (self->treefile_path);
   gboolean generate_from_previous = TRUE;
   if (!_rpmostree_jsonutil_object_get_optional_boolean_member (treedata,
                                                                "preserve-passwd",
@@ -431,8 +430,8 @@ install_packages_in_root (RpmOstreeTreeComposeContext  *self,
     {
       const char *dest = opt_unified_core ? "usr/etc/" : "etc/";
       if (!rpmostree_generate_passwd_from_previous (self->repo, rootfs_dfd, dest,
-                                                    treefile_dirpath,
-                                                    self->previous_root, treedata,
+                                                    self->treefile_rs, treedata,
+                                                    self->previous_root,
                                                     cancellable, error))
         return FALSE;
     }

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -60,9 +60,9 @@ gboolean
 rpmostree_generate_passwd_from_previous (OstreeRepo      *repo,
                                          int              rootfs_dfd,
                                          const char      *dest,
-                                         GFile           *treefile_dirpath,
-                                         GFile           *previous_root,
+                                         RORTreefile     *treefile_rs,
                                          JsonObject      *treedata,
+                                         GFile           *previous_root,
                                          GCancellable    *cancellable,
                                          GError         **error);
 


### PR DESCRIPTION
I missed this use before in the passwd code which was also parsing
the "filename" parameter.  Teach this to use the fd that was opened
Rust side too.

It's really tempting to try oxidizing this whole file but...baby steps.
