### PR TITLE
Use autocleanup for task output

### DIFF
--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -517,7 +517,7 @@ checkout_base_tree (RpmOstreeSysrootUpgrader *self,
     return TRUE; /* already checked out! */
 
   /* let's give the user some feedback so they don't think we're blocked */
-  rpmostree_output_task_begin ("Checking out tree %.7s", self->base_revision);
+  g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Checking out tree %.7s", self->base_revision);
 
   int repo_dfd = ostree_repo_get_dfd (self->repo); /* borrowed */
   /* Always delete this */
@@ -558,7 +558,6 @@ checkout_base_tree (RpmOstreeSysrootUpgrader *self,
                        &self->tmprootfs_dfd, error))
     return FALSE;
 
-  rpmostree_output_task_end ("done");
   return TRUE;
 }
 
@@ -1082,7 +1081,7 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
       if (rpmostree_origin_get_regenerate_initramfs (self->origin))
          add_dracut_argv = rpmostree_origin_get_initramfs_args (self->origin);
 
-      rpmostree_output_task_begin ("Generating initramfs");
+      g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Generating initramfs");
 
       g_assert (kernel_state && kernel_path);
 
@@ -1096,8 +1095,6 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
                                       &initramfs_tmpf, RPMOSTREE_FINALIZE_KERNEL_AUTO,
                                       cancellable, error))
         return FALSE;
-
-      rpmostree_output_task_end ("done");
     }
 
   if (!rpmostree_context_commit (self->ctx, self->base_revision,
@@ -1297,7 +1294,7 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
 
   if (use_staging)
     {
-      rpmostree_output_task_begin ("Staging deployment");
+      g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Staging deployment");
       if (!ostree_sysroot_stage_tree (self->sysroot, self->osname,
                                       target_revision, origin,
                                       self->cfg_merge_deployment,
@@ -1305,7 +1302,6 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
                                       &new_deployment,
                                       cancellable, error))
         return FALSE;
-      rpmostree_output_task_end ("done");
     }
   else
     {

--- a/src/libpriv/rpmostree-output.c
+++ b/src/libpriv/rpmostree-output.c
@@ -109,7 +109,7 @@ rpmostree_output_task_begin (const char *format, ...)
 void
 rpmostree_output_task_done_msg (RpmOstreeOutputTask *taskp, const char *format, ...)
 {
-  g_assert (*taskp);
+  g_assert (taskp && *taskp);
   *taskp = false;
   g_autofree char *final_msg = strdup_vprintf (format);
   RpmOstreeOutputTaskEnd task = { final_msg };

--- a/src/libpriv/rpmostree-output.c
+++ b/src/libpriv/rpmostree-output.c
@@ -45,7 +45,7 @@ rpmostree_output_default_handler (RpmOstreeOutputType type,
     g_print ("%s... ", ((RpmOstreeOutputTaskBegin*)data)->text);
     break;
   case RPMOSTREE_OUTPUT_TASK_END:
-    g_print ("%s\n", ((RpmOstreeOutputTaskEnd*)data)->text);
+    g_print ("%s\n", ((RpmOstreeOutputTaskEnd*)data)->text ?: "");
     break;
   case RPMOSTREE_OUTPUT_PROGRESS_PERCENT:
     if (!console.locked)
@@ -97,17 +97,20 @@ rpmostree_output_message (const char *format, ...)
   active_cb (RPMOSTREE_OUTPUT_MESSAGE, &task, active_cb_opaque);
 }
 
-void
+RpmOstreeOutputTask
 rpmostree_output_task_begin (const char *format, ...)
 {
   g_autofree char *final_msg = strdup_vprintf (format);
   RpmOstreeOutputTaskBegin task = { final_msg };
   active_cb (RPMOSTREE_OUTPUT_TASK_BEGIN, &task, active_cb_opaque);
+  return true;
 }
 
 void
-rpmostree_output_task_end (const char *format, ...)
+rpmostree_output_task_done_msg (RpmOstreeOutputTask *taskp, const char *format, ...)
 {
+  g_assert (*taskp);
+  *taskp = false;
   g_autofree char *final_msg = strdup_vprintf (format);
   RpmOstreeOutputTaskEnd task = { final_msg };
   active_cb (RPMOSTREE_OUTPUT_TASK_END, &task, active_cb_opaque);

--- a/src/libpriv/rpmostree-output.h
+++ b/src/libpriv/rpmostree-output.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 typedef enum {
   RPMOSTREE_OUTPUT_MESSAGE,
   RPMOSTREE_OUTPUT_TASK_BEGIN,
@@ -42,13 +44,20 @@ rpmostree_output_message (const char *format, ...) G_GNUC_PRINTF (1,2);
 
 typedef RpmOstreeOutputMessage RpmOstreeOutputTaskBegin;
 
-void
-rpmostree_output_task_begin (const char *format, ...) G_GNUC_PRINTF (1,2);
 
 typedef RpmOstreeOutputMessage RpmOstreeOutputTaskEnd;
 
-void
-rpmostree_output_task_end (const char *format, ...) G_GNUC_PRINTF (1,2);
+typedef bool RpmOstreeOutputTask;
+RpmOstreeOutputTask rpmostree_output_task_begin (const char *format, ...) G_GNUC_PRINTF (1,2);
+void rpmostree_output_task_done_msg (RpmOstreeOutputTask *task, const char *format, ...) G_GNUC_PRINTF (2,3);
+static inline void
+rpmostree_output_task_clear (RpmOstreeOutputTask *task)
+{
+  if (*task)
+    rpmostree_output_task_done_msg (task, NULL);
+}
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC (RpmOstreeOutputTask, rpmostree_output_task_clear)
+
 
 typedef struct {
   const char *text;

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -657,7 +657,7 @@ rpmostree_migrate_pkgcache_repo (OstreeRepo   *repo,
     {
       if (S_ISDIR (stbuf.st_mode))
         {
-          rpmostree_output_task_begin ("Migrating pkgcache");
+          g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Migrating pkgcache");
 
           g_autoptr(OstreeRepo) pkgcache = ostree_repo_open_at (repo_dfd,
                                                                 RPMOSTREE_OLD_PKGCACHE_DIR,
@@ -669,7 +669,7 @@ rpmostree_migrate_pkgcache_repo (OstreeRepo   *repo,
           if (!do_pkgcache_migration (repo, pkgcache, &n_migrated, cancellable, error))
             return FALSE;
 
-          rpmostree_output_task_end ("%u done", n_migrated);
+          rpmostree_output_task_done_msg (&task, "%u done", n_migrated);
           if (n_migrated > 0)
             sd_journal_print (LOG_INFO, "migrated %u cached package%s to system repo",
                               n_migrated, _NS(n_migrated));


### PR DESCRIPTION
I was playing with https://crates.io/crates/indicatif
and this is prep for using it.

By using autocleanups here we ensure that the output state
ends even if we encounter an error.  We previously had a few
explicit `failed` prints in cases where failure was more common
such as dependency resolution, but that was far from consistent.

Now we will always ensure a newline is printed even if an error
occurs, and we won't have to worry about missing calls to
`_task_done()` in the success case.

The downside of this is that we lose the `done` bit in the success
path...I thought about maybe taking a pointer to the error and
printing `done` or `failed` depending on whether it's non-`NULL`
but eh...the `done` is implied by us going on to the next line.
Also that issue will be fixed with the indicatif work.
