### PR TITLE
rust/ffi: Change dfd handling to unwrap, create naming convention

### DIFF
--- a/rust/src/ffiutil.rs
+++ b/rust/src/ffiutil.rs
@@ -30,7 +30,7 @@ use openat;
 /* Wrapper functions for translating basic types from C to Rust.
  *
  * Functions named `ffi_view_` do not take ownership of their argument; they
- * should be used "convert" input parameters from C types to Rust.  Be careful
+ * should be used to "convert" input parameters from C types to Rust.  Be careful
  * not to store the parameters outside of the function call.
  */
 
@@ -63,7 +63,7 @@ pub fn bytes_from_nonnull<'a>(s: *const libc::c_char) -> &'a [u8] {
 // must be less than or equal to that of parameter.
 pub fn ffi_view_openat_dir(fd: libc::c_int) -> openat::Dir {
     let src = unsafe { openat::Dir::from_raw_fd(fd) };
-    let r = src.sub_dir(".").expect("dir_from_dfd");
+    let r = src.sub_dir(".").expect("ffi_view_openat_dir");
     let _ = src.into_raw_fd();
     r
 }

--- a/rust/src/ffiutil.rs
+++ b/rust/src/ffiutil.rs
@@ -23,11 +23,16 @@ use std::ffi::CStr;
 use std::ffi::CString;
 use std::fmt::Display;
 use std::os::unix::io::{FromRawFd, IntoRawFd};
-use std::{io, ptr};
+use std::ptr;
 
 use openat;
 
-/* Wrapper functions for translating basic types from C to Rust */
+/* Wrapper functions for translating basic types from C to Rust.
+ *
+ * Functions named `ffi_view_` do not take ownership of their argument; they
+ * should be used "convert" input parameters from C types to Rust.  Be careful
+ * not to store the parameters outside of the function call.
+ */
 
 /// Convert a C (UTF-8) string to a &str; will panic
 /// if it isn't valid UTF-8.  Note the lifetime of
@@ -54,11 +59,13 @@ pub fn bytes_from_nonnull<'a>(s: *const libc::c_char) -> &'a [u8] {
     unsafe { CStr::from_ptr(s) }.to_bytes()
 }
 
-pub fn dir_from_dfd(fd: libc::c_int) -> io::Result<openat::Dir> {
+// View `fd` as an `openat::Dir` instance.  Lifetime of return value
+// must be less than or equal to that of parameter.
+pub fn ffi_view_openat_dir(fd: libc::c_int) -> openat::Dir {
     let src = unsafe { openat::Dir::from_raw_fd(fd) };
-    let r = src.sub_dir(".")?;
+    let r = src.sub_dir(".").expect("dir_from_dfd");
     let _ = src.into_raw_fd();
-    Ok(r)
+    r
 }
 
 /// Assert that a raw pointer is not `NULL`, and cast it to a Rust reference

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -832,13 +832,7 @@ mod ffi {
         // Convert arguments
         let filename = OsStr::from_bytes(bytes_from_nonnull(filename));
         let arch = str_from_nullable(arch);
-        let workdir = match dir_from_dfd(workdir_dfd) {
-            Ok(p) => p,
-            Err(e) => {
-                error_to_glib(&e, gerror);
-                return ptr::null_mut();
-            }
-        };
+        let workdir = ffi_view_openat_dir(workdir_dfd);
         // Run code, map error if any, otherwise extract raw pointer, passing
         // ownership back to C.
         ptr_glib_error(


### PR DESCRIPTION
I was going to add another usage of this function, and I think the
gerror stuff is unnecessary - if we are handed a bad file descriptor
(or a fd pointing to a regular file) that's something where we should
just abort.

While we're here, I'd like to codify expected usage in the function
names here.  If you like this I'll e.g. also change `str_from_nullable`
to `ffi_view_nullable_str`.
