### PR TITLE
cli/cancel: Close txn bus connection after cancelling

### DIFF
--- a/src/app/rpmostree-builtin-cancel.c
+++ b/src/app/rpmostree-builtin-cancel.c
@@ -105,8 +105,10 @@ rpmostree_builtin_cancel (int             argc,
   rpmostree_transaction_call_cancel (txn_proxy, cancellable,
                                      on_cancel_method_completed, NULL);
 
+  g_clear_object (&txn_proxy);
+
   gboolean done = FALSE;
-  g_signal_connect (txn_proxy, "notify::active-transaction-path",
+  g_signal_connect (sysroot_proxy, "notify::active-transaction-path",
                     G_CALLBACK (on_active_txn_path_changed), &done);
   /* Wait for the transaction to go away */
   while (!done)


### PR DESCRIPTION
There's no reason to keep this around, we aren't going to use it.
Motivation here is the lifetime of transactions is currently
entangled with the bus connections from clients, and we don't
want to hold them open unnecessarily.

Also, we were adding a notify on the wrong object.  I think it
was just working before because something else ran the mainloop
and we got the property notification anyways.
