### PR TITLE
core: Typo in indicatif commit: `metdata` → `metadata`

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1131,7 +1131,7 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
                                              G_CALLBACK (on_hifstate_percentage_changed),
                                              NULL);
     g_auto(RpmOstreeProgress) progress = { 0, };
-    rpmostree_output_progress_percent_begin (&progress, "Importing metdata");
+    rpmostree_output_progress_percent_begin (&progress, "Importing metadata");
 
     /* This will check the metadata again, but it *should* hit the cache; down
      * the line we should really improve the libdnf API around all of this.


### PR DESCRIPTION
A typo.
