### PR TITLE
libpriv/util: Add date field in auto-versioning

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -148,8 +148,24 @@ It supports the following parameters:
    ".1". Otherwise we parse the number after the prefix and increment it by one
    and then append that to the prefix.
 
-   This means that on an empty branch with an automatic_version_prefix of "22"
-   the first three commits would get the versions: "22", "22.1", "22.2"
+   A current date/time may also be passed through `automatic_version_prefix`,
+   by including a date tag in the prefix as such: `<date:format>`, where
+   `format` is a string with date formats such as `%Y` (year), `%m` (month), etc.
+   The full list of supported formats is [found in the GLib API](https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format).
+   Including a date/time format will automatically append a `.0` to
+   the version, if not present in the prefix, which resets to `.0` if
+   the date (or prefix) changes.
+
+   This means that on an empty branch with an `automatic_version_prefix`
+   of `"22"` the first three commits would get the versions: "22", "22.1",
+   "22.2". Some example progressions are shown:
+
+   | `automatic_version_prefix` | version progression                        |
+   | -------------------------- | ------------------------------------------ |
+   | `22`                       | 22, 22.1, 22.2, ...                        |
+   | `22.1`                     | 22.1.1, 22.1.2, 22.1.3, ...                |
+   | `22.<date:%Y>`             | 22.2019.0, 22.2019.1, 22.2020.0, ...       |
+   | `22.<date:%Y>.1`           | 22.2019.1.0, 22.2019.1.1, 22.2020.1.0, ... |
 
    Example: `automatic_version_prefix: "22.0"`
 

--- a/src/app/rpmostree-compose-builtin-rojig.c
+++ b/src/app/rpmostree-compose-builtin-rojig.c
@@ -398,7 +398,9 @@ impl_rojig_build (RpmOstreeRojigCompose *self,
       if (!ver_prefix)
         return FALSE;
 
-      next_version = _rpmostree_util_next_version (ver_prefix, self->previous_version);
+      next_version = _rpmostree_util_next_version (ver_prefix, self->previous_version, error);
+      if (!next_version)
+        return FALSE;
       g_hash_table_insert (self->metadata, g_strdup (OSTREE_COMMIT_META_KEY_VERSION),
                            g_variant_ref_sink (g_variant_new_string (next_version)));
     }

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -791,7 +791,9 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
           (void)g_variant_lookup (previous_metadata, OSTREE_COMMIT_META_KEY_VERSION, "s", &last_version);
         }
 
-      next_version = _rpmostree_util_next_version (ver_prefix, last_version);
+      next_version = _rpmostree_util_next_version (ver_prefix, last_version, error);
+      if (!next_version)
+        return FALSE;
       g_hash_table_insert (self->metadata, g_strdup (OSTREE_COMMIT_META_KEY_VERSION),
                            g_variant_ref_sink (g_variant_new_string (next_version)));
     }

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -78,8 +78,9 @@ char*
 rpmostree_translate_path_for_ostree (const char *path);
 
 char *
-_rpmostree_util_next_version (const char *auto_version_prefix,
-                              const char *last_version);
+_rpmostree_util_next_version (const char   *auto_version_prefix,
+                              const char   *last_version,
+                              GError      **error);
 
 char *
 rpmostree_str_replace (const char  *buf,

--- a/tests/check/jsonutil.c
+++ b/tests/check/jsonutil.c
@@ -53,13 +53,20 @@ static void
 test_auto_version (void)
 {
   char *version = NULL;
+  char *final_version = NULL;
+  g_autoptr(GDateTime) date_time_utc = g_date_time_new_now_utc ();
+  char *prev_version = NULL;
+  g_autoptr(GError) local_error = NULL;
+  GError **error = &local_error;
 
 #define _VER_TST(x, y, z)                              \
-  version = _rpmostree_util_next_version ((x), (y));   \
-  g_assert_cmpstr (version, ==, z);                    \
-  g_free (version);                                    \
+  g_clear_error (error);                               \
+  version = _rpmostree_util_next_version ((x), (y), error);   \
+  g_assert_cmpstr (version, ==, z);                           \
+  g_free (version);                                           \
   version = NULL
 
+  _VER_TST("10",  NULL,    "10");
   _VER_TST("10",  "",      "10");
   _VER_TST("10",  "xyz",   "10");
   _VER_TST("10",  "9",     "10");
@@ -87,6 +94,73 @@ test_auto_version (void)
   _VER_TST("10.1", "10.1x", "10.1");
   _VER_TST("10.1", "10.1.x", "10.1.1");
   _VER_TST("10.1", "10.1.2x", "10.1.3");
+
+  /* Like _VER_TST, but renders datetime specifiers in
+   * date_fmt with the current time. The rendered string
+   * is then compared against the result of _rpmostree_util_next_version(). */
+  #define _VER_DATE_TST(pre, last, final_datefmt)   \
+    g_clear_error (error);                          \
+    final_version = g_date_time_format (date_time_utc, (final_datefmt));   \
+    version = _rpmostree_util_next_version ((pre), (last), error);   \
+    g_assert_cmpstr (version, ==, final_version);                    \
+    g_free (final_version);                                          \
+    g_free (version);                                                \
+    version = NULL;                                                  \
+    final_version = NULL
+
+  /* Test date updates. */
+  _VER_DATE_TST("10.<date:%Y%m%d>", "10.20001010", "10.%Y%m%d.0");
+
+  /* Test increment reset when date changed. */
+  _VER_DATE_TST("10.<date:%Y%m%d>", "10.20001010.5", "10.%Y%m%d.0");
+
+  /* Test increment up when same date. */
+  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d.1");
+  _VER_DATE_TST("10.<date:%Y%m%d>", prev_version, "10.%Y%m%d.2");
+  g_free (prev_version);
+
+  /* Test append version number. */
+  _VER_DATE_TST("10.<date:%Y%m%d>", NULL, "10.%Y%m%d.0");
+  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d");
+  _VER_DATE_TST("10.<date:%Y%m%d>.0", prev_version, "10.%Y%m%d.0.0");
+  g_free (prev_version);
+  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d.0");
+  _VER_DATE_TST("10.<date:%Y%m%d>.0", prev_version, "10.%Y%m%d.0.0");
+  g_free (prev_version);
+  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d.x");
+  _VER_DATE_TST("10.<date:%Y%m%d>", prev_version, "10.%Y%m%d.1");
+  g_free (prev_version);
+  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d.2.x");
+  _VER_DATE_TST("10.<date:%Y%m%d>.2", prev_version, "10.%Y%m%d.2.1");
+  g_free (prev_version);
+  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d.1.2x");
+  _VER_DATE_TST("10.<date:%Y%m%d>.1", prev_version, "10.%Y%m%d.1.3");
+  g_free (prev_version);
+
+  /* Test variations to the formatting. */
+  _VER_DATE_TST("10.<date: %Y%m%d>",          "10.20001010",    "10. %Y%m%d.0");
+  _VER_DATE_TST("10.<date:%Y%m%d>.",          "10.20001010.",   "10.%Y%m%d..0");
+  _VER_DATE_TST("10.<date:%Y%m%d>abc",        "10.20001010abc", "10.%Y%m%dabc.0");
+  _VER_DATE_TST("10.<date:%Y%m%d >",          "10.20001010",    "10.%Y%m%d .0");
+  _VER_DATE_TST("10.<date:text%Y%m%dhere>",   "10.20001010",    "10.text%Y%m%dhere.0");
+  _VER_DATE_TST("10.<date:text %Y%m%d here>", "10.20001010",    "10.text %Y%m%d here.0");
+  _VER_DATE_TST("10.<date:%Y%m%d here>",      "10.20001010",    "10.%Y%m%d here.0");
+
+  /* Test equal last version and prefix. */
+  prev_version = g_date_time_format (date_time_utc, "10.%Y%m%d");
+  _VER_DATE_TST("10.<date:%Y%m%d>", prev_version, "10.%Y%m%d.0");
+  g_free (prev_version);
+
+  /* Test different prefix from last version. */
+  _VER_DATE_TST("10.<date:%Y%m%d>", "10", "10.%Y%m%d.0");
+
+  /* Test no field given. */
+  _VER_TST("10.<date: >",     "10.20001010", "10. .0");
+  _VER_TST("10.<date:>",      "10.20001010", "10..0");
+  _VER_TST("10.<wrongtag: >", "10.20001010", "10.<wrongtag: >");
+
+  /* Test invalid datetime specifier given. */
+  _VER_TST("10.<date:%f>", "10.20001010", NULL);
 }
 
 int


### PR DESCRIPTION
**Edited with new commit message**

---

This adds an optional date field to the prefix
passed by automatic_version_prefix. An example of specifying
the field is as follows:

10.<date: %Y%m%d>

And the fields progress like:

10.20181218.0
10.20181218.1
10.20181218.2
10.20181219.0

The date format is used to create a new "current date" string,
as long as it uses valid directives.

If there is a problem reading the given date format after
finding a <date: ...> tag, or in generating the current date,
a warning message is printed and the date field defaults to %Y%m%d.

If no <date: ...> tag is detected in the auto version prefix,
the same behavior as before (appending .1 and incrementing) occurs.

This may be helpful to avoid writing glue code to auto-update
the version if a date string in the commit version is desired.
Otherwise, --add-metadata-string=version= is an alternative for
complete customization.

---

Overall structure of the code is stable (pending review) - now adding a few more tests for edge cases, and need to update the treefile documentation.

Right now this adds more logic to `_rpmostree_util_next_version` - how does this look right now?

Fixes: #1712 