### PR TITLE
rust/treefile: Include filename in more error msgs

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -310,7 +310,10 @@ fn treefile_parse_recurse<P: AsRef<Path>>(
     let include_path = parsed.config.include.take();
     if let &Some(ref include_path) = &include_path {
         if depth == INCLUDE_MAXDEPTH {
-            bail!("Reached maximum include depth {}", INCLUDE_MAXDEPTH);
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Reached maximum include depth {}", INCLUDE_MAXDEPTH),
+            ).into());
         }
         let parent = filename.parent().unwrap();
         let include_path = parent.join(include_path);
@@ -369,7 +372,10 @@ impl Treefile {
         if let Some(files) = &config.add_files {
             for (_, dest) in files.iter() {
                 if !add_files_path_is_valid(&dest) {
-                    bail!("Unsupported path in add-files: {}", dest);
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("Unsupported path in add-files: {}", dest),
+                    ).into());
                 }
             }
         }

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -30,6 +30,7 @@ use std::path::Path;
 use std::{collections, fs, io};
 use utils;
 use failure::Fallible;
+use failure::ResultExt;
 
 const ARCH_X86_64: &'static str = "x86_64";
 const INCLUDE_MAXDEPTH: u32 = 50;
@@ -139,6 +140,12 @@ fn treefile_parse_stream<R: io::Read>(
     Ok(treefile)
 }
 
+/// Open file and provide context containing filename on failures.
+fn open_file<P: AsRef<Path>>(filename: P) -> Fallible<fs::File> {
+    return Ok(fs::File::open(filename.as_ref()).with_context(
+        |e| format!("Can't open file {:?}: {}", filename.as_ref().display(), e))?);
+}
+
 // If a passwd/group file is provided explicitly, load it as a fd
 fn load_passwd_file<P: AsRef<Path>>(
     basedir: P,
@@ -147,7 +154,7 @@ fn load_passwd_file<P: AsRef<Path>>(
     if let &Some(ref v) = v {
         let basedir = basedir.as_ref();
         if let Some(ref path) = v.filename {
-            return Ok(Some(fs::File::open(basedir.join(path))?));
+            return Ok(Some(open_file(basedir.join(path))?));
         }
     }
     return Ok(None);
@@ -160,12 +167,7 @@ fn treefile_parse<P: AsRef<Path>>(
     arch: Option<&str>,
 ) -> Fallible<ConfigAndExternals> {
     let filename = filename.as_ref();
-    let mut f = io::BufReader::new(fs::File::open(filename).map_err(|e| {
-        io::Error::new(
-            e.kind(),
-            format!("Opening {:?}: {}", filename, e.to_string()),
-        )
-    })?);
+    let mut f = io::BufReader::new(open_file(filename)?);
     let basename = filename
         .file_name()
         .map(|s| s.to_string_lossy())
@@ -182,14 +184,14 @@ fn treefile_parse<P: AsRef<Path>>(
         )
     })?;
     let postprocess_script = if let Some(ref postprocess) = tf.postprocess_script.as_ref() {
-        Some(fs::File::open(filename.with_file_name(postprocess))?)
+        Some(open_file(filename.with_file_name(postprocess))?)
     } else {
         None
     };
     let mut add_files: collections::HashMap<String, fs::File> = collections::HashMap::new();
     if let Some(ref add_file_names) = tf.add_files.as_ref() {
         for (name, _) in add_file_names.iter() {
-            add_files.insert(name.clone(), fs::File::open(filename.with_file_name(name))?);
+            add_files.insert(name.clone(), open_file(filename.with_file_name(name))?);
         }
     }
     let parent = filename.parent().unwrap();
@@ -806,6 +808,16 @@ packages:
         assert!(tf.packages.as_ref().unwrap().len() == 8);
         let rojig = tf.rojig.as_ref().unwrap();
         assert!(rojig.name == "exampleos");
+    }
+
+    #[test]
+    fn test_open_file_nonexistent() {
+        let path = "/usr/share/empty/manifest.yaml";
+        match treefile_parse(path, None) {
+            Err(ref e) => assert!(e.to_string().starts_with(
+                    format!("Can't open file {:?}:", path).as_str())),
+            Ok(_) => panic!("Expected nonexistent treefile error for {}", path),
+        }
     }
 }
 

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -29,6 +29,7 @@ use std::io::prelude::*;
 use std::path::Path;
 use std::{collections, fs, io};
 use utils;
+use failure::Fallible;
 
 const ARCH_X86_64: &'static str = "x86_64";
 const INCLUDE_MAXDEPTH: u32 = 50;
@@ -72,7 +73,7 @@ fn treefile_parse_stream<R: io::Read>(
     fmt: InputFormat,
     input: &mut R,
     arch: Option<&str>,
-) -> io::Result<TreeComposeConfig> {
+) -> Fallible<TreeComposeConfig> {
     let mut treefile: TreeComposeConfig = match fmt {
         InputFormat::YAML => {
             let tf: StrictTreeComposeConfig = serde_yaml::from_reader(input).map_err(|e| {
@@ -142,7 +143,7 @@ fn treefile_parse_stream<R: io::Read>(
 fn load_passwd_file<P: AsRef<Path>>(
     basedir: P,
     v: &Option<CheckPasswd>,
-) -> io::Result<Option<fs::File>> {
+) -> Fallible<Option<fs::File>> {
     if let &Some(ref v) = v {
         let basedir = basedir.as_ref();
         if let Some(ref path) = v.filename {
@@ -157,7 +158,7 @@ fn load_passwd_file<P: AsRef<Path>>(
 fn treefile_parse<P: AsRef<Path>>(
     filename: P,
     arch: Option<&str>,
-) -> io::Result<ConfigAndExternals> {
+) -> Fallible<ConfigAndExternals> {
     let filename = filename.as_ref();
     let mut f = io::BufReader::new(fs::File::open(filename).map_err(|e| {
         io::Error::new(
@@ -301,16 +302,13 @@ fn treefile_parse_recurse<P: AsRef<Path>>(
     filename: P,
     arch: Option<&str>,
     depth: u32,
-) -> io::Result<ConfigAndExternals> {
+) -> Fallible<ConfigAndExternals> {
     let filename = filename.as_ref();
     let mut parsed = treefile_parse(filename, arch)?;
     let include_path = parsed.config.include.take();
     if let &Some(ref include_path) = &include_path {
         if depth == INCLUDE_MAXDEPTH {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("Reached maximum include depth {}", INCLUDE_MAXDEPTH),
-            ));
+            bail!("Reached maximum include depth {}", INCLUDE_MAXDEPTH);
         }
         let parent = filename.parent().unwrap();
         let include_path = parent.join(include_path);
@@ -339,7 +337,7 @@ impl Treefile {
         filename: &Path,
         arch: Option<&str>,
         workdir: openat::Dir,
-    ) -> io::Result<Box<Treefile>> {
+    ) -> Fallible<Box<Treefile>> {
         let parsed = treefile_parse_recurse(filename, arch, 0)?;
         Treefile::validate_config(&parsed.config)?;
         let dfd = openat::Dir::open(filename.parent().unwrap())?;
@@ -364,22 +362,19 @@ impl Treefile {
     }
 
     /// Do some upfront semantic checks we can do beyond just the type safety serde provides.
-    fn validate_config(config: &TreeComposeConfig) -> io::Result<()> {
+    fn validate_config(config: &TreeComposeConfig) -> Fallible<()> {
         // check add-files
         if let Some(files) = &config.add_files {
             for (_, dest) in files.iter() {
                 if !add_files_path_is_valid(&dest) {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!("Unsupported path in add-files: {}", dest),
-                    ));
+                    bail!("Unsupported path in add-files: {}", dest);
                 }
             }
         }
         Ok(())
     }
 
-    fn serialize_json_string(config: &TreeComposeConfig) -> io::Result<CUtf8Buf> {
+    fn serialize_json_string(config: &TreeComposeConfig) -> Fallible<CUtf8Buf> {
         let mut output = vec![];
         serde_json::to_writer_pretty(&mut output, config)?;
         Ok(CUtf8Buf::from_string(
@@ -388,7 +383,7 @@ impl Treefile {
     }
 
     /// Generate a rojig spec file.
-    fn write_rojig_spec<'a, 'b>(workdir: &'a openat::Dir, r: &'b Rojig) -> io::Result<CUtf8Buf> {
+    fn write_rojig_spec<'a, 'b>(workdir: &'a openat::Dir, r: &'b Rojig) -> Fallible<CUtf8Buf> {
         let description = r
             .description
             .as_ref()
@@ -713,8 +708,12 @@ remove-files:
         let buf = buf.as_bytes();
         let mut input = io::BufReader::new(buf);
         match treefile_parse_stream(InputFormat::YAML, &mut input, Some(ARCH_X86_64)) {
-            Err(ref e) if e.kind() == io::ErrorKind::InvalidInput => {}
-            Err(ref e) => panic!("Expected invalid treefile, not {}", e.to_string()),
+            Err(ref e) => {
+                match e.downcast_ref::<io::Error>() {
+                    Some(ref ioe) if ioe.kind() == io::ErrorKind::InvalidInput => {},
+                    _ =>  panic!("Expected invalid treefile, not {}", e.to_string()),
+                }
+            }
             Ok(_) => panic!("Expected invalid treefile"),
         }
     }
@@ -745,7 +744,7 @@ remove-files:
     }
 
     impl TreefileTest {
-        fn new<'a, 'b>(contents: &'a str, arch: Option<&'b str>) -> io::Result<TreefileTest> {
+        fn new<'a, 'b>(contents: &'a str, arch: Option<&'b str>) -> Fallible<TreefileTest> {
             let workdir = tempfile::tempdir()?;
             let tf_path = workdir.path().join("treefile.yaml");
             {


### PR DESCRIPTION
This uses the `Context` feature of the failure crate to make error
messages more useful when we fail to open a file. The difference with
`map_err` is that one can still obtain the underlying error from the
context if need be. Though surprisingly, the normal `Display` for a
`Context` doesn't include the original error, so we essentially have to
do a prefix here (see [1]).

Before:

```
error: Failed to load YAML treefile: No such file or directory (os error 2)
```

After:

```
error: Failed to load YAML treefile: Can't open file "treecompose-post.sh": No such file or directory (os error 2)
```

[1] rust-lang-nursery/failure#182