### PR TITLE
app: Wrap `Version` in `--version` in quotes

### DIFF
--- a/src/app/main.c
+++ b/src/app/main.c
@@ -225,7 +225,7 @@ rpmostree_option_context_parse (GOptionContext *context,
        */
       g_auto(GStrv) features = g_strsplit (RPM_OSTREE_FEATURES, " ", -1);
       g_print ("%s:\n", PACKAGE_NAME);
-      g_print (" Version: %s\n", PACKAGE_VERSION);
+      g_print (" Version: '%s'\n", PACKAGE_VERSION);
       if (strlen (RPM_OSTREE_GITREV) > 0)
         g_print (" Git: %s\n", RPM_OSTREE_GITREV);
       g_print (" Features:\n");


### PR DESCRIPTION
Wrap the `Version` key in the YAML-compatible output of
`rpm-ostree --version` with quotes so that it's parsed as a string. The
issues with the previous approach in a nutshell:

```
In [5]: yaml.load("asdf: 2018.10")
Out[5]: {'asdf': 2018.1}
```

It's treating the version number as a floating-point. Now, this is
technically a backwards incompatible change, but given that the previous
approach is inherently broken for our needs, I don't see a way around
breaking it now.

See also: https://github.com/ostreedev/ostree/commit/759b099861a3065f01384d4d1121a7726771e5fe