### PR TITLE
rust: Use `failure` crate for errors

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Colin Walters <walters@verbum.org>", "Jonathan Lebon <jonathan@jlebon.com>"]
 
 [dependencies]
+failure = "0.1.3"
 serde = "1.0.78"
 serde_derive = "1.0.78"
 serde_json = "1.0"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -18,6 +18,8 @@
 
 extern crate c_utf8;
 extern crate curl;
+#[macro_use]
+extern crate failure;
 extern crate gio_sys;
 extern crate glib;
 extern crate glib_sys;

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -96,7 +96,10 @@ fn treefile_parse_stream<R: io::Read>(
         (Some(arch), Some(treeref)) => {
             let mut varsubsts = HashMap::new();
             varsubsts.insert("basearch".to_string(), arch.to_string());
-            Some(utils::varsubst(&treeref, &varsubsts)?)
+            Some(
+                utils::varsubst(&treeref, &varsubsts)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?,
+            )
         }
         (_, v) => v,
     };

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+use failure::Error;
 use std::collections::HashMap;
 use std::io::prelude::*;
 use std::{fs, io};
@@ -44,8 +45,7 @@ fn download_url_to_tmpfile(url: &str) -> io::Result<fs::File> {
 /// Given an input string `s`, replace variables of the form `${foo}` with
 /// values provided in `vars`.  No quoting syntax is available, so it is
 /// not possible to have a literal `${` in the string.
-#[allow(dead_code)]
-pub fn varsubst(instr: &str, vars: &HashMap<String, String>) -> io::Result<String> {
+pub fn varsubst(instr: &str, vars: &HashMap<String, String>) -> Result<String, Error> {
     let mut buf = instr;
     let mut s = "".to_string();
     while buf.len() > 0 {
@@ -59,17 +59,11 @@ pub fn varsubst(instr: &str, vars: &HashMap<String, String>) -> io::Result<Strin
                 if let Some(val) = vars.get(varname) {
                     s.push_str(val);
                 } else {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!("Unknown variable reference ${{{}}}", varname),
-                    ));
+                    bail!("Unknown variable reference ${{{}}}", varname);
                 }
                 buf = remainder;
             } else {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    format!("Unclosed variable"),
-                ));
+                bail!("Unclosed variable");
             }
         } else {
             s.push_str(buf);

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -16,7 +16,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-use failure::Error;
+use failure::Fallible;
 use std::collections::HashMap;
 use std::io::prelude::*;
 use std::{fs, io};
@@ -45,7 +45,7 @@ fn download_url_to_tmpfile(url: &str) -> io::Result<fs::File> {
 /// Given an input string `s`, replace variables of the form `${foo}` with
 /// values provided in `vars`.  No quoting syntax is available, so it is
 /// not possible to have a literal `${` in the string.
-pub fn varsubst(instr: &str, vars: &HashMap<String, String>) -> Result<String, Error> {
+pub fn varsubst(instr: &str, vars: &HashMap<String, String>) -> Fallible<String> {
     let mut buf = instr;
     let mut s = "".to_string();
     while buf.len() > 0 {


### PR DESCRIPTION
In a lot of places we're abusing `io::Error(io::ErrorKind::InvalidInput)`
which is both verbose and inaccurate really.  Maybe in some
places we should be defining custom errors, but eh.

I like the `failure` crate.  Use it in just `utils.rs` for now.
Tweak our error handling FFI wrappers to accept `Display` since
all we do is convert the error to a string.
