### PR TITLE
Switch to ISO8601 timestamps in more places

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -943,11 +943,7 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
    * https://stackoverflow.com/questions/10286204/the-right-json-date-format
    * */
   { guint64 commit_ts = ostree_commit_get_timestamp (new_commit);
-    g_autoptr(GDateTime) timestamp = g_date_time_new_from_unix_utc (commit_ts);
-    /* If this fails...something went badly wrong */
-    g_assert (timestamp);
-    g_autofree char *commit_ts_iso_8601 = g_date_time_format (timestamp, "%FT%H:%M:%SZ");
-    g_assert (commit_ts_iso_8601);
+    g_autofree char *commit_ts_iso_8601 = rpmostree_timestamp_str_from_unix_utc_format (commit_ts);
     g_variant_builder_add (&composemeta_builder, "{sv}", "ostree-timestamp", g_variant_new_string (commit_ts_iso_8601));
   }
   const char *commit_version = NULL;

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -943,7 +943,7 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
    * https://stackoverflow.com/questions/10286204/the-right-json-date-format
    * */
   { guint64 commit_ts = ostree_commit_get_timestamp (new_commit);
-    g_autofree char *commit_ts_iso_8601 = rpmostree_timestamp_str_from_unix_utc_format (commit_ts);
+    g_autofree char *commit_ts_iso_8601 = rpmostree_timestamp_str_from_unix_utc (commit_ts);
     g_variant_builder_add (&composemeta_builder, "{sv}", "ostree-timestamp", g_variant_new_string (commit_ts_iso_8601));
   }
   const char *commit_version = NULL;

--- a/src/app/rpmostree-libbuiltin.c
+++ b/src/app/rpmostree-libbuiltin.c
@@ -133,15 +133,6 @@ rpmostree_print_treepkg_diff (OstreeSysroot    *sysroot,
   return TRUE;
 }
 
-char*
-rpmostree_timestamp_str_from_unix_utc (guint64 t)
-{
-  g_autoptr(GDateTime) timestamp = g_date_time_new_from_unix_utc (t);
-  if (timestamp != NULL)
-    return g_date_time_format (timestamp, "%Y-%m-%d %T");
-  return g_strdup_printf ("(invalid timestamp)");
-}
-
 void
 rpmostree_print_timestamp_version (const char  *version_string,
                                    const char  *timestamp_string,

--- a/src/app/rpmostree-libbuiltin.h
+++ b/src/app/rpmostree-libbuiltin.h
@@ -71,9 +71,6 @@ rpmostree_print_treepkg_diff_from_sysroot_path (const gchar *sysroot_path,
                                                 GCancellable *cancellable,
                                                 GError **error);
 
-char*
-rpmostree_timestamp_str_from_unix_utc (guint64 t);
-
 void
 rpmostree_print_timestamp_version (const char  *version_string,
                                    const char  *timestamp_string,

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1088,14 +1088,7 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
         }
 
       guint64 ts = dnf_repo_get_timestamp_generated (repo);
-      g_autoptr(GDateTime) repo_ts = g_date_time_new_from_unix_utc (ts);
-      g_autofree char *repo_ts_str = NULL;
-
-      if (repo_ts != NULL)
-        repo_ts_str = g_date_time_format (repo_ts, "%Y-%m-%d %T");
-      else
-        repo_ts_str = g_strdup_printf ("(invalid timestamp)");
-
+      g_autofree char *repo_ts_str = rpmostree_timestamp_str_from_unix_utc (ts);
       rpmostree_output_message ("rpm-md repo '%s'%s; generated: %s",
                                 dnf_repo_get_id (repo), !did_update ? " (cached)" : "",
                                 repo_ts_str);

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -1048,3 +1048,13 @@ rpmostree_str_to_auto_update_policy (const char *str,
     return glnx_throw (error, "Invalid value for AutomaticUpdatePolicy: '%s'", str);
   return TRUE;
 }
+
+/* Get an ISO8601-formatted string for UTC timestamp t (seconds) */
+char*
+rpmostree_timestamp_str_from_unix_utc (guint64 t)
+{
+  g_autoptr(GDateTime) timestamp = g_date_time_new_from_unix_utc (t);
+  if (timestamp != NULL)
+    return g_date_time_format (timestamp, "%FT%H:%M:%SZ");
+  return g_strdup_printf ("(invalid timestamp)");
+}

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -226,3 +226,6 @@ gboolean
 rpmostree_str_to_auto_update_policy (const char *str,
                                      RpmostreedAutomaticUpdatePolicy *out_policy,
                                      GError **error);
+
+char*
+rpmostree_timestamp_str_from_unix_utc (guint64 t);


### PR DESCRIPTION
I was doing this for the "generated" bit on the compose side,
but let's be consistent elsewhere.
