### PR TITLE
core: Fix rpm-md repo caching

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1133,6 +1133,11 @@ rpmostree_context_download_metadata (RpmOstreeContext *self,
     g_auto(RpmOstreeProgress) progress = { 0, };
     rpmostree_output_progress_percent_begin (&progress, "Importing rpm-md");
 
+    /* We already explictly checked the repos above; don't try to check them
+     * again.
+     */
+    dnf_context_set_cache_age (self->dnfctx, G_MAXUINT);
+
     /* This will check the metadata again, but it *should* hit the cache; down
      * the line we should really improve the libdnf API around all of this.
      */


### PR DESCRIPTION
I'd been seeing hangs sometimes in "Importing metadata" and had
thought it was libsolv being slow, but actually the problem is
that while we explicitly check the libdnf repos,
`dnf_context_setup_sack_with_flags()` checks them again using
its `cache_age`.

Set the libdnf context's expiry to "never" after we've done the
checking so it's not checked twice.

This PR brought to you by airplane 🛫 travel and not wanting
to pay for expensive WiFi 💸.
