### PR TITLE
treefile: Fix octal mode for rojig spec too

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -399,7 +399,7 @@ impl Treefile {
             .unwrap_or(r.summary.as_str());
         let name: String = format!("{}.spec", r.name);
         {
-            let mut f = workdir.write_file(name.as_str(), 0644)?;
+            let mut f = workdir.write_file(name.as_str(), 0o644)?;
             write!(
                 f,
                 r###"


### PR DESCRIPTION
Going to need to see if clippy or something has a way for us
to reject leading `0`.
