### PR TITLE
libpriv/rpm-util: Tweak changelog entry indentation

### DIFF
--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -687,7 +687,7 @@ rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff)
           { /* add is first */
             Header ha = diff->hs_add->pdata[diff->hs_add->len-1];
 
-            g_print  ("+");
+            g_print ("+");
             pkg_print (ha);
             g_ptr_array_remove_index(diff->hs_add, diff->hs_add->len-1);
           }
@@ -696,7 +696,7 @@ rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff)
           { /* del is first */
             Header hd = diff->hs_del->pdata[diff->hs_del->len-1];
 
-            g_print  ("-");
+            g_print ("-");
             pkg_print (hd);
             g_ptr_array_remove_index(diff->hs_del, diff->hs_del->len-1);
           }
@@ -704,7 +704,7 @@ rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff)
           { /* add is first */
             Header ha = diff->hs_add->pdata[diff->hs_add->len-1];
 
-            g_print  ("+");
+            g_print ("+");
             pkg_print (ha);
             g_ptr_array_remove_index(diff->hs_add, diff->hs_add->len-1);
           }

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -593,14 +593,25 @@ rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff)
                   g_str_equal (ochange_text, nchange_text))
                 break;
 
+#define CHANGELOG_INDENTATION "    "
+
+              g_autofree char *indented_nchange_text = NULL;
+              if (strchr (nchange_text, '\n'))
+                {
+                  g_auto(GStrv) lines = g_strsplit (nchange_text, "\n", 0);
+                  indented_nchange_text = g_strjoinv ("\n" CHANGELOG_INDENTATION, lines);
+                }
+
               /* Otherwise, print. */
               dt = g_date_time_new_from_unix_utc (nchange_date);
               date_time_str = g_date_time_format (dt, "%a %b %d %Y");
               g_date_time_unref (dt);
 
-              g_print ("    * %s %s\n"
-                       "    %s\n\n", date_time_str, nchange_name,
-                       nchange_text);
+              g_print (CHANGELOG_INDENTATION "* %s %s\n"
+                       CHANGELOG_INDENTATION "%s\n\n", date_time_str, nchange_name,
+                       indented_nchange_text ?: nchange_text);
+
+#undef CHANGELOG_INDENTATION
 
               --ncnum;
             }

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -598,7 +598,8 @@ rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff)
               date_time_str = g_date_time_format (dt, "%a %b %d %Y");
               g_date_time_unref (dt);
 
-              g_print ("* %s %s\n%s\n\n", date_time_str, nchange_name,
+              g_print ("    * %s %s\n"
+                       "    %s\n\n", date_time_str, nchange_name,
                        nchange_text);
 
               --ncnum;

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -54,7 +54,6 @@ header_name_cmp (Header h1, Header h2)
   const char*    n1 = headerGetString (h1, RPMTAG_NAME);
   const char*    n2 = headerGetString (h2, RPMTAG_NAME);
   int cmp = strcmp (n1, n2);
-  /* printf("%s <=> %s = %u\n", n1, n2, cmp); */
   return cmp;
 }
 
@@ -420,7 +419,7 @@ rpmhdrs_list (struct RpmHeaders *l1)
   while (num < l1->hs->len)
     {
       Header h1 = l1->hs->pdata[num++];
-      printf (" ");
+      g_print (" ");
       pkg_print (h1);
     }
 }
@@ -599,8 +598,8 @@ rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff)
               date_time_str = g_date_time_format (dt, "%a %b %d %Y");
               g_date_time_unref (dt);
 
-              printf ("* %s %s\n%s\n\n", date_time_str, nchange_name,
-                      nchange_text);
+              g_print ("* %s %s\n%s\n\n", date_time_str, nchange_name,
+                       nchange_text);
 
               --ncnum;
             }
@@ -622,7 +621,7 @@ rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff)
               g_print ("Downgraded:\n");
             }
 
-          printf ("  ");
+          g_print ("  ");
           pkg_print_changed (ho, hn);
         }
     }
@@ -635,7 +634,7 @@ rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff)
         {
           Header hd = diff->hs_del->pdata[num];
 
-          printf ("  ");
+          g_print ("  ");
           pkg_print (hd);
         }
     }
@@ -648,7 +647,7 @@ rpmhdrs_diff_prnt_block (gboolean changelogs, struct RpmHeadersDiff *diff)
         {
           Header ha = diff->hs_add->pdata[num];
 
-          printf ("  ");
+          g_print ("  ");
           pkg_print (ha);
         }
     }
@@ -675,10 +674,10 @@ rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff)
           { /* mod is first */
             Header hm = diff->hs_mod_old->pdata[diff->hs_mod_old->len-1];
 
-            printf("!");
+            g_print ("!");
             pkg_print (hm);
             g_ptr_array_remove_index(diff->hs_mod_old, diff->hs_mod_old->len-1);
-            printf("=");
+            g_print ("=");
             hm = diff->hs_mod_new->pdata[diff->hs_mod_new->len-1];
             pkg_print (hm);
             g_ptr_array_remove_index(diff->hs_mod_new, diff->hs_mod_new->len-1);
@@ -687,7 +686,7 @@ rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff)
           { /* add is first */
             Header ha = diff->hs_add->pdata[diff->hs_add->len-1];
 
-            printf ("+");
+            g_print  ("+");
             pkg_print (ha);
             g_ptr_array_remove_index(diff->hs_add, diff->hs_add->len-1);
           }
@@ -696,7 +695,7 @@ rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff)
           { /* del is first */
             Header hd = diff->hs_del->pdata[diff->hs_del->len-1];
 
-            printf ("-");
+            g_print  ("-");
             pkg_print (hd);
             g_ptr_array_remove_index(diff->hs_del, diff->hs_del->len-1);
           }
@@ -704,7 +703,7 @@ rpmhdrs_diff_prnt_diff (struct RpmHeadersDiff *diff)
           { /* add is first */
             Header ha = diff->hs_add->pdata[diff->hs_add->len-1];
 
-            printf ("+");
+            g_print  ("+");
             pkg_print (ha);
             g_ptr_array_remove_index(diff->hs_add, diff->hs_add->len-1);
           }


### PR DESCRIPTION
Indent the changelog entries so it's easier to tell which entries belong
to which packages.

Before:

```
$ ros db diff -c
ostree diff commit old: rollback deployment (ef3c0e45ee1b874bc4952904a778084f0c32a0e06346e271786abf544dad54ff)
ostree diff commit new: booted deployment (c1d4c3ef571a53e5ab3dbd6ea1ec91a374ebd5f6ba9c0a99938d0649853588a5)
Upgraded:
  firefox 63.0.3-1.fc29.x86_64 -> 63.0.3-2.fc29.x86_64
* Wed Nov 21 2018 Martin Stransky <stransky@redhat.com> - 63.0.3-2
- Fixed mozbz#1507475 - crash when display changes (rhbz#1646151).

  httpd 2.4.37-3.fc29.x86_64 -> 2.4.37-5.fc29.x86_64
* Fri Nov 23 2018 Lubos Uhliarik <luhliari@redhat.com> - 2.4.37-5
- Resolves: #1652678 - TLS connection allowed while all protocols are forbidden

* Thu Nov 08 2018 Joe Orton <jorton@redhat.com> - 2.4.37-4
- add httpd.conf(5) (#1611361)
```

After:

```
$ ros db diff -c
ostree diff commit old: rollback deployment (ef3c0e45ee1b874bc4952904a778084f0c32a0e06346e271786abf544dad54ff)
ostree diff commit new: booted deployment (c1d4c3ef571a53e5ab3dbd6ea1ec91a374ebd5f6ba9c0a99938d0649853588a5)
Upgraded:
  firefox 63.0.3-1.fc29.x86_64 -> 63.0.3-2.fc29.x86_64
    * Wed Nov 21 2018 Martin Stransky <stransky@redhat.com> - 63.0.3-2
    - Fixed mozbz#1507475 - crash when display changes (rhbz#1646151).

  httpd 2.4.37-3.fc29.x86_64 -> 2.4.37-5.fc29.x86_64
    * Fri Nov 23 2018 Lubos Uhliarik <luhliari@redhat.com> - 2.4.37-5
    - Resolves: #1652678 - TLS connection allowed while all protocols are forbidden

    * Thu Nov 08 2018 Joe Orton <jorton@redhat.com> - 2.4.37-4
    - add httpd.conf(5) (#1611361)
```