### PR TITLE
Print CVEs fixed in available updates

### DIFF
--- a/src/daemon/rpmostreed-deployment-utils.c
+++ b/src/daemon/rpmostreed-deployment-utils.c
@@ -807,11 +807,35 @@ str2severity (const char *str)
   return RPM_OSTREE_ADVISORY_SEVERITY_NONE;
 }
 
+static int
+compare_advisory_refs (gconstpointer ap,
+                       gconstpointer bp)
+{
+  /* We use URLs to sort here; often CVE RHBZs will have multiple duplicates for each stream
+   * affected (e.g. Fedora, EPEL, RHEL, etc...), but we want the first one, which contains
+   * all the juicy details. A naive strcmp() sort on the URL gives us this. */
+  DnfAdvisoryRef *a = *((DnfAdvisoryRef**)ap);
+  DnfAdvisoryRef *b = *((DnfAdvisoryRef**)bp);
+  return strcmp (dnf_advisoryref_get_url (a), dnf_advisoryref_get_url (b));
+}
+
+#define CVE_REGEXP "CVE-[0-9]+-[0-9]+"
+
 /* Returns a *floating* variant ref representing the advisory */
 static GVariant*
 advisory_variant_new (DnfAdvisory *adv,
                       GPtrArray   *pkgs)
 {
+  static gsize cve_regex_initialized;
+  static GRegex *cve_regex;
+
+  if (g_once_init_enter (&cve_regex_initialized))
+    {
+      cve_regex = g_regex_new ("\\b" CVE_REGEXP "\\b", 0, 0, NULL);
+      g_assert (cve_regex);
+      g_once_init_leave (&cve_regex_initialized, 1);
+    }
+
   g_auto(GVariantBuilder) builder;
   g_variant_builder_init (&builder, G_VARIANT_TYPE_TUPLE);
   g_variant_builder_add (&builder, "s", dnf_advisory_get_id (adv));
@@ -825,8 +849,62 @@ advisory_variant_new (DnfAdvisory *adv,
     g_variant_builder_add_value (&builder, g_variant_builder_end (&pkgs_array));
   }
 
-  /* for now we don't ship any extra info about the errata (e.g. title, date, desc, refs) */
-  g_variant_builder_add_value (&builder, g_variant_new ("a{sv}", NULL));
+  /* final a{sv} for any additional metadata */
+  g_auto(GVariantDict) dict;
+  g_variant_dict_init (&dict, NULL);
+
+  { g_auto(GVariantBuilder) cve_references;
+    g_variant_builder_init (&cve_references, G_VARIANT_TYPE_ARRAY);
+
+    /* we maintain a set to make sure we only add the earliest ref for each CVE */
+    g_autoptr(GHashTable) created_cves =
+      g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+    g_autoptr(GPtrArray) refs = dnf_advisory_get_references (adv);
+    g_ptr_array_sort (refs, compare_advisory_refs);
+
+    /* for each ref, look for CVEs in their title, and add an (ss) for refs which mention
+     * new CVEs. */
+    for (guint i = 0; i < refs->len; i++)
+      {
+        DnfAdvisoryRef *ref = refs->pdata[i];
+        if (dnf_advisoryref_get_kind (ref) != DNF_REFERENCE_KIND_BUGZILLA)
+          continue;
+
+        g_autoptr(GMatchInfo) match = NULL;
+        const char *title = dnf_advisoryref_get_title (ref);
+        if (!g_regex_match (cve_regex, title, 0, &match))
+          continue;
+
+        /* collect all the found CVEs first */
+        g_autoptr(GPtrArray) found_cves = g_ptr_array_new_with_free_func (g_free);
+        while (g_match_info_matches (match))
+          {
+            g_ptr_array_add (found_cves, g_match_info_fetch (match, 0));
+            g_match_info_next (match, NULL);
+          }
+
+        gboolean has_new_cve = FALSE;
+        for (guint i = 0; i < found_cves->len && !has_new_cve; i++)
+          has_new_cve = !g_hash_table_contains (created_cves, found_cves->pdata[i]);
+
+        /* if a single CVE is new, make a GVariant for it */
+        if (has_new_cve)
+          {
+            const char *url = dnf_advisoryref_get_url (ref);
+            g_variant_builder_add (&cve_references, "(ss)", url, title);
+            /* steal all the cves and transfer to set, autofree'ing dupes */
+            g_ptr_array_add (found_cves, NULL);
+            g_autofree char **cves =
+              (char**)g_ptr_array_free (g_steal_pointer (&found_cves), FALSE);
+            for (char **cve = cves; cve && *cve; cve++)
+              g_hash_table_add (created_cves, *cve);
+          }
+      }
+    g_variant_dict_insert_value (&dict, "cve_references",
+                                 g_variant_builder_end (&cve_references));
+  }
+  g_variant_builder_add_value (&builder, g_variant_dict_end (&dict));
 
   return g_variant_builder_end (&builder);
 }
@@ -855,7 +933,10 @@ advisory_equal (gconstpointer v1,
         u     advisory kind (enum DnfAdvisoryKind)
         u     advisory severity (enum RpmOstreeAdvisorySeverity)
         as    list of packages (NEVRAs) contained in the advisory
-        a{sv} additional info about advisory (none so far)
+        a{sv} additional info about advisory
+          "cve_references" -> 'a(ss)'
+            s   title
+            s   URL
  */
 static GVariant*
 advisories_variant (DnfSack    *sack,

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -500,6 +500,10 @@ _init_updated_rpmmd_repo() {
     vm_build_rpm base-pkg-sec-none version 2.0 uinfo VMCHECK-SEC-NONE
     vm_build_rpm base-pkg-sec-low version 2.0 uinfo VMCHECK-SEC-LOW
     vm_build_rpm base-pkg-sec-crit version 2.0 uinfo VMCHECK-SEC-CRIT
+    vm_uinfo add-ref VMCHECK-SEC-LOW 1 http://example.com/vuln1 "CVE-12-34 vuln1"
+    vm_uinfo add-ref VMCHECK-SEC-LOW 2 http://example.com/vuln2 "CVE-12-34 vuln2"
+    vm_uinfo add-ref VMCHECK-SEC-LOW 3 http://example.com/vuln3 "CVE-56-78 CVE-90-12 vuln3"
+    vm_uinfo add-ref VMCHECK-SEC-LOW 4 http://example.com/vuln4 "CVE-12-JUNK CVE-JUNK vuln4"
 }
 
 # Start up a remote, and create two new commits (v1 and v2) which contain new

--- a/tests/utils/updateinfo
+++ b/tests/utils/updateinfo
@@ -80,6 +80,18 @@ def parse_args():
     delete_pkg.add_argument('id')
     delete_pkg.add_argument('name_or_nevra')
 
+    add_ref = subparsers.add_parser('add-ref')
+    add_ref.set_defaults(func=cmd_add_ref)
+    add_ref.add_argument('id')
+    add_ref.add_argument('refid')
+    add_ref.add_argument('url')
+    add_ref.add_argument('title')
+
+    delete_ref = subparsers.add_parser('delete-ref')
+    delete_ref.set_defaults(func=cmd_delete_ref)
+    delete_ref.add_argument('id')
+    delete_ref.add_argument('refid')
+
     return parser.parse_args()
 
 
@@ -196,6 +208,19 @@ def cmd_delete_pkg(args):
     set_updateinfo(args.repo, uinfo)
 
 
+def cmd_add_ref(args):
+    uinfo = get_updateinfo(args.repo)
+    uinfo = add_ref_to_update(uinfo, args.id,
+                              (args.refid, args.url, args.title))
+    set_updateinfo(args.repo, uinfo)
+
+
+def cmd_delete_ref(args):
+    uinfo = get_updateinfo(args.repo)
+    uinfo = delete_ref_from_update(uinfo, args.id, args.refid)
+    set_updateinfo(args.repo, uinfo)
+
+
 def get_updateinfo(repo):
     '''
         Parse existing repo updateinfo.xml or create a new one.
@@ -270,13 +295,15 @@ def show_updates(uinfo, uid):
         print update.id, update.type, update.severity
         for col in update.collections:
             for pkg in col.packages:
-                print "  ", pkg.filename
+                print "  pkg:", pkg.filename
+        for ref in update.references:
+            print "  ref:", ref.id, ref.href
 
 
 def shallow_clone_update(update):
-    # the default copy() also copies collections, and then there's no API to
-    # *remove* from those lists, so instead we re-create from scratch each time
-    # we need to modify them
+    # the default copy() also copies collections and refs, and then there's no
+    # API to *remove* from those lists, so instead we re-create from scratch
+    # each time we need to modify them
     new_update = cr.UpdateRecord()
     new_update.id = update.id
     new_update.type = update.type
@@ -316,6 +343,10 @@ def add_pkg_to_update_cb(uid, update, nevra):
 
     new_update.append_collection(new_col)
 
+    # and copy over the references
+    for ref in update.references:
+        new_update.append_reference(ref)
+
     return new_update
 
 
@@ -351,11 +382,64 @@ def delete_pkg_from_update_cb(uid, update, name_or_nevra):
     if len(new_col.packages) > 0:
         new_update.append_collection(new_col)
 
+    # and copy over the references
+    for ref in update.references:
+        new_update.append_reference(ref)
+
     return new_update
 
 
 def delete_pkg_from_update(uinfo, uid, name_or_nevra):
     return modify_update(uinfo, uid, delete_pkg_from_update_cb, name_or_nevra)
+
+
+def add_ref_to_update_cb(uid, update, ref_tuple):
+    new_update = shallow_clone_update(update)
+    new_ref = cr.UpdateReference()
+    new_ref.type = "bugzilla"
+    (new_ref.id, new_ref.href, new_ref.title) = ref_tuple
+    new_update.append_reference(new_ref)
+
+    for ref in update.references:
+        if ref.id == new_ref.id:
+            raise Exception("Update '%s' already contains ref '%s'" %
+                            (uid, ref.id))
+        new_update.append_reference(ref)
+
+    # and copy over the collections
+    for col in update.collections:
+        new_update.append_collection(col)
+
+    return new_update
+
+
+def add_ref_to_update(uinfo, uid, ref_tuple):
+    return modify_update(uinfo, uid, add_ref_to_update_cb, ref_tuple)
+
+
+def delete_ref_from_update_cb(uid, update, refid):
+    new_update = shallow_clone_update(update)
+
+    found = False
+    for ref in update.references:
+        if ref.id == refid:
+            found = True
+        else:
+            new_update.append_reference(ref)
+
+    if not found:
+        raise Exception("Update '%s' does not have ref '%s'" %
+                        (uid, refid))
+
+    # and copy over the collections
+    for col in update.collections:
+        new_update.append_collection(col)
+
+    return new_update
+
+
+def delete_ref_from_update(uinfo, uid, refid):
+    return modify_update(uinfo, uid, delete_ref_from_update_cb, refid)
 
 
 def new_updateinfo_record(repo, uinfo):

--- a/tests/utils/updateinfo
+++ b/tests/utils/updateinfo
@@ -157,6 +157,7 @@ def nevra_from_primary(repo, name):
     repomd = cr.Repomd(repomd_xml(repo))
 
     pkgs = []
+
     def pkgcb(pkg):
         if pkg.name == name:
             pkgs.append(pkg)
@@ -176,7 +177,7 @@ def nevra_from_primary(repo, name):
 
 def cmd_add_pkg(args):
     uinfo = get_updateinfo(args.repo)
-    if args.epoch is None: # user only passed the 'name' param
+    if args.epoch is None:  # user only passed the 'name' param
         # we support passing an RPM file from which to extract fields
         if os.path.isfile(args.name):
             nevra = nevra_from_rpm(args.name)
@@ -218,8 +219,10 @@ def sev2xml(sev):
 class UpdateExistsError(Exception):
     pass
 
+
 class UpdateNotExistsError(Exception):
     pass
+
 
 def add_update(uinfo, uid, utype, severity):
 

--- a/tests/utils/updateinfo
+++ b/tests/utils/updateinfo
@@ -273,8 +273,10 @@ def show_updates(uinfo, uid):
                 print "  ", pkg.filename
 
 
-def copy_update_no_cols(update):
-    # the default copy() also copies collections
+def shallow_clone_update(update):
+    # the default copy() also copies collections, and then there's no API to
+    # *remove* from those lists, so instead we re-create from scratch each time
+    # we need to modify them
     new_update = cr.UpdateRecord()
     new_update.id = update.id
     new_update.type = update.type
@@ -292,7 +294,7 @@ def add_pkg_to_update_cb(uid, update, nevra):
     else:
         col = cr.UpdateCollection()
 
-    new_update = copy_update_no_cols(update)
+    new_update = shallow_clone_update(update)
     new_col = cr.UpdateCollection()
 
     for pkg in col.packages:
@@ -331,7 +333,7 @@ def delete_pkg_from_update_cb(uid, update, name_or_nevra):
     else:
         col = cr.UpdateCollection()
 
-    new_update = copy_update_no_cols(update)
+    new_update = shallow_clone_update(update)
     new_col = cr.UpdateCollection()
 
     found = False

--- a/tests/vmcheck/test-autoupdate-check.sh
+++ b/tests/vmcheck/test-autoupdate-check.sh
@@ -141,9 +141,15 @@ assert_output() {
   assert_file_has_content out-verbose.txt \
     "SecAdvisories: VMCHECK-SEC-NONE  Unknown    layered-sec-none-2.0-1.x86_64" \
     "               VMCHECK-SEC-LOW   Low        layered-sec-low-2.0-1.x86_64" \
-    "               VMCHECK-SEC-CRIT  Critical   layered-sec-crit-2.0-1.x86_64"
+    "               VMCHECK-SEC-CRIT  Critical   layered-sec-crit-2.0-1.x86_64" \
+    "CVE-43-21 vuln5" \
+    "http://example.com/vuln5" \
+    "CVE-87-65 CVE-21-09 vuln7" \
+    "http://example.com/vuln7"
 
-  assert_not_file_has_content out-verbose.txt "layered-constant 1.0-1 -> 1.0-1"
+  assert_not_file_has_content out-verbose.txt \
+    "layered-constant 1.0-1 -> 1.0-1" \
+    "vuln6" "JUNK" "vuln8"
 
   # make sure any future call doesn't forget to create fresh ones
   rm -f out.txt out-verbose.txt
@@ -152,6 +158,10 @@ assert_output() {
 # now add all of them
 vm_build_rpm layered-sec-low version 2.0 uinfo VMCHECK-SEC-LOW
 vm_build_rpm layered-sec-crit version 2.0 uinfo VMCHECK-SEC-CRIT
+vm_uinfo add-ref VMCHECK-SEC-CRIT 5 http://example.com/vuln5 "CVE-43-21 vuln5"
+vm_uinfo add-ref VMCHECK-SEC-CRIT 6 http://example.com/vuln6 "CVE-43-21 vuln6"
+vm_uinfo add-ref VMCHECK-SEC-CRIT 7 http://example.com/vuln7 "CVE-87-65 CVE-21-09 vuln7"
+vm_uinfo add-ref VMCHECK-SEC-CRIT 8 http://example.com/vuln8 "CVE-12-JUNK CVE-JUNK vuln8"
 vm_rpmostree upgrade --trigger-automatic-update-policy
 vm_rpmostree status > out.txt
 vm_rpmostree status -v > out-verbose.txt
@@ -202,16 +212,27 @@ assert_output2() {
     "VMCHECK-SEC-NONE  Unknown    base-pkg-sec-none-2.0-1.x86_64" \
     "VMCHECK-SEC-NONE  Unknown    layered-sec-none-2.0-1.x86_64" \
     "VMCHECK-SEC-LOW   Low        base-pkg-sec-low-2.0-1.x86_64" \
+    "CVE-12-34 vuln1" \
+    "http://example.com/vuln1" \
+    "CVE-56-78 CVE-90-12 vuln3" \
+    "http://example.com/vuln3" \
     "VMCHECK-SEC-LOW   Low        layered-sec-low-2.0-1.x86_64" \
     "VMCHECK-SEC-CRIT  Critical   base-pkg-sec-crit-2.0-1.x86_64" \
     "VMCHECK-SEC-CRIT  Critical   layered-sec-crit-2.0-1.x86_64" \
+    "CVE-43-21 vuln5" \
+    "http://example.com/vuln5" \
+    "CVE-87-65 CVE-21-09 vuln7" \
+    "http://example.com/vuln7" \
     'Upgraded: base-pkg-enh 1.0-1 -> 2.0-1' \
     '          base-pkg-foo 1.4-7 -> 1.4-8' \
     'Downgraded: base-pkg-bar 1.0-1 -> 0.9-3' \
     'Removed: base-pkg-baz-1.1-1.x86_64' \
     'Added: base-pkg-boo-3.7-2.11.x86_64'
 
-  assert_not_file_has_content out-verbose.txt "layered-constant 1.0-1 -> 1.0-1"
+  assert_not_file_has_content out-verbose.txt \
+    "layered-constant 1.0-1 -> 1.0-1" \
+    "vuln2" "JUNK" "vuln4" \
+    "vuln6" "JUNK" "vuln8" \
 
   # make sure any future call doesn't forget to create fresh ones
   rm -f out.txt out-verbose.txt


### PR DESCRIPTION
One question I often have when looking at the output of `status -a`:

```
AvailableUpdate:
        Version: 29.20181202.0 (2018-12-02T08:37:50Z)
         Commit: dece5737a087d5c6038efdb86cb4512f867082ccfc6eb0fa97b2734c1f6d99c3
   GPGSignature: Valid signature by 5A03B4DD8254ECA02FDA1637A20AA56B429476B4
  SecAdvisories: FEDORA-2018-042156f164  Unknown    net-snmp-libs-1:5.8-3.fc29.x86_64
                 FEDORA-2018-87ba0312c2  Moderate   kernel-4.19.5-300.fc29.x86_64
                 FEDORA-2018-87ba0312c2  Moderate   kernel-core-4.19.5-300.fc29.x86_64
                 FEDORA-2018-87ba0312c2  Moderate   kernel-modules-4.19.5-300.fc29.x86_64
                 FEDORA-2018-87ba0312c2  Moderate   kernel-modules-extra-4.19.5-300.fc29.x86_64
                 FEDORA-2018-f467c36c2b  Moderate   git-core-2.19.2-1.fc29.x86_64
           Diff: 67 upgraded, 1 removed, 16 added
```

is "How serious and relevant are these advisories to me? How soon should
I reboot?". For the packages that I'm most familiar with, e.g. `kernel`
and `git-core`, I usually look up the advisory and check why it was
marked as a security update, mentioned CVEs, and how those affect me.

The updateinfo metadata includes a wealth of information that could be
useful here. In Fedora, CVEs treated by the security response team
result in RHBZs, which end up attached to the advisories and thus make
it into that metadata.

This patch tries to reduce friction in answering some of those questions
above by checking for those CVEs and printing a short description in the
output of `status -a`. Example:

```
AvailableUpdate:
        Version: 29.20181202.0 (2018-12-02T08:37:50Z)
         Commit: dece5737a087d5c6038efdb86cb4512f867082ccfc6eb0fa97b2734c1f6d99c3
   GPGSignature: Valid signature by 5A03B4DD8254ECA02FDA1637A20AA56B429476B4
  SecAdvisories: FEDORA-2018-042156f164  Unknown    net-snmp-libs-1:5.8-3.fc29.x86_64
                   CVE-2018-18065 CVE-2018-18066 net-snmp: various flaws [fedora-all]
                   https://bugzilla.redhat.com/show_bug.cgi?id=1637573
                 FEDORA-2018-87ba0312c2  Moderate   kernel-4.19.5-300.fc29.x86_64
                 FEDORA-2018-87ba0312c2  Moderate   kernel-core-4.19.5-300.fc29.x86_64
                 FEDORA-2018-87ba0312c2  Moderate   kernel-modules-4.19.5-300.fc29.x86_64
                 FEDORA-2018-87ba0312c2  Moderate   kernel-modules-extra-4.19.5-300.fc29.x86_64
                   CVE-2018-16862 kernel: cleancache: Infoleak of deleted files after reuse of old inodes
                   https://bugzilla.redhat.com/show_bug.cgi?id=1649017
                   CVE-2018-19407 kernel: kvm: NULL pointer dereference in vcpu_scan_ioapic in arch/x86/kvm/x86.c
                   https://bugzilla.redhat.com/show_bug.cgi?id=1652656
                 FEDORA-2018-f467c36c2b  Moderate   git-core-2.19.2-1.fc29.x86_64
                   CVE-2018-19486 git: Improper handling of PATH allows for commands to executed from current directory
                   https://bugzilla.redhat.com/show_bug.cgi?id=1653143
           Diff: 67 upgraded, 1 removed, 16 added
```

Including the CVE name and RHBZ link also makes it easier to look for
more details if desired.