### PR TITLE
daemon: Drop unused mutex

### DIFF
--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -73,13 +73,6 @@ struct _RpmostreedSysroot {
   GHashTable *os_interfaces;
   GHashTable *osexperimental_interfaces;
 
-  /* The OS interface's various diff methods can run concurrently with
-   * transactions, which is safe except when the transaction is writing
-   * new deployments to disk or downloading RPM package details.  The
-   * writer lock protects these critical sections so the diff methods
-   * (holding reader locks) can run safely. */
-  GRWLock method_rw_lock;
-
   GFileMonitor *monitor;
   guint sig_changed;
 };


### PR DESCRIPTION
Was reading the code while looking at
https://github.com/projectatomic/rpm-ostree/issues/1692
and blinked at the comment, then noticed it hasn't been used
since:  3e289ffab0f18af4a59fb084dd2d4e39b79fdc7a
