### PR TITLE
compose: Fix EBADF in unified core mode without cachedir

### DIFF
--- a/tests/compose-tests/test-basic-unified.sh
+++ b/tests/compose-tests/test-basic-unified.sh
@@ -26,6 +26,11 @@ cat > metadata.json <<EOF
 EOF
 runcompose --ex-unified-core --add-metadata-from-json metadata.json
 
+# Run it again, but without RPMOSTREE_PRESERVE_TMPDIR. Should be a no-op. This
+# exercises fd handling in the tree context.
+rpm-ostree compose tree ${compose_base_argv} ${treefile} "$@"
+echo "ok no cachedir"
+
 . ${dn}/libbasic-test.sh
 basic_test
 


### PR DESCRIPTION
If no cache dir is given in the workdir, we would alias the cache dir fd
to the workdir fd. But of course, this meant that we'd try to close the
same fd twice when freeing the compose context. Instead, let's just copy
the fd as is also done in the non-unified path.

Closes: #1697