### PR TITLE
 Use indicatif for progress

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,6 +17,8 @@ openat = "0.1.15"
 curl = "0.4.14"
 c_utf8 = "0.1.0"
 systemd = "0.4.0"
+indicatif = "0.9.0"
+lazy_static = "1.1.0"
 
 [lib]
 name = "rpmostree_rust"

--- a/rust/src/ffiutil.rs
+++ b/rust/src/ffiutil.rs
@@ -42,6 +42,13 @@ pub fn str_from_nullable<'a>(s: *const libc::c_char) -> Option<&'a str> {
     }
 }
 
+/// Given a NUL-terminated C string, convert it to an owned
+/// String.  Will panic if the C string is not valid UTF-8.
+pub fn string_from_nonnull(s: *const libc::c_char) -> String {
+    let buf = bytes_from_nonnull(s);
+    String::from_utf8(buf.into()).expect("string_from_nonnull: valid utf-8")
+}
+
 /// Convert a C "bytestring" to a OsStr; panics if `s` is `NULL`.
 pub fn bytes_from_nonnull<'a>(s: *const libc::c_char) -> &'a [u8] {
     assert!(!s.is_null());

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -21,10 +21,13 @@ extern crate curl;
 extern crate gio_sys;
 extern crate glib;
 extern crate glib_sys;
+extern crate indicatif;
 extern crate libc;
 extern crate openat;
 extern crate tempfile;
 
+#[macro_use]
+extern crate lazy_static;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;
@@ -35,6 +38,8 @@ mod ffiutil;
 
 mod treefile;
 pub use treefile::*;
+mod progress;
+pub use progress::*;
 mod journal;
 pub use journal::*;
 mod utils;

--- a/rust/src/progress.rs
+++ b/rust/src/progress.rs
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+extern crate indicatif;
+
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use std::borrow::Cow;
+use std::sync::Mutex;
+
+#[derive(PartialEq)]
+enum ProgressType {
+    Task,
+    NItems(u64),
+    Percent,
+}
+
+/// A wrapper around indicatif's ProgressBar with some extra state.
+struct ProgressState {
+    bar: ProgressBar,
+    // In some cases we still want to print things even if stdout
+    // isn't a tty; this helps us know that.
+    is_hidden: bool,
+    // We have a high level concept of progress bar types.
+    ptype: ProgressType,
+    // indicatif doesn't expose an API to retrieve the message used,
+    // but we want to print "Frobnicating...done".  So we keep around
+    // the original message and use it sometimes.  Also, to add confusion
+    // this `message` is really the `prefix` in the format string.
+    message: String,
+}
+
+// We only have one stdout, so we can really only print one progress
+// bar at a time.  I understand why indicatif didn't want to commit
+// to having static data, but still.
+lazy_static! {
+    static ref PROGRESS: Mutex<Option<ProgressState>> = Mutex::new(None);
+}
+
+impl ProgressState {
+    /// Create a new progress bar.  Should really only be stored
+    /// in the PROGRESS static ref.
+    fn new<M: Into<String>>(msg: M, ptype: ProgressType) -> Self {
+        let msg = msg.into();
+        let target = ProgressDrawTarget::stdout();
+        let style = ProgressStyle::default_bar();
+        let pb = match ptype {
+            ProgressType::Task => {
+                let pb = ProgressBar::new_spinner();
+                pb.set_style(style.template("{spinner} {prefix} {msg}"));
+                pb.enable_steady_tick(200);
+                pb
+            }
+            ProgressType::NItems(n) => {
+                let pb = ProgressBar::new(n);
+                let width = n_digits(n);
+                // Our width is static, so format the format string with it
+                let fmt = format!("{{spinner}} {{prefix}} {{pos:>{width}$}}/{{len:width$}} [{{bar:20}}] ({{eta}}) {{msg}}",
+                                  width = width);
+                pb.set_style(style.template(&fmt));
+                pb
+            }
+            ProgressType::Percent => {
+                let pb = ProgressBar::new(100);
+                pb.set_style(style.template("{spinner} {prefix} {pos:>3}% [{bar:20}] ({eta}) {msg}"));
+                pb
+            }
+        };
+        let is_hidden = target.is_hidden();
+        if is_hidden {
+            print!("{}...", msg);
+        } else {
+            let msg = match ptype {
+                ProgressType::Task => Cow::Owned(format!("{}...", msg)),
+                _ => Cow::Borrowed(&msg),
+            };
+            pb.set_prefix(&msg);
+        }
+        Self {
+            bar: pb,
+            is_hidden: is_hidden,
+            ptype: ptype,
+            message: msg,
+        }
+    }
+
+    /// Change the "message" which is actually the indicatif `{prefix}`. This
+    /// text appears near the start of the progress bar.
+    fn set_message<M: Into<String>>(&mut self, msg: M) {
+        let msg = msg.into();
+        self.bar.set_prefix(&msg);
+        self.message = msg;
+    }
+
+    /// Change the "sub message" which is the indicatif `{message}`. This text
+    /// appears after everything else - it's meant for text that changes width
+    /// often (otherwise the progress bar would bounce around).
+    fn set_sub_message(&self, msg: Option<&str>) {
+        if let Some(ref sub_message) = msg {
+            self.bar.set_message(sub_message)
+        } else {
+            self.bar.set_message("");
+        }
+    }
+
+    /// For a percent or nitems progress, set the progress state.
+    fn update(&self, n: u64) {
+        assert!(!(self.ptype == ProgressType::Task));
+        self.bar.set_position(n);
+    }
+
+    /// Clear the progress bar and print a completion message even on non-ttys.
+    fn end(&self, suffix: Option<&str>) {
+        self.bar.finish_and_clear();
+        let suffix = suffix.unwrap_or("done");
+        if self.is_hidden {
+            println!("{}", suffix);
+        } else {
+            println!("{}... {}", self.message, suffix);
+        }
+    }
+}
+
+/// Compute the maximum number of digits needed to represent an integer when
+/// formatted as decimal.
+fn n_digits(n: u64) -> u32 {
+    let mut width = 1;
+    let mut n = n;
+    while n >= 10 {
+        width += 1;
+        n = n/10;
+    }
+    width
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_n_digits() {
+        assert_eq!(n_digits(0), 1);
+        assert_eq!(n_digits(9), 1);
+        assert_eq!(n_digits(10), 2);
+        assert_eq!(n_digits(98), 2);
+        assert_eq!(n_digits(100), 3);
+        assert_eq!(n_digits(177), 3);
+        assert_eq!(n_digits(123798), 6);
+        assert_eq!(n_digits(7123798), 7);
+    }
+}
+
+mod ffi {
+    use super::*;
+    use std::sync::MutexGuard;
+    use ffiutil::*;
+    use libc;
+
+    fn assert_empty(m: &MutexGuard<Option<ProgressState>>) {
+        if let Some(ref state) = **m {
+            panic!("Overwriting task: \"{}\"", state.message)
+        }
+    }
+
+    #[no_mangle]
+    pub extern "C" fn ror_progress_begin_task(msg: *const libc::c_char) {
+        let msg = string_from_nonnull(msg);
+        let mut lock = PROGRESS.lock().unwrap();
+        assert_empty(&lock);
+        *lock = Some(ProgressState::new(msg, ProgressType::Task));
+    }
+
+    #[no_mangle]
+    pub extern "C" fn ror_progress_begin_n_items(msg: *const libc::c_char, n: libc::c_int) {
+        let msg = string_from_nonnull(msg);
+        let mut lock = PROGRESS.lock().unwrap();
+        assert_empty(&lock);
+        *lock = Some(ProgressState::new(msg, ProgressType::NItems(n as u64)));
+    }
+
+    #[no_mangle]
+    pub extern "C" fn ror_progress_begin_percent(msg: *const libc::c_char) {
+        let msg = string_from_nonnull(msg);
+        let mut lock = PROGRESS.lock().unwrap();
+        assert_empty(&lock);
+        *lock = Some(ProgressState::new(msg, ProgressType::Percent));
+    }
+
+    #[no_mangle]
+    pub extern "C" fn ror_progress_set_message(msg: *const libc::c_char) {
+        let msg = string_from_nonnull(msg);
+        let mut lock = PROGRESS.lock().unwrap();
+        let state = lock.as_mut().expect("progress to update");
+        state.set_message(msg);
+    }
+
+    #[no_mangle]
+    pub extern "C" fn ror_progress_set_sub_message(msg: *const libc::c_char) {
+        let msg = str_from_nullable(msg);
+        let mut lock = PROGRESS.lock().unwrap();
+        let state = lock.as_mut().expect("progress to update");
+        state.set_sub_message(msg);
+    }
+
+    #[no_mangle]
+    pub extern "C" fn ror_progress_update(n: libc::c_int) {
+        let lock = PROGRESS.lock().unwrap();
+        let state = lock.as_ref().expect("progress to update");
+        state.update(n as u64);
+    }
+
+    #[no_mangle]
+    pub extern "C" fn ror_progress_end(suffix: *const libc::c_char) {
+        let suffix = str_from_nullable(suffix);
+        let mut lock = PROGRESS.lock().unwrap();
+        let state = lock.take().expect("progress to end");
+        state.end(suffix);
+    }
+}
+pub use self::ffi::*;

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -517,7 +517,8 @@ checkout_base_tree (RpmOstreeSysrootUpgrader *self,
     return TRUE; /* already checked out! */
 
   /* let's give the user some feedback so they don't think we're blocked */
-  g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Checking out tree %.7s", self->base_revision);
+  g_auto(RpmOstreeProgress) task = { 0, };
+  rpmostree_output_task_begin (&task, "Checking out tree %.7s", self->base_revision);
 
   int repo_dfd = ostree_repo_get_dfd (self->repo); /* borrowed */
   /* Always delete this */
@@ -1081,7 +1082,8 @@ perform_local_assembly (RpmOstreeSysrootUpgrader *self,
       if (rpmostree_origin_get_regenerate_initramfs (self->origin))
          add_dracut_argv = rpmostree_origin_get_initramfs_args (self->origin);
 
-      g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Generating initramfs");
+      g_auto(RpmOstreeProgress) task = { 0, };
+      rpmostree_output_task_begin (&task, "Generating initramfs");
 
       g_assert (kernel_state && kernel_path);
 
@@ -1294,7 +1296,8 @@ rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
 
   if (use_staging)
     {
-      g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Staging deployment");
+      g_auto(RpmOstreeProgress) task = { 0, };
+      rpmostree_output_task_begin (&task, "Staging deployment");
       if (!ostree_sysroot_stage_tree (self->sysroot, self->osname,
                                       target_revision, origin,
                                       self->cfg_merge_deployment,

--- a/src/daemon/rpmostreed-transaction-livefs.c
+++ b/src/daemon/rpmostreed-transaction-livefs.c
@@ -181,7 +181,8 @@ copy_new_config_files (OstreeRepo          *repo,
                        GCancellable        *cancellable,
                        GError             **error)
 {
-g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Copying new config files");
+  g_auto(RpmOstreeProgress) task = { 0, };
+  rpmostree_output_task_begin (&task, "Copying new config files");
 
   /* Initialize checkout options; we want to make copies, and don't replace any
    * existing files.
@@ -265,7 +266,7 @@ g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Copying new con
         return g_prefix_error (error, "Copying %s: ", path), FALSE;
       n_added++;
     }
-  rpmostree_output_task_done_msg (&task, "%u", n_added);
+  rpmostree_output_progress_end_msg (&task, "%u", n_added);
   return TRUE;
 }
 
@@ -801,7 +802,8 @@ livefs_transaction_execute_inner (LiveFsTransaction *self,
 
   if (!replacing)
     {
-      g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Overlaying /usr");
+      g_auto(RpmOstreeProgress) task = { 0, };
+      rpmostree_output_task_begin (&task, "Overlaying /usr");
       if (!checkout_add_usr (repo, deployment_dfd, diff, target_csum, cancellable, error))
         return FALSE;
 
@@ -824,7 +826,8 @@ livefs_transaction_execute_inner (LiveFsTransaction *self,
       /* Hold my beer 🍺, we're going loop over /usr and RENAME_EXCHANGE things
        * that were modified.
        */
-      g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Replacing /usr");
+      g_auto(RpmOstreeProgress) task = { 0, };
+      rpmostree_output_task_begin (&task, "Replacing /usr");
       if (!replace_usr (repo, deployment_dfd, &replace_tmpdir,
                         diff, target_csum,
                         cancellable, error))
@@ -837,7 +840,8 @@ livefs_transaction_execute_inner (LiveFsTransaction *self,
       const char *tmpfiles_argv[] = { "systemd-tmpfiles", "--create",
                                       "--prefix", NULL, NULL };
 
-      g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Running systemd-tmpfiles for /run,/var");
+      g_auto(RpmOstreeProgress) task = { 0, };
+      rpmostree_output_task_begin (&task, "Running systemd-tmpfiles for /run,/var");
 
       for (guint i = 0; i < G_N_ELEMENTS (tmpfiles_prefixes); i++)
         {

--- a/src/libpriv/rpmostree-output.c
+++ b/src/libpriv/rpmostree-output.c
@@ -22,13 +22,12 @@
 #include <libglnx.h>
 
 #include "rpmostree-output.h"
+#include "rpmostree-rust.h"
 
 /* These are helper functions that automatically determine whether data should
  * be sent through an appropriate D-Bus signal or sent directly to the local
  * terminal. This is helpful in situations in which code may be executed both
  * from the daemon and daemon-less. */
-
-static GLnxConsoleRef console;
 
 void
 rpmostree_output_default_handler (RpmOstreeOutputType type,
@@ -40,34 +39,35 @@ rpmostree_output_default_handler (RpmOstreeOutputType type,
   case RPMOSTREE_OUTPUT_MESSAGE:
     g_print ("%s\n", ((RpmOstreeOutputMessage*)data)->text);
     break;
-  case RPMOSTREE_OUTPUT_TASK_BEGIN:
-    /* XXX: move to libglnx spinner once it's implemented */
-    g_print ("%s... ", ((RpmOstreeOutputTaskBegin*)data)->text);
-    break;
-  case RPMOSTREE_OUTPUT_TASK_END:
-    g_print ("%s\n", ((RpmOstreeOutputTaskEnd*)data)->text ?: "");
-    break;
-  case RPMOSTREE_OUTPUT_PROGRESS_PERCENT:
-    if (!console.locked)
-      glnx_console_lock (&console);
-    RpmOstreeOutputProgressPercent *prog = data;
-    /* let's not spam stdout if it's not a tty; see dbus-helpers.c */
-    if (prog->percentage == 100 || console.is_tty)
-      glnx_console_progress_text_percent (prog->text, prog->percentage);
-    break;
-  case RPMOSTREE_OUTPUT_PROGRESS_N_ITEMS:
+  case RPMOSTREE_OUTPUT_PROGRESS_BEGIN:
     {
-      RpmOstreeOutputProgressNItems *nitems = data;
-      if (!console.locked)
-        glnx_console_lock (&console);
-
-      glnx_console_progress_n_items (nitems->text, nitems->current, nitems->total);
+      RpmOstreeOutputProgressBegin *begin = data;
+      if (begin->percent)
+        ror_progress_begin_percent (begin->prefix);
+      else if (begin->n > 0)
+        ror_progress_begin_n_items (begin->prefix, begin->n);
+      else
+        ror_progress_begin_task (begin->prefix);
+    }
+    break;
+  case RPMOSTREE_OUTPUT_PROGRESS_UPDATE:
+    {
+      RpmOstreeOutputProgressUpdate *upd = data;
+      ror_progress_update (upd->c);
+    }
+    break;
+  case RPMOSTREE_OUTPUT_PROGRESS_SUB_MESSAGE:
+    {
+      const char *msg = data;
+      ror_progress_set_sub_message (msg);
     }
     break;
   case RPMOSTREE_OUTPUT_PROGRESS_END:
-    if (console.locked)
-      glnx_console_unlock (&console);
-    break;
+    {
+      RpmOstreeOutputProgressEnd *end = data;
+      ror_progress_end (end->msg);
+      break;
+    }
   }
 }
 
@@ -97,41 +97,69 @@ rpmostree_output_message (const char *format, ...)
   active_cb (RPMOSTREE_OUTPUT_MESSAGE, &task, active_cb_opaque);
 }
 
-RpmOstreeOutputTask
-rpmostree_output_task_begin (const char *format, ...)
+void
+rpmostree_output_task_begin (RpmOstreeProgress *taskp, const char *format, ...)
 {
-  g_autofree char *final_msg = strdup_vprintf (format);
-  RpmOstreeOutputTaskBegin task = { final_msg };
-  active_cb (RPMOSTREE_OUTPUT_TASK_BEGIN, &task, active_cb_opaque);
-  return true;
+  g_assert (taskp && !taskp->initialized);
+  taskp->initialized = TRUE;
+  taskp->type = RPMOSTREE_PROGRESS_TASK;
+  g_autofree char *msg = strdup_vprintf (format);
+  RpmOstreeOutputProgressBegin begin = { msg, false, 0 };
+  active_cb (RPMOSTREE_OUTPUT_PROGRESS_BEGIN, &begin, active_cb_opaque);
 }
 
 void
-rpmostree_output_task_done_msg (RpmOstreeOutputTask *taskp, const char *format, ...)
+rpmostree_output_set_sub_message (const char *sub_message)
 {
-  g_assert (taskp && *taskp);
-  *taskp = false;
-  g_autofree char *final_msg = strdup_vprintf (format);
-  RpmOstreeOutputTaskEnd task = { final_msg };
-  active_cb (RPMOSTREE_OUTPUT_TASK_END, &task, active_cb_opaque);
+  active_cb (RPMOSTREE_OUTPUT_PROGRESS_SUB_MESSAGE, (void*)sub_message, active_cb_opaque);
 }
 
 void
-rpmostree_output_progress_percent (const char *text, int percentage)
+rpmostree_output_progress_end_msg (RpmOstreeProgress *taskp, const char *format, ...)
 {
-  RpmOstreeOutputProgressPercent progress = { text, percentage };
-  active_cb (RPMOSTREE_OUTPUT_PROGRESS_PERCENT, &progress, active_cb_opaque);
+  g_assert (taskp);
+  if (!taskp->initialized)
+    return;
+  taskp->initialized = false;
+  g_autofree char *final_msg = format ? strdup_vprintf (format) : NULL;
+  RpmOstreeOutputProgressEnd done = { final_msg };
+  active_cb (RPMOSTREE_OUTPUT_PROGRESS_END, &done, active_cb_opaque);
 }
 
 void
-rpmostree_output_progress_n_items (const char *text, guint current, guint total)
+rpmostree_output_progress_percent (int percentage)
 {
-  RpmOstreeOutputProgressNItems progress = { text, current, total };
-  active_cb (RPMOSTREE_OUTPUT_PROGRESS_N_ITEMS, &progress, active_cb_opaque);
+  RpmOstreeOutputProgressUpdate progress = { percentage };
+  active_cb (RPMOSTREE_OUTPUT_PROGRESS_UPDATE, &progress, active_cb_opaque);
 }
 
 void
-rpmostree_output_progress_end (void)
+rpmostree_output_progress_nitems_begin (RpmOstreeProgress *taskp,
+                                        guint n, const char *format, ...)
 {
-  active_cb (RPMOSTREE_OUTPUT_PROGRESS_END, NULL, active_cb_opaque);
+  g_assert (taskp && !taskp->initialized);
+  taskp->initialized = TRUE;
+  taskp->type = RPMOSTREE_PROGRESS_N_ITEMS;
+  g_autofree char *msg = strdup_vprintf (format);
+  RpmOstreeOutputProgressBegin begin = { msg, false, n };
+  active_cb (RPMOSTREE_OUTPUT_PROGRESS_BEGIN, &begin, active_cb_opaque);
+}
+
+void
+rpmostree_output_progress_percent_begin (RpmOstreeProgress *taskp,
+                                         const char *format, ...)
+{
+  g_assert (taskp && !taskp->initialized);
+  taskp->initialized = TRUE;
+  taskp->type = RPMOSTREE_PROGRESS_PERCENT;
+  g_autofree char *msg = strdup_vprintf (format);
+  RpmOstreeOutputProgressBegin begin = { msg, true, 0 };
+  active_cb (RPMOSTREE_OUTPUT_PROGRESS_BEGIN, &begin, active_cb_opaque);
+}
+
+void
+rpmostree_output_progress_n_items (guint current)
+{
+  RpmOstreeOutputProgressUpdate progress = { current };
+  active_cb (RPMOSTREE_OUTPUT_PROGRESS_UPDATE, &progress, active_cb_opaque);
 }

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -616,7 +616,8 @@ rpmostree_migrate_pkgcache_repo (OstreeRepo   *repo,
     {
       if (S_ISDIR (stbuf.st_mode))
         {
-          g_auto(RpmOstreeOutputTask) task = rpmostree_output_task_begin ("Migrating pkgcache");
+          g_auto(RpmOstreeProgress) task = { 0, };
+          rpmostree_output_task_begin (&task, "Migrating pkgcache");
 
           g_autoptr(OstreeRepo) pkgcache = ostree_repo_open_at (repo_dfd,
                                                                 RPMOSTREE_OLD_PKGCACHE_DIR,
@@ -628,7 +629,7 @@ rpmostree_migrate_pkgcache_repo (OstreeRepo   *repo,
           if (!do_pkgcache_migration (repo, pkgcache, &n_migrated, cancellable, error))
             return FALSE;
 
-          rpmostree_output_task_done_msg (&task, "%u done", n_migrated);
+          rpmostree_output_progress_end_msg (&task, "%u done", n_migrated);
           if (n_migrated > 0)
             sd_journal_print (LOG_INFO, "migrated %u cached package%s to system repo",
                               n_migrated, _NS(n_migrated));

--- a/tests/vmcheck/test-layering-basic-1.sh
+++ b/tests/vmcheck/test-layering-basic-1.sh
@@ -140,7 +140,7 @@ assert_streq $rc 77
 # Test that we don't do progress bars if on a tty (with the client)
 # (And use --unchanged-exit-77 to verify that we *don't* exit 77).
 vm_rpmostree install foo-1.0 --unchanged-exit-77 > foo-install.txt
-assert_file_has_content_literal foo-install.txt 'Checking out packages (1/1) 100%'
+assert_file_has_content_literal foo-install.txt 'Checking out packages...done'
 echo "ok install not on a tty"
 
 # check that by default we diff booted vs pending

--- a/tests/vmcheck/test-layering-basic-2.sh
+++ b/tests/vmcheck/test-layering-basic-2.sh
@@ -27,14 +27,14 @@ set -x
 # install foo and make sure it was imported
 vm_build_rpm foo
 vm_rpmostree install foo | tee output.txt
-assert_file_has_content output.txt '^Importing...done'
+assert_file_has_content output.txt '^Importing\.\.\.done'
 # also check that we definitely had to checkout the tree
 assert_file_has_content output.txt "Checking out tree "
 
 # upgrade with same foo in repos --> shouldn't re-import
 vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
 vm_rpmostree upgrade | tee output.txt
-assert_not_file_has_content output.txt '^Importing...'
+assert_not_file_has_content output.txt '^Importing\.\.\.'
 echo "ok reuse cached pkg"
 
 # upgrade with different foo in repos --> should re-import
@@ -45,7 +45,7 @@ if cmp -s c1 c2; then
   assert_not_reached "RPM rebuild yielded same SHA256"
 fi
 vm_rpmostree upgrade | tee output.txt
-assert_file_has_content output.txt '^Importing...done'
+assert_file_has_content output.txt '^Importing\.\.\.done'
 echo "ok invalidate pkgcache from RPM chksum"
 
 # make sure installing in /boot translates to /usr/lib/ostree-boot

--- a/tests/vmcheck/test-layering-basic-2.sh
+++ b/tests/vmcheck/test-layering-basic-2.sh
@@ -27,14 +27,14 @@ set -x
 # install foo and make sure it was imported
 vm_build_rpm foo
 vm_rpmostree install foo | tee output.txt
-assert_file_has_content output.txt '^Importing (1/1)'
+assert_file_has_content output.txt '^Importing...done'
 # also check that we definitely had to checkout the tree
 assert_file_has_content output.txt "Checking out tree "
 
 # upgrade with same foo in repos --> shouldn't re-import
 vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
 vm_rpmostree upgrade | tee output.txt
-assert_not_file_has_content output.txt '^Importing ('
+assert_not_file_has_content output.txt '^Importing...'
 echo "ok reuse cached pkg"
 
 # upgrade with different foo in repos --> should re-import
@@ -45,7 +45,7 @@ if cmp -s c1 c2; then
   assert_not_reached "RPM rebuild yielded same SHA256"
 fi
 vm_rpmostree upgrade | tee output.txt
-assert_file_has_content output.txt '^Importing (1/1)'
+assert_file_has_content output.txt '^Importing...done'
 echo "ok invalidate pkgcache from RPM chksum"
 
 # make sure installing in /boot translates to /usr/lib/ostree-boot


### PR DESCRIPTION
This turned out to be messier than I thought, because of two primary
factors; the biggest mess here of course is the indirection
through the DBus API, and this patch actually doesn't yet update
the client-side rendering of that.

The other problem is that previously we passed the string to render
each time, and with current indicatif that'd trigger a rerender.
Since we never changed the "prefix string", rework the API.

Change the "percent/n_items" bits to use autocleanups as well, and
to take the prefix string as an initial argument.

Since the state expands to multiple components, also change the
API to use the `0-initialized` pattern rather than trying to
return an aggregate.

We also gain a "sub message" which we use to display e.g.
package names as we're doing checkouts.