### PR TITLE
compose: Don't require SELinux policy in legacy path

### DIFF
--- a/src/app/rpmostree-compose-builtin-rojig.c
+++ b/src/app/rpmostree-compose-builtin-rojig.c
@@ -303,6 +303,7 @@ rpm_ostree_rojig_compose_new (const char    *treefile_path,
   self->treespec = rpmostree_composeutil_get_treespec (self->corectx,
                                                        self->treefile_rs,
                                                        self->treefile,
+                                                       TRUE,
                                                        error);
 
   *out_context = g_steal_pointer (&self);

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -576,6 +576,7 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
   self->treespec = rpmostree_composeutil_get_treespec (self->corectx,
                                                        self->treefile_rs,
                                                        self->treefile,
+                                                       opt_unified_core,
                                                        error);
   if (!self->treespec)
     return FALSE;

--- a/src/app/rpmostree-composeutil.c
+++ b/src/app/rpmostree-composeutil.c
@@ -242,6 +242,7 @@ RpmOstreeTreespec *
 rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
                                     RORTreefile *treefile_rs,
                                     JsonObject  *treedata,
+                                    gboolean     bind_selinux,
                                     GError     **error)
 {
   GLNX_AUTO_PREFIX_ERROR ("Parsing treefile", error);
@@ -256,8 +257,6 @@ rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
     return FALSE;
   if (!treespec_bind_bool (treedata, treespec, "recommends", TRUE, error))
     return FALSE;
-  if (!treespec_bind_bool (treedata, treespec, "selinux", TRUE, error))
-    return FALSE;
   if (!treespec_bind_array (treedata, treespec, "install-langs", "instlangs", FALSE, error))
     return FALSE;
   { const char *releasever;
@@ -267,6 +266,19 @@ rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
     if (releasever)
       g_key_file_set_string (treespec, "tree", "releasever", releasever);
   }
+
+  if (bind_selinux)
+    {
+      if (!treespec_bind_bool (treedata, treespec, "selinux", TRUE, error))
+        return FALSE;
+    }
+  else
+    {
+      /* In the legacy compose path, we don't want to use any of the core's selinux stuff,
+       * e.g. importing, relabeling, etc... so just disable it. We do still set the policy
+       * to the final one right before commit as usual. */
+      g_key_file_set_boolean (treespec, "tree", "selinux", FALSE);
+    }
 
   const char *input_ref = NULL;
   if (!_rpmostree_jsonutil_object_get_optional_string_member (treedata, "ref", &input_ref, error))

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -47,6 +47,7 @@ RpmOstreeTreespec *
 rpmostree_composeutil_get_treespec (RpmOstreeContext  *ctx,
                                     RORTreefile *treefile_rs,
                                     JsonObject  *treedata,
+                                    gboolean     bind_selinux,
                                     GError     **error);
 
 GHashTable *


### PR DESCRIPTION
In #1630, we lowered SELinux policy loading into the core. However, this
also enabled SELinux policy loading from the host system even in the
legacy (non-unified) compose path. This meant that compose systems now
needed to have the policy installed even though we didn't need it at
all. This caused regressions in pungi:

https://pagure.io/dusty/failed-composes/issue/956

Just make the binding of the "selinux" member conditional on whether or
not we're in unified mode (which is really when we even care about
having it loaded from the start for pkgcache purposes).