### PR TITLE
compose: Add a CUtf8Buf copy of rojig_name

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -46,7 +46,10 @@ pub struct Treefile {
     // This one isn't used today, but we may do more in the future.
     _workdir: openat::Dir,
     primary_dfd: openat::Dir,
+    #[allow(dead_code)] // Not used in tests
     parsed: TreeComposeConfig,
+    // This is a copy of rojig.name to avoid needing to convert to CStr when reading
+    rojig_name: Option<CUtf8Buf>,
     rojig_spec: Option<CUtf8Buf>,
     serialized: CUtf8Buf,
     externals: TreefileExternals,
@@ -340,16 +343,18 @@ impl Treefile {
         let parsed = treefile_parse_recurse(filename, arch, 0)?;
         Treefile::validate_config(&parsed.config)?;
         let dfd = openat::Dir::open(filename.parent().unwrap())?;
-        let rojig_spec = if let &Some(ref rojig) = &parsed.config.rojig {
-            Some(Treefile::write_rojig_spec(&workdir, rojig)?)
+        let (rojig_name, rojig_spec) = if let Some(rojig) = parsed.config.rojig.as_ref() {
+            (Some(Treefile::write_rojig_spec(&workdir, rojig)?),
+             Some(CUtf8Buf::from_string(rojig.name.clone())))
         } else {
-            None
+            (None, None)
         };
         let serialized = Treefile::serialize_json_string(&parsed.config)?;
         Ok(Box::new(Treefile {
             primary_dfd: dfd,
             parsed: parsed.config,
             _workdir: workdir,
+            rojig_name: rojig_name,
             rojig_spec: rojig_spec,
             serialized: serialized,
             externals: parsed.externals,
@@ -807,7 +812,6 @@ mod ffi {
     use glib_sys;
     use libc;
 
-    use std::ffi::CString;
     use std::io::Seek;
     use std::os::unix::io::{AsRawFd, RawFd};
     use std::{fs, io, ptr};
@@ -899,14 +903,10 @@ mod ffi {
     }
 
     #[no_mangle]
-    pub extern "C" fn ror_treefile_get_rojig_name(tf: *mut Treefile) -> *mut libc::c_char {
+    pub extern "C" fn ror_treefile_get_rojig_name(tf: *mut Treefile) -> *const libc::c_char {
         assert!(!tf.is_null());
         let tf = unsafe { &mut *tf };
-        if let &Some(ref rojig) = &tf.parsed.rojig {
-            CString::new(rojig.name.as_str()).unwrap().into_raw()
-        } else {
-            ptr::null_mut()
-        }
+        tf.rojig_name.as_ref().map(|v| v.as_ptr()).unwrap_or(ptr::null_mut())
     }
 
     #[no_mangle]

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -344,8 +344,10 @@ impl Treefile {
         Treefile::validate_config(&parsed.config)?;
         let dfd = openat::Dir::open(filename.parent().unwrap())?;
         let (rojig_name, rojig_spec) = if let Some(rojig) = parsed.config.rojig.as_ref() {
-            (Some(Treefile::write_rojig_spec(&workdir, rojig)?),
-             Some(CUtf8Buf::from_string(rojig.name.clone())))
+            (
+                Some(CUtf8Buf::from_string(rojig.name.clone())),
+                Some(Treefile::write_rojig_spec(&workdir, rojig)?),
+            )
         } else {
             (None, None)
         };
@@ -906,7 +908,10 @@ mod ffi {
     pub extern "C" fn ror_treefile_get_rojig_name(tf: *mut Treefile) -> *const libc::c_char {
         assert!(!tf.is_null());
         let tf = unsafe { &mut *tf };
-        tf.rojig_name.as_ref().map(|v| v.as_ptr()).unwrap_or(ptr::null_mut())
+        tf.rojig_name
+            .as_ref()
+            .map(|v| v.as_ptr())
+            .unwrap_or(ptr::null_mut())
     }
 
     #[no_mangle]

--- a/src/app/rpmostree-compose-builtin-rojig.c
+++ b/src/app/rpmostree-compose-builtin-rojig.c
@@ -325,7 +325,7 @@ impl_rojig_build (RpmOstreeRojigCompose *self,
       g_usleep (3 * G_USEC_PER_SEC);
     }
 
-  g_autofree char *rojig_name = ror_treefile_get_rojig_name (self->treefile_rs);
+  const char *rojig_name = ror_treefile_get_rojig_name (self->treefile_rs);
   if (!rojig_name)
     return glnx_throw (error, "No `rojig` entry in manifest");
   g_autoptr(GKeyFile) tsk = g_key_file_new ();


### PR DESCRIPTION
Avoids passing an allocated buffer from Rust to C; there's
controversy in the PR I sent to rust-lang around defining this as
supported.
