### PR TITLE
compose: Don't require full previous commit

### DIFF
--- a/src/app/rpmostree-compose-builtin-rojig.c
+++ b/src/app/rpmostree-compose-builtin-rojig.c
@@ -199,7 +199,7 @@ install_packages (RpmOstreeRojigCompose  *self,
   if (opt_download_only)
     return TRUE; /* 🔚 Early return */
 
-  if (!rpmostree_passwd_compose_prep (self->rootfs_dfd, TRUE, self->treefile_rs,
+  if (!rpmostree_passwd_compose_prep (self->rootfs_dfd, NULL, TRUE, self->treefile_rs,
                                       self->treefile, NULL, cancellable, error))
     return FALSE;
 

--- a/src/libpriv/rpmostree-passwd-util.h
+++ b/src/libpriv/rpmostree-passwd-util.h
@@ -58,10 +58,11 @@ rpmostree_passwd_migrate_except_root (int            rootfs_dfd,
 
 gboolean
 rpmostree_passwd_compose_prep (int              rootfs_dfd,
+                               OstreeRepo      *repo,
                                gboolean         unified_core,
                                RORTreefile     *treefile_rs,
                                JsonObject      *treedata,
-                               GFile           *previous_root,
+                               const char      *previous_checksum,
                                GCancellable    *cancellable,
                                GError         **error);
 


### PR DESCRIPTION
Right now, if we want to commit onto the same ref, we require the full
previous commit. The previous commit full root is currently used as
follow:

- for handling `check-passwd` in the `previous` case
- as an optimization for SELinux policy matching (#1659)

Let's change the logic so that we gracefully handle partial commits.
This patch lowers full commit root loading in the one function that
really needs it (`rpmostree_passwd_compose_prep()`). We also turn off
the SELinux optimization if the commit is partial.

My goal here is to use this in coreos-assembler to seed the repo just
enough to keep the commit history intact. (Though we do have cache so
that we can still profit from the SELinux optimization if it's
populated).