### PR TITLE
Add rpm-ostree-bootstatus.service

### DIFF
--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -78,6 +78,7 @@ dbusconfdir = ${sysconfdir}/dbus-1/system.d
 systemdunit_service_in_files = \
 	$(srcdir)/src/daemon/rpm-ostreed.service.in \
 	$(srcdir)/src/daemon/rpm-ostreed-automatic.service.in \
+	$(srcdir)/src/daemon/rpm-ostree-bootstatus.service.in \
 	$(NULL)
 
 systemdunit_service_files = $(systemdunit_service_in_files:.service.in=.service)

--- a/src/daemon/rpm-ostree-bootstatus.service.in
+++ b/src/daemon/rpm-ostree-bootstatus.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Log booted deployment status to journal
+Documentation=man:rpm-ostree(1)
+ConditionPathExists=/ostree
+
+[Service]
+Type=oneshot
+ExecStart=@bindir@/rpm-ostree status -b
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/src/daemon/rpm-ostree-bootstatus.service.in
+++ b/src/daemon/rpm-ostree-bootstatus.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Log RPM-OSTree booted deployment status to journal
+Description=Log RPM-OSTree Booted Deployment Status To Journal
 Documentation=man:rpm-ostree(1)
 ConditionPathExists=/run/ostree-booted
 

--- a/src/daemon/rpm-ostree-bootstatus.service.in
+++ b/src/daemon/rpm-ostree-bootstatus.service.in
@@ -1,7 +1,7 @@
 [Unit]
-Description=Log booted deployment status to journal
+Description=Log RPM-OSTree booted deployment status to journal
 Documentation=man:rpm-ostree(1)
-ConditionPathExists=/ostree
+ConditionPathExists=/run/ostree-booted
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Capturing the system state at boot aids debugging.  This is a
trivial implementation; we could in the future do structured
logging too.

The high level goal here is to help us track system state in
Red Hat CoreOS.
