### PR TITLE
core: Don't try to update libdnf _TYPE_MEDIA repos

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1107,8 +1107,14 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
           g_auto(RpmOstreeProgress) progress = { 0, };
           rpmostree_output_progress_percent_begin (&progress, "Updating metadata for '%s'",
                                                    dnf_repo_get_id (repo));
-          if (!dnf_repo_update (repo, DNF_REPO_UPDATE_FLAG_FORCE, hifstate, error))
-            return FALSE;
+          /* https://discussion.fedoraproject.org/t/rpm-ostree-giving-error/772/2
+           * This would be better fixed in libdnf but that blocks on the rebase
+           */
+          if (dnf_repo_get_kind (repo) != DNF_REPO_KIND_MEDIA)
+            {
+              if (!dnf_repo_update (repo, DNF_REPO_UPDATE_FLAG_FORCE, hifstate, error))
+                return FALSE;
+            }
 
           did_update = TRUE;
 


### PR DESCRIPTION
Ref: https://discussion.fedoraproject.org/t/rpm-ostree-giving-error/772/2
Currently plugging in a live USB will auto-create a `media` repo
and then cause rpm-ostree to error out.

I think we should really change libdnf to silently do nothing for
this rather than error out, but that blocks on the rebase.
