### PR TITLE
rust/treefile: Add container key

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -540,6 +540,8 @@ struct TreeComposeConfig {
 
     // Content installation opts
     #[serde(skip_serializing_if = "Option::is_none")]
+    container: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     recommends: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     documentation: Option<bool>,


### PR DESCRIPTION
This was omitted since in practice we aren't actually testing it,
the container path is mostly via `ex container` which uses keyfiles.

Closes: #1701
