### PR TITLE
postprocess: Add ostree-finalize-staged.path

### DIFF
--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1014,7 +1014,9 @@ rpmostree_postprocess_final (int            rootfs_dfd,
   if (!glnx_shutil_mkdir_p_at (rootfs_dfd, preset_dir, 0755, cancellable, error))
     return FALSE;
   { g_autofree char *preset_path = g_build_filename (preset_dir, "40-rpm-ostree-auto.preset", NULL);
-    static const char remount_preset[] = "# Written by rpm-ostree compose tree\nenable ostree-remount.service\n";
+    static const char remount_preset[] = "# Written by rpm-ostree compose tree\n"
+                                         "enable ostree-remount.service\n"
+                                         "enable ostree-finalize-staged.path\n";
     if (!glnx_file_replace_contents_at (rootfs_dfd, preset_path, (guint8*)remount_preset,
                                         strlen (remount_preset),
                                         GLNX_FILE_REPLACE_NODATASYNC,

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -32,6 +32,7 @@ echo "ok autovar"
 
 ostree --repo=${repobuild} cat ${treeref} /usr/lib/systemd/system-preset/40-rpm-ostree-auto.preset > preset.txt
 assert_file_has_content preset.txt '^enable ostree-remount.service$'
+assert_file_has_content preset.txt '^enable ostree-finalize-staged.path$'
 
 prepare_compose_test "from-yaml"
 python <<EOF


### PR DESCRIPTION
In preparations for ostreedev/ostree#1740, just
hard enable this path unit for now since centrally-maintained distro
presets still need to be updated.

Marking as WIP for now, just want to make doubly sure this definitely works.