### PR TITLE
core: Tweak "Importing" messages

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1131,7 +1131,7 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
                                              G_CALLBACK (on_hifstate_percentage_changed),
                                              NULL);
     g_auto(RpmOstreeProgress) progress = { 0, };
-    rpmostree_output_progress_percent_begin (&progress, "Importing rpm-md metadata");
+    rpmostree_output_progress_percent_begin (&progress, "Importing rpm-md");
 
     /* This will check the metadata again, but it *should* hit the cache; down
      * the line we should really improve the libdnf API around all of this.

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1131,7 +1131,7 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
                                              G_CALLBACK (on_hifstate_percentage_changed),
                                              NULL);
     g_auto(RpmOstreeProgress) progress = { 0, };
-    rpmostree_output_progress_percent_begin (&progress, "Importing metadata");
+    rpmostree_output_progress_percent_begin (&progress, "Importing rpm-md metadata");
 
     /* This will check the metadata again, but it *should* hit the cache; down
      * the line we should really improve the libdnf API around all of this.
@@ -2374,7 +2374,7 @@ rpmostree_context_import_rojig (RpmOstreeContext *self,
   self->async_cancellable = cancellable;
 
   g_auto(RpmOstreeProgress) progress = { 0, };
-  rpmostree_output_progress_nitems_begin (&progress, self->pkgs_to_import->len, "Importing");
+  rpmostree_output_progress_nitems_begin (&progress, self->pkgs_to_import->len, "Importing packages");
 
   /* Process imports */
   GMainContext *mainctx = g_main_context_get_thread_default ();

--- a/src/libpriv/rpmostree-importer.c
+++ b/src/libpriv/rpmostree-importer.c
@@ -930,7 +930,7 @@ rpmostree_importer_run (RpmOstreeImporter *self,
   if (!import_rpm_to_repo (self, &csum, cancellable, error))
     {
       g_autofree char *name = headerGetAsString (self->hdr, RPMTAG_NAME);
-      g_prefix_error (error, "Importing %s: ", name);
+      g_prefix_error (error, "Importing package %s: ", name);
       return FALSE;
     }
 

--- a/tests/vmcheck/test-layering-basic-2.sh
+++ b/tests/vmcheck/test-layering-basic-2.sh
@@ -27,14 +27,14 @@ set -x
 # install foo and make sure it was imported
 vm_build_rpm foo
 vm_rpmostree install foo | tee output.txt
-assert_file_has_content output.txt '^Importing\.\.\.done'
+assert_file_has_content output.txt '^Importing packages\.\.\.done'
 # also check that we definitely had to checkout the tree
 assert_file_has_content output.txt "Checking out tree "
 
 # upgrade with same foo in repos --> shouldn't re-import
 vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck
 vm_rpmostree upgrade | tee output.txt
-assert_not_file_has_content output.txt '^Importing\.\.\.'
+assert_not_file_has_content output.txt '^Importing packages\.\.\.'
 echo "ok reuse cached pkg"
 
 # upgrade with different foo in repos --> should re-import
@@ -45,7 +45,7 @@ if cmp -s c1 c2; then
   assert_not_reached "RPM rebuild yielded same SHA256"
 fi
 vm_rpmostree upgrade | tee output.txt
-assert_file_has_content output.txt '^Importing\.\.\.done'
+assert_file_has_content output.txt '^Importing packages\.\.\.done'
 echo "ok invalidate pkgcache from RPM chksum"
 
 # make sure installing in /boot translates to /usr/lib/ostree-boot


### PR DESCRIPTION
To make it more obvious what the difference between "Importing metadata"
and "Importing" is, add "rpm-md" to the first and "packages" to the
second.