### PR TITLE
vmcheck: Sync over libsolv too

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -60,14 +60,11 @@ required: true
 cluster:
   hosts:
     - name: vmcheck1
-      # XXX: temp hack until smoketested has newer glib2
-      # XXX: and also causes layering-relabel to fail?
-      # https://github.com/projectatomic/rpm-ostree/pull/1406
-      distro: centos/7/atomic/continuous
+      distro: centos/7/atomic/smoketested
     - name: vmcheck2
-      distro: centos/7/atomic/continuous
+      distro: centos/7/atomic/smoketested
     - name: vmcheck3
-      distro: centos/7/atomic/continuous
+      distro: centos/7/atomic/smoketested
   container:
     image: registry.centos.org/centos/centos:7
 

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -93,7 +93,7 @@ if !HAVE_EXTERNAL_CBINDGEN
 rpmostree-bindgen: bindgen/Cargo.toml bindgen/src/main.rs
 	cd $(top_srcdir)/bindgen && \
 	export CARGO_TARGET_DIR=@abs_top_builddir@/bindgen-target && \
-	if test -d "$${CARGO_TARGET_DIR}" && [ "$$(stat -c '%u' ${target_subdir})" != "$$(id -u)" ]; then echo "mismatched uids on build"; exit 1; fi && \
+	if test -d "$${CARGO_TARGET_DIR}" && [ "$$(stat -c '%u' $${CARGO_TARGET_DIR})" != "$$(id -u)" ]; then echo "mismatched uids on build"; exit 1; fi && \
 	$(cargo_build) && \
 	ln -sf $${CARGO_TARGET_DIR}/debug/rpmostree-bindgen $(abs_top_builddir)/rpmostree-bindgen
 endif

--- a/Makefile-rpm-ostree.am
+++ b/Makefile-rpm-ostree.am
@@ -98,6 +98,7 @@ rpmostree-bindgen: bindgen/Cargo.toml bindgen/src/main.rs
 	ln -sf $${CARGO_TARGET_DIR}/debug/rpmostree-bindgen $(abs_top_builddir)/rpmostree-bindgen
 endif
 endif
+GITIGNOREFILES += bindgen-target/ rpmostree-bindgen
 
 librpmostree_rust_path = @abs_top_builddir@/target/@RUST_TARGET_SUBDIR@/librpmostree_rust.a
 # If the target directory exists, and isn't owned by our uid, then

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -347,6 +347,7 @@ package_diff_transaction_execute (RpmostreedTransaction *transaction,
       if (!apply_revision_override (transaction, repo, progress, origin,
                                     self->revision, cancellable, error))
         return FALSE;
+      rpmostree_transaction_emit_progress_end (RPMOSTREE_TRANSACTION (transaction));
     }
   else if (upgrading)
     {
@@ -870,6 +871,7 @@ deploy_transaction_execute (RpmostreedTransaction *transaction,
       if (!apply_revision_override (transaction, repo, progress, origin,
                                     self->revision, cancellable, error))
         return FALSE;
+      rpmostree_transaction_emit_progress_end (RPMOSTREE_TRANSACTION (transaction));
     }
   else
     {

--- a/src/daemon/rpmostreed-utils.c
+++ b/src/daemon/rpmostreed-utils.c
@@ -307,6 +307,9 @@ rpmostreed_repo_pull_ancestry (OstreeRepo               *repo,
                                               g_variant_dict_end (&options),
                                               progress, cancellable, error))
             goto out;
+
+          if (progress)
+            ostree_async_progress_finish (progress);
         }
 
       /* First pass only.  Now we can resolve the ref to a checksum. */

--- a/tests/vmcheck/install.sh
+++ b/tests/vmcheck/install.sh
@@ -15,7 +15,14 @@ rm -rf ${DESTDIR}
 mkdir -p ${DESTDIR}
 
 ostree --version
-for pkg in ostree{,-libs,-grub2}; do
+# We don't want to sync all of userspace, just things
+# that rpm-ostree links to or uses and tend to drift
+# in important ways.
+pkgs="libsolv"
+if rpm -q zchunk-libs 2>/dev/null; then
+    pkgs="${pkgs} zchunk-libs"
+fi
+for pkg in ostree{,-libs,-grub2} ${pkgs}; do
 
     rpm -q $pkg
 

--- a/tests/vmcheck/multitest.py
+++ b/tests/vmcheck/multitest.py
@@ -118,8 +118,7 @@ class Host:
             os.remove(outfile)
 
         rcs = "PASS" if rc == 0 else ("FAIL (rc %d)" % rc)
-        print("%s: %s" % (rcs, self.test))
-        print("Execution took {} seconds".format(int(endtime - self._starttime)))
+        print("{}: {} (took {}s)".format(rcs, self.test, int(endtime - self._starttime)))
 
         self.test = ""
         self._p = None

--- a/tests/vmcheck/multitest.py
+++ b/tests/vmcheck/multitest.py
@@ -105,7 +105,7 @@ class Host:
     def flush(self):
         if not self._p:
             return 0
-        print("Waiting for completion of {} (pid={})".format(self.test, self._p.pid))
+        print("WAITING: {} (pid={})".format(self.test, self._p.pid))
         rc = self._p.wait()
         endtime = time.time()
 

--- a/tests/vmcheck/multitest.py
+++ b/tests/vmcheck/multitest.py
@@ -76,6 +76,7 @@ class Host:
         self.hostname = hostname
         self.test = ""
         self._p = None
+        self._starttime = None
         self.saw_fail = False
 
     def is_done(self):
@@ -94,6 +95,7 @@ class Host:
         if not os.path.isdir("vmcheck"):
             os.mkdir("vmcheck")
         testsh = os.path.join(sys.path[0], "test.sh")
+        self._starttime = time.time()
         self._p = subprocess.Popen([testsh], env=env,
                                    stdout=open("vmcheck/%s.log" % test, 'wb'),
                                    stderr=subprocess.STDOUT)
@@ -104,6 +106,7 @@ class Host:
         if not self._p:
             return 0
         rc = self._p.wait()
+        endtime = time.time()
 
         # just merge the two files
         outfile = "vmcheck/{}.out".format(self.test)
@@ -115,6 +118,7 @@ class Host:
 
         rcs = "PASS" if rc == 0 else ("FAIL (rc %d)" % rc)
         print("%s: %s" % (rcs, self.test))
+        print("Execution took {} seconds".format(int(endtime - self._starttime)))
 
         self.test = ""
         self._p = None

--- a/tests/vmcheck/multitest.py
+++ b/tests/vmcheck/multitest.py
@@ -105,6 +105,7 @@ class Host:
     def flush(self):
         if not self._p:
             return 0
+        print("Waiting for completion of {} (pid={})".format(self.test, self._p.pid))
         rc = self._p.wait()
         endtime = time.time()
 


### PR DESCRIPTION
In general our current CI/test system is susceptible to drift
between the container and AH.  The direction we should be
going is to have coreos-assembler solve this problem with
a SDK, but for now, let's ensure that the container's libsolv
makes it to the host, same thing we do for libostree.
