### PR TITLE
compose: Fix `install --unified-core`

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1112,6 +1112,14 @@ rpmostree_compose_builtin_install (int             argc,
   gboolean changed;
   if (!impl_install_tree (self, &changed, cancellable, error))
     return FALSE;
+  if (opt_unified_core)
+    {
+      if (!glnx_renameat (self->workdir_tmp.src_dfd, self->workdir_tmp.path,
+                          AT_FDCWD, destdir, error))
+        return FALSE;
+      glnx_tmpdir_unset (&self->workdir_tmp);
+      self->workdir_dfd = -1;
+    }
   g_print ("rootfs: %s/rootfs\n", destdir);
 
   return TRUE;

--- a/tests/compose-tests/test-installroot.sh
+++ b/tests/compose-tests/test-installroot.sh
@@ -9,9 +9,8 @@ prepare_compose_test "installroot"
 # This is used to test postprocessing with treefile vs not
 pysetjsonmember "boot_location" '"new"'
 instroot_tmp=$(mktemp -d /var/tmp/rpm-ostree-instroot.XXXXXX)
-rpm-ostree compose install --repo="${repobuild}" ${treefile} ${instroot_tmp}
+rpm-ostree compose install --unified-core --repo="${repobuild}" ${treefile} ${instroot_tmp}
 instroot=${instroot_tmp}/rootfs
-assert_not_has_dir ${instroot}/usr/lib/ostree-boot
 assert_not_has_dir ${instroot}/etc
 test -L ${instroot}/home
 assert_has_dir ${instroot}/usr/etc


### PR DESCRIPTION
There's lots of gyrations here for unified-core vs not; it's
been broken in the case of `--unified-core` for a while I think.
In that case our workdir is tmpdir, so rename that directory.

