### PR TITLE
libpriv: Rebuild policy during postprocessing

### DIFF
--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -981,6 +981,8 @@ rpmostree_postprocess_final (int            rootfs_dfd,
 
   if (selinux)
     {
+      g_print ("Recompiling policy\n");
+
       /* Now regenerate SELinux policy so that postprocess scripts from users and from us
        * (e.g. the /etc/default/useradd incision) that affect it are baked in. */
       char *child_argv[] = { "semodule", "-nB", NULL };

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -25,11 +25,12 @@ assert_file_has_content_literal useradd.txt HOME=/var/home
 
 ostree --repo=${repobuild} cat ${treeref} \
   /usr/etc/selinux/targeted/contexts/files/file_contexts.homedirs > homedirs.txt
-assert_file_has_content_literal homedirs.txt /var/home
+assert_file_has_content homedirs.txt '^/var/home'
 
 ostree --repo=${repobuild} cat ${treeref} \
   /usr/etc/selinux/targeted/contexts/files/file_contexts.subs_dist > subs_dist.txt
-assert_not_file_has_content subs_dist.txt /var/home
+assert_not_file_has_content subs_dist.txt '^/var/home \+'
+assert_file_has_content subs_dist.txt '^/home \+/var/home$'
 echo "ok etc/default/useradd"
 
 for path in /usr/share/rpm /usr/lib/sysimage/rpm-ostree-base-db; do

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -26,6 +26,10 @@ assert_file_has_content_literal useradd.txt HOME=/var/home
 ostree --repo=${repobuild} cat ${treeref} \
   /usr/etc/selinux/targeted/contexts/files/file_contexts.homedirs > homedirs.txt
 assert_file_has_content_literal homedirs.txt /var/home
+
+ostree --repo=${repobuild} cat ${treeref} \
+  /usr/etc/selinux/targeted/contexts/files/file_contexts.subs_dist > subs_dist.txt
+assert_not_file_has_content subs_dist.txt /var/home
 echo "ok etc/default/useradd"
 
 for path in /usr/share/rpm /usr/lib/sysimage/rpm-ostree-base-db; do

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -22,6 +22,10 @@ validate_passwd group
 
 ostree --repo=${repobuild} cat ${treeref} /usr/etc/default/useradd > useradd.txt
 assert_file_has_content_literal useradd.txt HOME=/var/home
+
+ostree --repo=${repobuild} cat ${treeref} \
+  /usr/etc/selinux/targeted/contexts/files/file_contexts.homedirs > homedirs.txt
+assert_file_has_content_literal homedirs.txt /var/home
 echo "ok etc/default/useradd"
 
 for path in /usr/share/rpm /usr/lib/sysimage/rpm-ostree-base-db; do


### PR DESCRIPTION
It's possible for some postprocessing scripts to affect the final
SELinux policy. This is the case for the new `/etc/default/useradd` edit
we now do (#1726), but it could've been the case beforehand too with
user scripts modifying e.g. booleans (though ideally all these
modifications would be part of RPMs).

Do a final `semodule -nB` during postprocessing so that the final policy
we commit is "up to date". Otherwise, users may only see changes take
effect if they layer packages that trigger a rebuild.

The motivation for this is specifically for `/etc/default/useradd`.
There is magic in `selinux-policy` that parses the file and generates
templated rules from the value of `HOME`.

For more info, see:
https://bugzilla.redhat.com/show_bug.cgi?id=1669982
https://src.fedoraproject.org/rpms/selinux-policy/pull-request/14