### PR TITLE
libpriv/scripts: Add /run/ostree-booted for scriptlets

### DIFF
--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -334,6 +334,7 @@ run_script_in_bwrap_container (int rootfs_fd,
   const char *postscript_path_host = postscript_path_container + 1;
   g_autoptr(RpmOstreeBwrap) bwrap = NULL;
   gboolean created_var_lib_rpmstate = FALSE;
+  gboolean created_run_ostree_booted = FALSE;
   glnx_autofd int stdout_fd = -1;
   glnx_autofd int stderr_fd = -1;
 
@@ -398,6 +399,7 @@ run_script_in_bwrap_container (int rootfs_fd,
   if (fd == -1)
     return glnx_throw_errno_prefix (error, "touch(run/ostree-booted)");
   (void) close (fd);
+  created_run_ostree_booted = TRUE;
 
   if (var_lib_rpm_statedir)
     rpmostree_bwrap_bind_readwrite (bwrap, var_lib_rpm_statedir->path, "/var/lib/rpm-state");
@@ -497,6 +499,8 @@ run_script_in_bwrap_container (int rootfs_fd,
   (void) unlinkat (rootfs_fd, postscript_path_host, 0);
   if (created_var_lib_rpmstate)
     (void) unlinkat (rootfs_fd, "var/lib/rpm-state", AT_REMOVEDIR);
+  if (created_run_ostree_booted)
+    (void) unlinkat (rootfs_fd, "run/ostree-booted", 0);
   return ret;
 }
 

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -196,6 +196,10 @@ assert_file_has_content err.txt "run.*journalctl.*for more information"
 vm_assert_journal_has_content $cursor 'rpm-ostree(bad-post.post).*a bad post'
 echo "ok script output prefixed in journal"
 
+vm_build_rpm check-ostree-booted post "test -f /run/ostree-booted"
+vm_rpmostree install check-ostree-booted
+echo "ok /run/ostree-booted in scriptlet container"
+
 # check refresh-md/-C functionality
 
 # local repos are always cached, so let's start up an http server for the same


### PR DESCRIPTION
RPM-OSTree has been pretty good so far at consuming the exact same RPMs
used for traditional OSes without modifications. This is important,
because shielding RPMs from the OSTree abstraction means we remain
compatible with a large portion of the ecosystem.

However, there are some apps that definitely require rethinking their
approach. The example right now is akmods, which has a patch proposed to
build kmods at `%post` time on OSTree systems instead of from the
daemon.[1]

In such situations, scriptlets need something to key off of for the
OSTree-specific approach. The `/run/ostree-booted` file is the de facto
API to determine if we're running on an OSTree system or not. This patch
simply extends this API so that scriptlets can naturally make use of
them.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1667014