### PR TITLE
man: Fix references to automatic timer and service

### DIFF
--- a/man/rpm-ostreed.conf.xml
+++ b/man/rpm-ostreed.conf.xml
@@ -128,7 +128,8 @@ Boston, MA 02111-1307, USA.
 
     <para>
       <citerefentry><refentrytitle>rpm-ostree</refentrytitle><manvolnum>1</manvolnum></citerefentry>
-      <citerefentry><refentrytitle>rpm-ostreed-automatic</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+      <citerefentry><refentrytitle>rpm-ostreed-automatic.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+      <citerefentry><refentrytitle>rpm-ostreed-automatic.timer</refentrytitle><manvolnum>8</manvolnum></citerefentry>
     </para>
   </refsect1>
 


### PR DESCRIPTION
There is no `rpm-ostreed-automatic` man page, only
`rpm-ostreed-automatic.service` and `rpm-ostreed-automatic.timer`. Fix
references from the conf man page to those pages.

Closes: #1651