### PR TITLE
app/livefs: Require --i-like-danger switch

### DIFF
--- a/src/app/rpmostree-builtin-livefs.c
+++ b/src/app/rpmostree-builtin-livefs.c
@@ -31,9 +31,11 @@
 
 static gboolean opt_dry_run;
 static gboolean opt_replace;
+static gboolean opt_consented;
 
 static GOptionEntry option_entries[] = {
   { "dry-run", 'n', 0, G_OPTION_ARG_NONE, &opt_dry_run, "Only perform analysis, do not make changes", NULL },
+  { "i-like-danger", 0, 0, G_OPTION_ARG_NONE, &opt_consented, "Consent to the dangers that livefs may pose", NULL },
   /* Known broken with kernel updates; see https://github.com/projectatomic/rpm-ostree/issues/1495 */
   { "dangerous-do-not-use-replace", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_replace, "Completely replace all files in /usr (known broken)", NULL },
   { NULL }
@@ -72,6 +74,10 @@ rpmostree_ex_builtin_livefs (int             argc,
                                        NULL,
                                        error))
     return FALSE;
+
+  if (!opt_consented)
+    return glnx_throw (error, "livefs is currently considered dangerous; "
+                              "pass --i-like-danger to override");
 
   glnx_unref_object RPMOSTreeOS *os_proxy = NULL;
   glnx_unref_object RPMOSTreeOSExperimental *osexperimental_proxy = NULL;

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -101,7 +101,7 @@ vm_build_rpm scriptpkg2 \
 vm_build_rpm scriptpkg3 \
              post 'echo %%{_prefix} > /usr/lib/noprefixtest.txt'
 vm_rpmostree pkg-add scriptpkg{2,3}
-vm_rpmostree ex livefs
+vm_rpmostree ex livefs --i-like-danger
 vm_cmd cat /usr/lib/noprefixtest.txt > noprefixtest.txt
 assert_file_has_content noprefixtest.txt '%{_prefix}'
 vm_cmd cat /usr/lib/prefixtest.txt > prefixtest.txt
@@ -116,7 +116,7 @@ vm_build_rpm rpmostree-lua-override-test-expand \
              post_args "-e -p <lua>" \
              post 'posix.stat("/")'
 vm_rpmostree install rpmostree-lua-override-test{,-expand}
-vm_rpmostree ex livefs
+vm_rpmostree ex livefs --i-like-danger
 vm_cmd cat /usr/share/rpmostree-lua-override-test > lua-override.txt
 assert_file_has_content lua-override.txt _install_langs
 vm_cmd rpm --eval '%{_install_langs}' > install-langs.txt
@@ -140,7 +140,7 @@ vm_build_rpm scriptpkg5 \
              transfiletriggerun "/usr/share/licenses/systemd /usr/share/licenses/rpm" 'sort >/usr/share/transfiletriggerun-license-systemd-rpm.txt' \
              transfiletriggerin2 "/usr/share/licenses/sed /usr/share/licenses/tzdata" 'sort >/usr/share/transfiletriggerin-license-sed-tzdata.txt'
 vm_rpmostree pkg-add scriptpkg{4,5}
-vm_rpmostree ex livefs
+vm_rpmostree ex livefs --i-like-danger
 for combo in ${license_combos}; do
     vm_cmd cat /usr/share/transfiletriggerin-license-${combo}.txt > transfiletriggerin-license-${combo}.txt
     rm -f transfiletriggerin-fs-${combo}.txt.tmp
@@ -226,7 +226,7 @@ echo "ok impervious to rm -rf post"
 # capabilities
 vm_build_rpm test-cap-drop post "capsh --print > /usr/share/rpmostree-capsh.txt"
 vm_rpmostree install test-cap-drop
-vm_rpmostree ex livefs
+vm_rpmostree ex livefs --i-like-danger
 vm_cmd cat /usr/share/rpmostree-capsh.txt > caps.txt
 assert_not_file_has_content caps.test '^Current: =.*cap_sys_admin'
 

--- a/tests/vmcheck/test-livefs.sh
+++ b/tests/vmcheck/test-livefs.sh
@@ -39,7 +39,7 @@ if vm_cmd rpm -q foo; then
     assert_not_reached "have foo?"
 fi
 assert_livefs_ok() {
-    vm_rpmostree ex livefs -n > livefs-analysis.txt
+    vm_rpmostree ex livefs --i-like-danger -n > livefs-analysis.txt
     assert_file_has_content livefs-analysis.txt 'livefs OK (dry run)'
 }
 assert_livefs_ok
@@ -47,7 +47,7 @@ assert_livefs_ok
 vm_assert_status_jq '.deployments|length == 2' \
                     '.deployments[0]["live-replaced"]|not' \
                     '.deployments[1]["live-replaced"]|not'
-vm_rpmostree ex livefs
+vm_rpmostree ex livefs --i-like-danger
 vm_cmd rpm -q foo > rpmq.txt
 assert_file_has_content rpmq.txt foo-1.0-1
 vm_assert_status_jq '.deployments|length == 3' '.deployments[0]["live-replaced"]|not' \
@@ -87,7 +87,7 @@ vm_cmd rm -rf /etc/test-livefs-with-etc \
 
 vm_rpmostree install /var/tmp/vmcheck/yumrepo/packages/x86_64/test-livefs-{with-etc,service}-1.0-1.x86_64.rpm
 assert_livefs_ok
-vm_rpmostree ex livefs
+vm_rpmostree ex livefs --i-like-danger
 vm_cmd rpm -q foo test-livefs-{with-etc,service} > rpmq.txt
 assert_file_has_content rpmq.txt foo-1.0-1 test-livefs-{with-etc,service}-1.0-1
 vm_cmd cat /etc/test-livefs-with-etc.conf > test-livefs-with-etc.conf
@@ -127,7 +127,7 @@ vm_rpmostree install /var/tmp/vmcheck/yumrepo/packages/x86_64/test-livefs-with-e
 vm_cmd cat /etc/test-livefs-with-etc.conf || true
 vm_cmd echo custom \> /etc/test-livefs-with-etc.conf
 vm_cmd cat /etc/test-livefs-with-etc.conf
-vm_rpmostree ex livefs
+vm_rpmostree ex livefs --i-like-danger
 vm_cmd cat /etc/test-livefs-with-etc.conf > test-livefs-with-etc.conf
 assert_file_has_content test-livefs-with-etc.conf "custom"
 echo "ok livefs preserved modified config"
@@ -140,7 +140,7 @@ echo "ok livefs redeploy booted commit"
 
 reset
 vm_rpmostree install /var/tmp/vmcheck/yumrepo/packages/x86_64/foo-1.0-1.x86_64.rpm
-vm_rpmostree ex livefs
+vm_rpmostree ex livefs --i-like-danger
 # Picked a file that should be around, but harmless to change for testing.  The
 # first is available on Fedora, the second on CentOS (and newer too).
 dummy_file_to_modify=usr/share/licenses/ostree/COPYING
@@ -176,7 +176,7 @@ generate_upgrade "mkdir -p vmcheck/usr/newsubdir && date > vmcheck/usr/newsubdir
 vm_rpmostree upgrade
 vm_assert_status_jq '.deployments|length == 2' '.deployments[0]["live-replaced"]|not' \
                     '.deployments[1]["live-replaced"]|not'
-if vm_rpmostree ex livefs -n &> livefs-analysis.txt; then
+if vm_rpmostree ex livefs --i-like-danger -n &> livefs-analysis.txt; then
     assert_not_reached "livefs succeeded?"
 fi
 vm_assert_status_jq '.deployments|length == 2' '.deployments[0]["live-replaced"]|not' \
@@ -185,11 +185,11 @@ assert_file_has_content livefs-analysis.txt 'No packages added'
 echo "ok no modifications"
 
 # And now replacement
-vm_rpmostree ex livefs -n --dangerous-do-not-use-replace &> livefs-analysis.txt
+vm_rpmostree ex livefs -n --i-like-danger --dangerous-do-not-use-replace &> livefs-analysis.txt
 assert_file_has_content livefs-analysis.txt 'livefs OK (dry run)'
 vm_assert_status_jq '.deployments|length == 2' '.deployments[0]["live-replaced"]|not' \
                     '.deployments[1]["live-replaced"]|not'
-vm_rpmostree ex livefs --dangerous-do-not-use-replace
+vm_rpmostree ex livefs --i-like-danger --dangerous-do-not-use-replace
 vm_cmd cat /${dummy_file_to_modify} > dummyfile.txt
 assert_file_has_content dummyfile.txt "JUST KIDDING DO WHATEVER"
 vm_cmd test -f /usr/newsubdir/date.txt


### PR DESCRIPTION
We've had multiple reports by now of folks using plain `ex livefs` and
getting their bootloader wrecked:

https://github.com/projectatomic/rpm-ostree/issues/1495
https://github.com/projectatomic/rpm-ostree/issues/1504
https://github.com/ostreedev/ostree/issues/1459

Let's require a scary switch for now to emphasize this.