### PR TITLE
compose: Add --ex-lockfile and --ex-write-lockfile-to

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -70,6 +70,8 @@ static gboolean opt_print_only;
 static char *opt_write_commitid_to;
 static char *opt_write_composejson_to;
 static gboolean opt_no_parent;
+static char *opt_write_lockfile;
+static char *opt_read_lockfile;
 
 /* shared by both install & commit */
 static GOptionEntry common_option_entries[] = {
@@ -92,6 +94,8 @@ static GOptionEntry install_option_entries[] = {
   { "touch-if-changed", 0, 0, G_OPTION_ARG_STRING, &opt_touch_if_changed, "Update the modification time on FILE if a new commit was created", "FILE" },
   { "workdir", 0, 0, G_OPTION_ARG_STRING, &opt_workdir, "Working directory", "WORKDIR" },
   { "workdir-tmpfs", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_workdir_tmpfs, "Use tmpfs for working state", NULL },
+  { "ex-write-lockfile-to", 0, 0, G_OPTION_ARG_STRING, &opt_write_lockfile, "Write RPM versions information to FILE", "FILE" },
+  { "ex-lockfile", 0, 0, G_OPTION_ARG_STRING, &opt_read_lockfile, "Read RPM version information from FILE", "FILE" },
   { NULL }
 };
 
@@ -333,6 +337,10 @@ install_packages (RpmOstreeTreeComposeContext  *self,
     return FALSE;
 
   rpmostree_print_transaction (dnfctx);
+
+  if (opt_write_lockfile &&
+      !rpmostree_composeutil_write_lockfilejson (self->corectx, opt_write_lockfile, error))
+      return FALSE;
 
   /* FIXME - just do a depsolve here before we compute download requirements */
   g_autofree char *ret_new_inputhash = NULL;
@@ -681,6 +689,16 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
                                               cancellable, error);
   if (!self->corectx)
     return FALSE;
+
+  if (opt_read_lockfile)
+    {
+      g_autoptr(GHashTable) map = rpmostree_composeutil_get_vlockmap (opt_read_lockfile,
+                                                                      error);
+      if (!map)
+        return FALSE;
+      rpmostree_context_set_vlockmap (self->corectx, map);
+      g_print ("Loaded lockfile: %s\n", opt_read_lockfile);
+    }
 
   const char *arch = dnf_context_get_base_arch (rpmostree_context_get_dnf (self->corectx));
   if (!parse_treefile_to_json (gs_file_get_path_cached (self->treefile_path),

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -68,5 +68,13 @@ rpmostree_composeutil_write_composejson (OstreeRepo  *repo,
                                          GVariantBuilder *builder,
                                          GError    **error);
 
+gboolean
+rpmostree_composeutil_write_lockfilejson (RpmOstreeContext  *ctx,
+                                          const char        *path,
+                                          GError           **error);
+
+GHashTable *
+rpmostree_composeutil_get_vlockmap (const char *path,
+                                    GError    **error);
 G_END_DECLS
 

--- a/src/libpriv/rpmostree-core-private.h
+++ b/src/libpriv/rpmostree-core-private.h
@@ -72,6 +72,8 @@ struct _RpmOstreeContext {
   GHashTable *pkgs_to_remove;  /* pkgname --> gv_nevra */
   GHashTable *pkgs_to_replace; /* new gv_nevra --> old gv_nevra */
 
+  GHashTable *vlockmap; /* nevra --> repochecksum */
+
   GLnxTmpDir tmpdir;
 
   gboolean kernel_changed;

--- a/src/libpriv/rpmostree-core.h
+++ b/src/libpriv/rpmostree-core.h
@@ -170,6 +170,8 @@ gboolean rpmostree_context_set_packages (RpmOstreeContext *self,
 
 GPtrArray *rpmostree_context_get_packages_to_import (RpmOstreeContext *self);
 
+void rpmostree_context_set_vlockmap (RpmOstreeContext *self, GHashTable *map);
+
 gboolean rpmostree_context_download (RpmOstreeContext *self,
                                      GCancellable     *cancellable,
                                      GError           **error);

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -1257,6 +1257,60 @@ rpmostree_create_rpmdb_pkglist_variant (int              dfd,
   return TRUE;
 }
 
+gboolean
+rpmostree_create_pkglist_variant (GPtrArray     *pkglist,
+                                  GVariant     **out_variant,
+                                  GCancellable  *cancellable,
+                                  GError       **error)
+{
+  /* we insert it sorted here so it can efficiently be searched on retrieval */
+  g_ptr_array_sort (pkglist, (GCompareFunc)rpmostree_pkg_array_compare);
+
+  GVariantBuilder pkglist_v_builder;
+  g_variant_builder_init (&pkglist_v_builder, G_VARIANT_TYPE ("a(ss)"));
+  for (guint i = 0; i < pkglist->len; i++)
+    {
+      DnfPackage *pkg = pkglist->pdata[i];
+      g_autofree gchar *repodata_chksum = NULL;
+
+      if (!rpmostree_get_repodata_chksum_repr (pkg, &repodata_chksum, error))
+        return FALSE;
+
+      g_variant_builder_add (&pkglist_v_builder, "(ss)",
+                             dnf_package_get_nevra (pkg),
+                             repodata_chksum);
+    }
+
+  *out_variant = g_variant_ref_sink (g_variant_builder_end (&pkglist_v_builder));
+  return TRUE;
+}
+
+DnfPackage *
+rpmostree_get_locked_package (DnfSack    *sack,
+                              GHashTable *lockmap,
+                              const char *name)
+{
+  if (!lockmap || !name)
+    return NULL;
+
+  /* The manifest might specify not only package names (foo-1.x) but also
+   * something-that-foo-provides */
+  g_autoptr(GPtrArray) alts = rpmostree_get_matching_packages (sack, name);
+
+  for (gsize i = 0; i < alts->len; i++)
+  {
+    DnfPackage *pkg = alts->pdata[i];
+    g_autofree gchar *repodata_chksum = NULL;
+    if (!rpmostree_get_repodata_chksum_repr (pkg, &repodata_chksum, NULL))
+      continue;
+
+    const char *chksum = g_hash_table_lookup (lockmap, dnf_package_get_nevra (pkg));
+    if (chksum && !g_strcmp0 (chksum, repodata_chksum))
+      return g_object_ref (pkg);
+  }
+  return NULL;
+}
+
 /* Simple wrapper around hy_split_nevra() that adds allow-none and GError convention */
 gboolean
 rpmostree_decompose_nevra (const char  *nevra,

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -210,6 +210,15 @@ rpmostree_create_rpmdb_pkglist_variant (int              dfd,
                                         GCancellable    *cancellable,
                                         GError         **error);
 
+gboolean
+rpmostree_create_pkglist_variant (GPtrArray     *pkglist,
+                                  GVariant     **out_variant,
+                                  GCancellable  *cancellable,
+                                  GError       **error);
+
+DnfPackage *
+rpmostree_get_locked_package (DnfSack *sack, GHashTable *lockmap, const char *name);
+
 char * rpmostree_get_cache_branch_for_n_evr_a (const char *name, const char *evr, const char *arch);
 char *rpmostree_get_cache_branch_header (Header hdr);
 char *rpmostree_get_rojig_branch_header (Header hdr);

--- a/tests/compose-tests/test-lockfile.sh
+++ b/tests/compose-tests/test-lockfile.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -xeuo pipefail
+
+dn=$(cd $(dirname $0) && pwd)
+. ${dn}/libcomposetest.sh
+
+prepare_compose_test "lockfile"
+# Add a local rpm-md repo so we can mutate local test packages
+pyappendjsonmember "repos" '["test-repo"]'
+build_rpm test-pkg \
+          files "/usr/bin/test-pkg" \
+          install "mkdir -p %{buildroot}/usr/bin && echo localpkg data > %{buildroot}/usr/bin/test-pkg"
+# The test suite writes to pwd, but we need repos in composedata
+# Also we need to disable gpgcheck
+echo gpgcheck=0 >> yumrepo.repo
+ln yumrepo.repo composedata/test-repo.repo
+pyappendjsonmember "packages" '["test-pkg"]'
+pysetjsonmember "documentation" 'False'
+mkdir cache
+# Create lockfile
+runcompose --ex-write-lockfile-to=$PWD/versions.lock --cachedir $(pwd)/cache
+npkgs=$(rpm-ostree --repo=${repobuild} db list ${treeref} |grep -v '^ostree commit' | wc -l)
+echo "npkgs=${npkgs}"
+rpm-ostree --repo=${repobuild} db list ${treeref} test-pkg >test-pkg-list.txt
+assert_file_has_content test-pkg-list.txt 'test-pkg-1.0-1.x86_64'
+echo "ok compose"
+
+assert_has_file "versions.lock"
+assert_file_has_content $PWD/versions.lock 'packages'
+assert_file_has_content $PWD/versions.lock 'test-pkg-1.0-1.x86_64'
+echo "lockfile created"
+# Read lockfile back
+build_rpm test-pkg \
+          version 2.0 \
+          files "/usr/bin/test-pkg" \
+          install "mkdir -p %{buildroot}/usr/bin && echo localpkg data > %{buildroot}/usr/bin/test-pkg"
+runcompose --ex-lockfile=$PWD/versions.lock --cachedir $(pwd)/cache
+echo "ok compose with lockfile"
+
+rpm-ostree --repo=${repobuild} db list ${treeref} test-pkg >test-pkg-list.txt
+assert_file_has_content test-pkg-list.txt 'test-pkg-1.0-1.x86_64'
+echo "lockfile read"


### PR DESCRIPTION
This is a skeleton of the solution for issue #1670.

The writing the lockfile part works but reading hasn't been tested yet.
I'm sending this PR so that we can start a discussion on my approach and I'll change things accordingly.

What's known to be missing:
 * Using the repodata checksum when reading the lock file
 * Make write-lockfile behave like coreos-assembler fetch. Right now the file is generated during the compose process.
 * How to properly pass the pkg NEVRAs to the depsolver.
 * Relevant tests: might involve creating a cached repo with fake/empty pkgs to make it deterministic.