### PR TITLE
compose: Use dracut tmpdir under target root

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -179,7 +179,7 @@ container:
 
 env:
   # this corresponds to the DTS rustc version we want to support
-  RUST_MIN_VERSION: 1.26.2
+  RUST_MIN_VERSION: 1.29.2
 
 tests:
   - ci/installdeps.sh

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,9 +20,6 @@ c_utf8 = "0.1.0"
 systemd = "0.4.0"
 indicatif = "0.9.0"
 lazy_static = "1.1.0"
-# Drop this once we bump our minimum rustc requirement.
-# https://github.com/alexcrichton/backtrace-rs/pull/137
-backtrace = "=0.3.9"
 
 [lib]
 name = "rpmostree_rust"

--- a/src/libpriv/rpmostree-kernel.c
+++ b/src/libpriv/rpmostree-kernel.c
@@ -457,7 +457,7 @@ rpmostree_run_dracut (int     rootfs_dfd,
     "#!/usr/bin/bash\n"
     "set -euo pipefail\n"
     "extra_argv=; if (dracut --help; true) | grep -q -e --reproducible; then extra_argv=\"--reproducible --gzip\"; fi\n"
-    "dracut $extra_argv -v --add ostree --tmpdir=/tmp -f /tmp/initramfs.img \"$@\"\n"
+    "mkdir -p /tmp/dracut && dracut $extra_argv -v --add ostree --tmpdir=/tmp/dracut -f /tmp/initramfs.img \"$@\"\n"
     "cat /tmp/initramfs.img >/proc/self/fd/3\n";
   g_autoptr(RpmOstreeBwrap) bwrap = NULL;
   g_autoptr(GPtrArray) rebuild_argv = NULL;
@@ -542,9 +542,6 @@ rpmostree_run_dracut (int     rootfs_dfd,
 
   if (kver)
     rpmostree_bwrap_append_child_argv (bwrap, "--kver", kver, NULL);
-
-  if (dracut_host_tmpdir)
-    rpmostree_bwrap_append_child_argv (bwrap, "--tmpdir", "/tmp/dracut", NULL);
 
   rpmostree_bwrap_set_child_setup (bwrap, dracut_child_setup, GINT_TO_POINTER (tmpf.fd));
 

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -426,7 +426,7 @@ process_kernel_and_initramfs (int            rootfs_dfd,
    * xattrs, including e.g. user.ostreemeta, which can't be copied to tmpfs.
    */
   { g_auto(GLnxTmpDir) dracut_host_tmpd = { 0, };
-    if (!glnx_mkdtempat (rootfs_dfd, "tmp/rpmostree-dracut.XXXXXX", 0700,
+    if (!glnx_mkdtempat (rootfs_dfd, "rpmostree-dracut.XXXXXX", 0700,
                          &dracut_host_tmpd, error))
       return FALSE;
     if (!rpmostree_run_dracut (rootfs_dfd,

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -422,8 +422,11 @@ process_kernel_and_initramfs (int            rootfs_dfd,
   g_ptr_array_add (dracut_argv, NULL);
 
   g_auto(GLnxTmpfile) initramfs_tmpf = { 0, };
+  /* We use a tmpdir under the target root since dracut currently tries to copy
+   * xattrs, including e.g. user.ostreemeta, which can't be copied to tmpfs.
+   */
   { g_auto(GLnxTmpDir) dracut_host_tmpd = { 0, };
-    if (!glnx_mkdtempat (AT_FDCWD, "/var/tmp/rpmostree-dracut.XXXXXX", 0700,
+    if (!glnx_mkdtempat (rootfs_dfd, "tmp/rpmostree-dracut.XXXXXX", 0700,
                          &dracut_host_tmpd, error))
       return FALSE;
     if (!rpmostree_run_dracut (rootfs_dfd,


### PR DESCRIPTION
The problem here is that bare-user has `user.ostreemeta` xattrs,
`tmpfs` (which bwrap uses for `/var/tmp` by default) doesn't support that.

Pass through the tmpdir to the target rootfs, which is the same place
as the repo in unified-core mode.

Ref: https://github.com/coreos/coreos-assembler/issues/254
