### PR TITLE
scripts: Fully neuter microcode_ctl scripts everywhere

### DIFF
--- a/src/libpriv/rpmostree-script-gperf.gperf
+++ b/src/libpriv/rpmostree-script-gperf.gperf
@@ -39,5 +39,7 @@ systemd.transfiletriggerin, RPMOSTREE_SCRIPT_ACTION_IGNORE
 man-db.transfiletriggerin, RPMOSTREE_SCRIPT_ACTION_IGNORE
 # https://src.fedoraproject.org/rpms/nfs-utils/pull-request/1
 nfs-utils.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
+# There is some totally insane stuff going on here in RHEL7
+microcode_ctl.post, RPMOSTREE_SCRIPT_ACTION_IGNORE
 # https://bugzilla.redhat.com/show_bug.cgi?id=1199582
 microcode_ctl.posttrans, RPMOSTREE_SCRIPT_ACTION_IGNORE

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -180,10 +180,6 @@ static const RpmOstreeScriptReplacement script_replacements[] = {
    * https://src.fedoraproject.org/rpms/pam/pull-request/3
    */
   { "pam.post", ".el7", NULL, NULL },
-  /* Same here. */
-  { "microcode_ctl.post", ".el7", NULL, NULL },
-  /* And this one runs dracut, which we don't want. */
-  { "microcode_ctl.posttrans", ".el7", NULL, NULL },
 };
 
 static gboolean


### PR DESCRIPTION
I swear I tested the previous PR here but it looks like they
did a new build recently whose release ends in `el7_5` which no
longer matches.

Since the Fedora spec doesn't have any scripts, let's go back
to using the gperf list.
