### PR TITLE
compose: Check that add-files are compatible after parsing

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -200,7 +200,12 @@ It supports the following parameters:
    file name, and the second element is the destination name.  The
    source file must be in the same directory as the treefile.
 
-   Example: `"add-files": [["bar", "/bar"], ["foo", "/foo"]]`
+   Example: `"add-files": [["bar", "/usr/share/bar"], ["foo", "/lib/foo"]]`
+
+   Note that in the OSTree model, not all directories are managed by OSTree. In
+   short, only files in `/usr` (or UsrMove symlinks into `/usr`) and `/etc` are
+   supported. For more details, see the OSTree manual:
+   https://ostree.readthedocs.io/en/latest/manual/deployment/
 
  * `tmp-is-dir`: boolean, optional: Defaults to `false`.  By default,
    rpm-ostree creates symlink `/tmp` → `sysroot/tmp`.  When set to `true`,

--- a/src/libpriv/rpmostree-importer.c
+++ b/src/libpriv/rpmostree-importer.c
@@ -37,6 +37,7 @@
 #include "rpmostree-core.h"
 #include "rpmostree-rojig-assembler.h"
 #include "rpmostree-rpm-util.h"
+#include "rpmostree-util.h"
 #include <rpm/rpmlib.h>
 #include <rpm/rpmlog.h>
 #include <rpm/rpmfi.h>
@@ -605,13 +606,7 @@ path_is_ostree_compliant (const char *path)
 {
   g_assert (*path == '/');
   path++;
-  return (*path == '\0' ||
-          g_str_equal (path, "usr")   || (g_str_has_prefix (path, "usr/")
-                                          && !g_str_has_prefix (path, "usr/local/")) ||
-          g_str_equal (path, "bin")   || g_str_has_prefix (path, "bin/")  ||
-          g_str_equal (path, "sbin")  || g_str_has_prefix (path, "sbin/") ||
-          g_str_equal (path, "lib")   || g_str_has_prefix (path, "lib/")  ||
-          g_str_equal (path, "lib64") || g_str_has_prefix (path, "lib64/"));
+  return (*path == '\0' || rpmostree_relative_path_is_ostree_compliant (path));
 }
 
 static OstreeRepoCommitFilterResult

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1400,6 +1400,7 @@ copy_additional_files (int            rootfs_dfd,
           dest = dest_owned;
         }
 
+      g_assert (rpmostree_relative_path_is_ostree_compliant (dest));
       g_print ("Adding file '%s'\n", dest);
 
       g_string_truncate (dnbuf, 0);

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -1058,3 +1058,16 @@ rpmostree_timestamp_str_from_unix_utc (guint64 t)
     return g_date_time_format (timestamp, "%FT%H:%M:%SZ");
   return g_strdup_printf ("(invalid timestamp)");
 }
+
+gboolean
+rpmostree_relative_path_is_ostree_compliant (const char *path)
+{
+  g_assert (path);
+  g_assert (*path != '/');
+  return (g_str_equal (path, "usr")   || (g_str_has_prefix (path, "usr/")
+                                          && !g_str_has_prefix (path, "usr/local/")) ||
+          g_str_equal (path, "bin")   || g_str_has_prefix (path, "bin/")  ||
+          g_str_equal (path, "sbin")  || g_str_has_prefix (path, "sbin/") ||
+          g_str_equal (path, "lib")   || g_str_has_prefix (path, "lib/")  ||
+          g_str_equal (path, "lib64") || g_str_has_prefix (path, "lib64/"));
+}

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -229,3 +229,6 @@ rpmostree_str_to_auto_update_policy (const char *str,
 
 char*
 rpmostree_timestamp_str_from_unix_utc (guint64 t);
+
+gboolean
+rpmostree_relative_path_is_ostree_compliant (const char *path);


### PR DESCRIPTION
While serde gives us type checking, it of course doesn't understand
semantics beyond that. One example is checking the compatibility of
`add-files` entries with the OSTree model. This is something we can do
upfront early on to avoid surprises for users.

Also tweak the docs to reflect this new check.

Related: #1642