### PR TITLE
treefile: Support dash convention for all options

### DIFF
--- a/api-doc/treefile-examples/fedora-rawhide-base.json
+++ b/api-doc/treefile-examples/fedora-rawhide-base.json
@@ -1,19 +1,15 @@
 {
     "ref": "fedora-atomic/rawhide/x86_64/base/core",
 
-    "gpg_key": "<SET KEY ID FOR GPG>",
+    "gpg-key": "<SET KEY ID FOR GPG>",
 
     "repos": ["fedora-rawhide"],
 
     "selinux": true,
 
-    "bootstrap_packages": ["filesystem", "glibc", "nss-altfiles", "shadow-utils",
-			   "generic-release"],
-
     "packages": ["kernel", "ostree", "lvm2",
-		 "btrfs-progs", "e2fsprogs", "xfsprogs",
-		 "gnupg2", "selinux-policy-targeted",
-		 "openssh-server", "openssh-clients",
-		 "NetworkManager", "vim-minimal", "nano", "sudo"]
+                 "btrfs-progs", "e2fsprogs", "xfsprogs",
+                 "gnupg2", "selinux-policy-targeted",
+                 "openssh-server", "openssh-clients",
+                 "NetworkManager", "vim-minimal", "nano", "sudo"]
 }
-	    

--- a/api-doc/treefile-examples/fedora-rawhide-docker.json
+++ b/api-doc/treefile-examples/fedora-rawhide-docker.json
@@ -4,7 +4,6 @@
     "include": "fedora-rawhide-base.json",
 
     "packages": ["docker-io"],
-    
+
     "units": ["docker.service", "docker.socket"]
 }
-	    

--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -13,8 +13,8 @@ It supports the following parameters:
  * `ref`: string, mandatory: Holds a string which will be the name of
    the branch for the content.
 
- * `gpg_key` string, optional: Key ID for GPG signing; the secret key
-   must be in the home directory of the building user.  Defaults to
+ * `gpg-key` (or `gpg_key`): string, optional: Key ID for GPG signing; the
+   secret key must be in the home directory of the building user.  Defaults to
    none.
 
  * `repos` array of strings, mandatory: Names of yum repositories to
@@ -26,10 +26,10 @@ It supports the following parameters:
  * `selinux`: boolean, optional: Defaults to `true`.  If `false`, then
    no SELinux labeling will be performed on the server side.
 
- * `boot_location`: string, optional: Historically, ostree put bootloader data
-    in /boot.  However, this has a few flaws; it gets shadowed at boot time,
-    and also makes dealing with Anaconda installation harder.  There are 3
-    possible values:
+ * `boot-location` (or `boot_location`): string, optional: Historically, ostree
+    put bootloader data in /boot.  However, this has a few flaws; it gets
+    shadowed at boot time, and also makes dealing with Anaconda installation
+    harder.  There are 3 possible values:
     * "both": the default, kernel data goes in /boot and /usr/lib/ostree-boot
     * "legacy": Now an alias for "both"; historically meant just "boot"
     * "new": kernel data goes in /usr/lib/ostree-boot and /usr/lib/modules
@@ -66,7 +66,8 @@ It supports the following parameters:
 
  * `units`: Array of strings, optional: Systemd units to enable by default
 
- * `default_target`: String, optional: Set the default systemd target
+ * `default-target` (or `default_target`): String, optional: Set the default
+    systemd target.
 
  * `initramfs-args`: Array of strings, optional.  Passed to the
     initramfs generation program (presently `dracut`).  An example use
@@ -143,14 +144,14 @@ It supports the following parameters:
 
    Example: `releasever: "26"`
 
- * `automatic_version_prefix`: String, optional: Set the prefix for versions
-   on the commits. The idea is that if the previous commit on the branch to the
-   doesn't match the prefix, or doesn't have a version, then the new commit will
-   have the version as specified. If the prefix matches exactly, then we append
-   ".1". Otherwise we parse the number after the prefix and increment it by one
-   and then append that to the prefix.
+ * `automatic-version-prefix` (or `automatic_version_prefix`): String, optional:
+   Set the prefix for versions on the commits. The idea is that if the previous
+   commit on the branch to the doesn't match the prefix, or doesn't have a
+   version, then the new commit will have the version as specified. If the
+   prefix matches exactly, then we append ".1". Otherwise we parse the number
+   after the prefix and increment it by one and then append that to the prefix.
 
-   A current date/time may also be passed through `automatic_version_prefix`,
+   A current date/time may also be passed through `automatic-version-prefix`,
    by including a date tag in the prefix as such: `<date:format>`, where
    `format` is a string with date formats such as `%Y` (year), `%m` (month), etc.
    The full list of supported formats is [found in the GLib API](https://developer.gnome.org/glib/stable/glib-GDateTime.html#g-date-time-format).
@@ -158,18 +159,18 @@ It supports the following parameters:
    the version, if not present in the prefix, which resets to `.0` if
    the date (or prefix) changes.
 
-   This means that on an empty branch with an `automatic_version_prefix`
+   This means that on an empty branch with an `automatic-version-prefix`
    of `"22"` the first three commits would get the versions: "22", "22.1",
    "22.2". Some example progressions are shown:
 
-   | `automatic_version_prefix` | version progression                        |
+   | `automatic-version-prefix` | version progression                        |
    | -------------------------- | ------------------------------------------ |
    | `22`                       | 22, 22.1, 22.2, ...                        |
    | `22.1`                     | 22.1.1, 22.1.2, 22.1.3, ...                |
    | `22.<date:%Y>`             | 22.2019.0, 22.2019.1, 22.2020.0, ...       |
    | `22.<date:%Y>.1`           | 22.2019.1.0, 22.2019.1.1, 22.2020.1.0, ... |
 
-   Example: `automatic_version_prefix: "22.0"`
+   Example: `automatic-version-prefix: "22.0"`
 
  * `postprocess-script`: String, optional: Full filesystem path to a script
    that will be executed in the context of the target tree.  The script

--- a/rust/src/composepost.rs
+++ b/rust/src/composepost.rs
@@ -60,11 +60,17 @@ fn postprocess_useradd(rootfs_dfd: &openat::Dir) -> Fallible<()> {
 // enabled; let's just do this rather than trying to propagate the
 // preset everywhere.
 fn postprocess_presets(rootfs_dfd: &openat::Dir) -> Fallible<()> {
-    let mut o = rootfs_dfd.write_file("usr/lib/systemd/system-preset/40-rpm-ostree-auto.preset", 0o644)?;
-    o.write(r###"# Written by rpm-ostree compose tree
+    let mut o = rootfs_dfd.write_file(
+        "usr/lib/systemd/system-preset/40-rpm-ostree-auto.preset",
+        0o644,
+    )?;
+    o.write(
+        r###"# Written by rpm-ostree compose tree
 enable ostree-remount.service
 enable ostree-finalize-staged.path
-"###.as_bytes())?;
+"###
+        .as_bytes(),
+    )?;
     o.flush()?;
     Ok(())
 }
@@ -101,7 +107,11 @@ fn postprocess_subs_dist(rootfs_dfd: &openat::Dir) -> Fallible<()> {
 // This function is called from rpmostree_postprocess_final(); think of
 // it as the bits of that function that we've chosen to implement in Rust.
 fn compose_postprocess_final(rootfs_dfd: &openat::Dir) -> Fallible<()> {
-    let tasks = [postprocess_useradd, postprocess_presets, postprocess_subs_dist];
+    let tasks = [
+        postprocess_useradd,
+        postprocess_presets,
+        postprocess_subs_dist,
+    ];
     tasks.par_iter().try_for_each(|f| f(rootfs_dfd))
 }
 

--- a/rust/src/ffiutil.rs
+++ b/rust/src/ffiutil.rs
@@ -19,11 +19,11 @@
 use gio_sys;
 use glib_sys;
 use libc;
-use std::ffi::{CStr, OsStr};
 use std::ffi::CString;
+use std::ffi::{CStr, OsStr};
 use std::fmt::Display;
-use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::os::unix::ffi::OsStrExt;
+use std::os::unix::io::{FromRawFd, IntoRawFd};
 use std::ptr;
 
 use openat;
@@ -84,7 +84,7 @@ pub fn ffi_view_bytestring<'a>(s: *const libc::c_char) -> &'a [u8] {
 /// View a C "bytestring" (NUL terminated) as a Rust OsStr.
 /// Panics if `s` is `NULL`.
 pub fn ffi_view_os_str<'a>(s: *const libc::c_char) -> &'a OsStr {
-    OsStr::from_bytes(ffi_view_bytestring (s))
+    OsStr::from_bytes(ffi_view_bytestring(s))
 }
 
 // View `fd` as an `openat::Dir` instance.  Lifetime of return value

--- a/rust/src/journal.rs
+++ b/rust/src/journal.rs
@@ -18,9 +18,9 @@
 
 extern crate systemd;
 
-use failure::Fallible;
 use self::systemd::id128::Id128;
 use self::systemd::journal;
+use failure::Fallible;
 
 static OSTREE_FINALIZE_STAGED_SERVICE: &'static str = "ostree-finalize-staged.service";
 static OSTREE_DEPLOYMENT_FINALIZING_MSG_ID: &'static str = "e8646cd63dff4625b77909a8e7a40994";

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -27,8 +27,8 @@ extern crate glib_sys;
 extern crate indicatif;
 extern crate libc;
 extern crate openat;
-extern crate tempfile;
 extern crate rayon;
+extern crate tempfile;
 
 #[macro_use]
 extern crate lazy_static;

--- a/rust/src/openat_utils.rs
+++ b/rust/src/openat_utils.rs
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-use std::{fs, io};
 use openat;
+use std::{fs, io};
 
 /// Helper functions for openat::Dir
 pub(crate) trait OpenatDirExt {
@@ -54,4 +54,3 @@ impl OpenatDirExt for openat::Dir {
         }
     }
 }
-

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -104,7 +104,8 @@ mod tests {
         let r = varsubst(
             "ostree/${osvendor}/${basearch}/blah/${basearch}/whee",
             &subs,
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(r, "ostree/fedora/ppc64le/blah/ppc64le/whee");
         let r = varsubst("${osvendor}${basearch}", &subs).unwrap();
         assert_eq!(r, "fedorappc64le");

--- a/src/app/rpmostree-compose-builtin-rojig.c
+++ b/src/app/rpmostree-compose-builtin-rojig.c
@@ -389,12 +389,12 @@ impl_rojig_build (RpmOstreeRojigCompose *self,
     return FALSE;
 
   g_autofree char *next_version = NULL;
-  if (json_object_has_member (self->treefile, "automatic_version_prefix") &&
+  if (json_object_has_member (self->treefile, "automatic-version-prefix") &&
       /* let --add-metadata-string=version=... take precedence */
       !g_hash_table_contains (self->metadata, OSTREE_COMMIT_META_KEY_VERSION))
     {
       const char *ver_prefix =
-        _rpmostree_jsonutil_object_require_string_member (self->treefile, "automatic_version_prefix", error);
+        _rpmostree_jsonutil_object_require_string_member (self->treefile, "automatic-version-prefix", error);
       if (!ver_prefix)
         return FALSE;
 

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -773,12 +773,12 @@ impl_install_tree (RpmOstreeTreeComposeContext *self,
     return FALSE;
 
   g_autofree char *next_version = NULL;
-  if (json_object_has_member (self->treefile, "automatic_version_prefix") &&
+  if (json_object_has_member (self->treefile, "automatic-version-prefix") &&
       /* let --add-metadata-string=version=... take precedence */
       !g_hash_table_contains (self->metadata, OSTREE_COMMIT_META_KEY_VERSION))
     {
       const char *ver_prefix =
-        _rpmostree_jsonutil_object_require_string_member (self->treefile, "automatic_version_prefix", error);
+        _rpmostree_jsonutil_object_require_string_member (self->treefile, "automatic-version-prefix", error);
       if (!ver_prefix)
         return FALSE;
 
@@ -953,7 +953,7 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
   g_variant_builder_init (&composemeta_builder, G_VARIANT_TYPE ("a{sv}"));
 
   const char *gpgkey = NULL;
-  if (!_rpmostree_jsonutil_object_get_optional_string_member (self->treefile, "gpg_key", &gpgkey, error))
+  if (!_rpmostree_jsonutil_object_get_optional_string_member (self->treefile, "gpg-key", &gpgkey, error))
     return FALSE;
 
   gboolean selinux = TRUE;
@@ -1156,7 +1156,7 @@ rpmostree_compose_builtin_postprocess (int             argc,
 
   const char *rootfs_path = argv[1];
   /* Here we *optionally* process a treefile; some things like `tmp-is-dir` and
-   * `boot_location` are configurable and relevant here, but a lot of users
+   * `boot-location` are configurable and relevant here, but a lot of users
    * will also probably be OK with the defaults, and part of the idea here is
    * to avoid at least some of the use cases requiring a treefile.
    */

--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -270,7 +270,7 @@ rpmostree_postprocess_run_depmod (int           rootfs_dfd,
  *  - /boot (CentOS, Fedora treecompose before we suppressed kernel.spec's %posttrans)
  *  - /usr/lib/modules (Fedora treecompose without kernel.spec's %posttrans)
  *
- * We then need to handle the boot_location option, which can put that data in
+ * We then need to handle the boot-location option, which can put that data in
  * either both (/boot and /usr/lib/ostree-boot), or just the latter.
  */
 static gboolean
@@ -359,7 +359,7 @@ process_kernel_and_initramfs (int            rootfs_dfd,
     RPMOSTREE_POSTPROCESS_BOOT_LOCATION_BOTH;
   const char *boot_location_str = NULL;
   if (!_rpmostree_jsonutil_object_get_optional_string_member (treefile,
-                                                              "boot_location",
+                                                              "boot-location",
                                                               &boot_location_str, error))
     return FALSE;
   if (boot_location_str != NULL)
@@ -1571,7 +1571,7 @@ rpmostree_treefile_postprocessing (int            rootfs_fd,
     return FALSE;
 
   const char *default_target = NULL;
-  if (!_rpmostree_jsonutil_object_get_optional_string_member (treefile, "default_target",
+  if (!_rpmostree_jsonutil_object_get_optional_string_member (treefile, "default-target",
                                                               &default_target, error))
     return FALSE;
 


### PR DESCRIPTION
Now that we support YAML, it's a gotcha/eyesore that some of our options
use underscores rather than dashes. Let's be nice and switch those few
options over, while of course still supporting the previous name.