### PR TITLE
daemon/deploy: Fix free() of override replace pkgs

### DIFF
--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -588,13 +588,13 @@ typedef struct {
   GVariantDict *modifiers;
   char   *refspec; /* NULL for non-rebases */
   const char   *revision; /* NULL for upgrade; owned by @options */
-  char  **install_pkgs; /* single malloc block pointing into GVariant, not strv; same for other *_pkgs */
+  char  **install_pkgs; /* strv but strings owned by modifiers */
   GUnixFDList *install_local_pkgs;
-  char  **uninstall_pkgs;
-  char  **override_replace_pkgs;
+  char  **uninstall_pkgs; /* strv but strings owned by modifiers */
+  char  **override_replace_pkgs; /* strv but strings owned by modifiers */
   GUnixFDList *override_replace_local_pkgs;
-  char  **override_remove_pkgs;
-  char  **override_reset_pkgs;
+  char  **override_remove_pkgs; /* strv but strings owned by modifiers */
+  char  **override_reset_pkgs; /* strv but strings owned by modifiers */
 } DeployTransaction;
 
 typedef RpmostreedTransactionClass DeployTransactionClass;
@@ -619,7 +619,7 @@ deploy_transaction_finalize (GObject *object)
   g_free (self->install_pkgs);
   g_clear_pointer (&self->install_local_pkgs, g_object_unref);
   g_free (self->uninstall_pkgs);
-  g_strfreev (self->override_replace_pkgs);
+  g_free (self->override_replace_pkgs);
   g_clear_pointer (&self->override_replace_local_pkgs, g_object_unref);
   g_free (self->override_remove_pkgs);
   g_free (self->override_reset_pkgs);

--- a/tests/vmcheck/test-override-replace-2.sh
+++ b/tests/vmcheck/test-override-replace-2.sh
@@ -24,6 +24,13 @@ set -euo pipefail
 
 set -x
 
+# check that we error out right now if not providing an RPM
+if vm_rpmostree override replace foo bar baz |& tee out.txt; then
+  assert_not_reached "Able to replace RPMs from repos?"
+fi
+assert_file_has_content out.txt "Non-local replacement overrides not implemented yet"
+echo "ok error on non-local replacements"
+
 YUMREPO=/var/tmp/vmcheck/yumrepo/packages/x86_64
 
 vm_assert_status_jq \


### PR DESCRIPTION
We were using `g_strfreev()` to free the string array, but the strings
themselves were owned by the `modifiers` GVariantDict. Fix this and make
the comments about it more explicit. On my computer (and at least
Dusty's), this was only actually tripping up libc when passing more than
just one package on the CLI.

Closes: #1707