### PR TITLE
compose: Allow --print-only without bwrap support

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -513,7 +513,7 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
   /* Test whether or not bwrap is going to work - we will fail inside e.g. a Docker
    * container without --privileged or userns exposed.
    */
-  if (!rpmostree_bwrap_selftest (error))
+  if (!opt_print_only && !rpmostree_bwrap_selftest (error))
     return FALSE;
 
   self->repo = ostree_repo_open_at (AT_FDCWD, opt_repo, cancellable, error);


### PR DESCRIPTION
We don't need to run the bwrap self test if we just want to print the
manifest. I played with putting the self test in `impl_install`, though
e.g. `postprocess` also needs this so it wasn't quite right.