### PR TITLE
core: Disable librpm SELinux plugin when writing rpmdb

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -4151,7 +4151,11 @@ rpmostree_context_assemble (RpmOstreeContext      *self,
 #ifdef BUILDOPT_HAVE_NEW_RPM_VERIFY
   rpmtsSetVfyLevel (rpmdb_ts, 0);
 #endif
-  rpmtsSetFlags (rpmdb_ts, RPMTRANS_FLAG_JUSTDB);
+  /* We're just writing the rpmdb, hence _JUSTDB. Also disable the librpm
+   * SELinux plugin since rpm-ostree (and ostree) have fundamentally better
+   * code.
+   */
+  rpmtsSetFlags (rpmdb_ts, RPMTRANS_FLAG_JUSTDB | RPMTRANS_FLAG_NOCONTEXTS);
 
   tdata.ctx = self;
   rpmtsSetNotifyCallback (rpmdb_ts, ts_callback, &tdata);


### PR DESCRIPTION
OSTree was designed from the very beginning of its existence
to support SELinux well instead of being something wedged on.
rpm-ostree builds on that foundation.  We don't want to have anything
to do with librpm's SELinux code.  And with unified core,
we usually don't, but that `rpm-plugin-selinux` code does get loaded.

Disable it here.  The main reason I'm submitting this patch
is to help an effort in coreos-assembler to use a "supermin" virtual
machine: https://github.com/coreos/coreos-assembler/pull/124
