### PR TITLE
packaging: Don't include checksums for ltmain.sh

### DIFF
--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -57,6 +57,16 @@ j = json.load(open(checksum_file))
 j["files"] = {f:c for f, c in j["files"].items() if not f.startswith(subdir)}
 open(checksum_file, "w").write(json.dumps(j))' $crate_subdir
  done
+ # Also drop ltmain.sh and config.guess checksums since they get mangled by
+ # %configure.
+ for crate in backtrace-sys; do
+   python -c '
+import json, sys, os
+checksum_file = ("vendor/%s/.cargo-checksum.json" % sys.argv[1])
+j = json.load(open(checksum_file))
+j["files"] = {f:c for f, c in j["files"].items() if os.path.basename(f) not in ["ltmain.sh", "config.guess", "config.sub"]}
+open(checksum_file, "w").write(json.dumps(j))' $crate
+ done
  tar --transform="s,^,${PKG_VER}/rust/," -rf ${TARFILE_TMP} * .cargo/
  )
 


### PR DESCRIPTION
And `config.guess` and `config.sub`. These files get mangled by the
`%configure` macro when it tries to insert hardening compile flags and
so the checksums no longer match. This is an ugly hack akin to #1554
that requires an incision in the cargo vendor JSON.

Fedora does package a lot of these crate sources now which we
could use to drop these hacks, but not all the crates are packaged (I
counted 4 unpackaged top-level crates), and I'm not sure what their
states are in RHEL7/8 either.