### PR TITLE
app/status: Always print pending deployment diff

### DIFF
--- a/src/app/rpmostree-builtin-deploy.c
+++ b/src/app/rpmostree-builtin-deploy.c
@@ -190,8 +190,7 @@ rpmostree_builtin_deploy (int            argc,
       /* do diff without dbus: https://github.com/projectatomic/rpm-ostree/pull/116 */
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
-                                                           cancellable,
-                                                           error))
+            RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable, error))
         return FALSE;
 
       g_print ("Run \"systemctl reboot\" to start a reboot\n");

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -232,8 +232,7 @@ rpmostree_builtin_upgrade (int             argc,
       /* do diff without dbus: https://github.com/projectatomic/rpm-ostree/pull/116 */
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
-                                                           cancellable,
-                                                           error))
+            RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable, error))
         return FALSE;
 
       g_print ("Run \"systemctl reboot\" to start a reboot\n");

--- a/src/app/rpmostree-db-builtin-diff.c
+++ b/src/app/rpmostree-db-builtin-diff.c
@@ -87,7 +87,8 @@ print_diff (OstreeRepo   *repo,
       if (g_str_equal (opt_format, "diff"))
         rpmostree_diff_print (removed, added, modified_old, modified_new);
       else if (g_str_equal (opt_format, "block"))
-        rpmostree_diff_print_formatted (removed, added, modified_old, modified_new);
+        rpmostree_diff_print_formatted (RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0,
+                                        removed, added, modified_old, modified_new);
       else
         return glnx_throw (error, "Format argument is invalid, pick one of: diff, block");
     }

--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -1445,13 +1445,13 @@ rpmostree_print_diff_advisories (GVariant         *rpm_diff,
                                             upgraded, downgraded, removed, added);
   else
     {
-      g_autoptr(GString) diff_summary = g_string_new (NULL);
-      append_to_summary (diff_summary, "upgraded", g_variant_n_children (upgraded));
-      append_to_summary (diff_summary, "downgraded", g_variant_n_children (downgraded));
-      append_to_summary (diff_summary, "removed", g_variant_n_children (removed));
-      append_to_summary (diff_summary, "added", g_variant_n_children (added));
-      if (diff_summary->len > 0) /* only print if we have something to print */
-        rpmostree_print_kv ("Diff", max_key_len, diff_summary->str);
+      g_autofree char *diff_summary =
+        rpmostree_generate_diff_summary (g_variant_n_children (upgraded),
+                                         g_variant_n_children (downgraded),
+                                         g_variant_n_children (removed),
+                                         g_variant_n_children (added));
+      if (strlen (diff_summary) > 0) /* only print if we have something to print */
+        rpmostree_print_kv ("Diff", max_key_len, diff_summary);
     }
 
   return TRUE;

--- a/src/app/rpmostree-dbus-helpers.c
+++ b/src/app/rpmostree-dbus-helpers.c
@@ -860,8 +860,7 @@ rpmostree_transaction_client_run (RpmOstreeCommandInvocation *invocation,
           /* do diff without dbus: https://github.com/projectatomic/rpm-ostree/pull/116 */
           const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
           if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
-                                                               cancellable,
-                                                               error))
+                RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable, error))
             return FALSE;
         }
 

--- a/src/app/rpmostree-libbuiltin.c
+++ b/src/app/rpmostree-libbuiltin.c
@@ -100,27 +100,26 @@ rpmostree_print_treepkg_diff_from_sysroot_path (const gchar *sysroot_path,
   OstreeDeployment *new_deployment = deployments->pdata[0];
   OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);
 
-  if (booted_deployment && new_deployment != booted_deployment)
-    {
-      g_autoptr(OstreeRepo) repo = NULL;
-      if (!ostree_sysroot_get_repo (sysroot, &repo, cancellable, error))
-        return FALSE;
+  if (!booted_deployment || ostree_deployment_equal (booted_deployment, new_deployment))
+    return TRUE;
 
-      const char *from_rev = ostree_deployment_get_csum (booted_deployment);
-      const char *to_rev = ostree_deployment_get_csum (new_deployment);
+  g_autoptr(OstreeRepo) repo = NULL;
+  if (!ostree_sysroot_get_repo (sysroot, &repo, cancellable, error))
+    return FALSE;
 
-      g_autoptr(GPtrArray) removed = NULL;
-      g_autoptr(GPtrArray) added = NULL;
-      g_autoptr(GPtrArray) modified_old = NULL;
-      g_autoptr(GPtrArray) modified_new = NULL;
-      if (!rpm_ostree_db_diff (repo, from_rev, to_rev,
-                               &removed, &added, &modified_old, &modified_new,
-                               cancellable, error))
-        return FALSE;
+  const char *from_rev = ostree_deployment_get_csum (booted_deployment);
+  const char *to_rev = ostree_deployment_get_csum (new_deployment);
 
-      rpmostree_diff_print_formatted (removed, added, modified_old, modified_new);
-    }
+  g_autoptr(GPtrArray) removed = NULL;
+  g_autoptr(GPtrArray) added = NULL;
+  g_autoptr(GPtrArray) modified_old = NULL;
+  g_autoptr(GPtrArray) modified_new = NULL;
+  if (!rpm_ostree_db_diff (repo, from_rev, to_rev,
+                           &removed, &added, &modified_old, &modified_new,
+                           cancellable, error))
+    return FALSE;
 
+  rpmostree_diff_print_formatted (removed, added, modified_old, modified_new);
   return TRUE;
 }
 

--- a/src/app/rpmostree-libbuiltin.c
+++ b/src/app/rpmostree-libbuiltin.c
@@ -85,9 +85,11 @@ rpmostree_has_new_default_deployment (RPMOSTreeOS *os_proxy,
 
 /* Print the diff between the booted and pending deployments */
 gboolean
-rpmostree_print_treepkg_diff_from_sysroot_path (const gchar *sysroot_path,
-                                                GCancellable *cancellable,
-                                                GError **error)
+rpmostree_print_treepkg_diff_from_sysroot_path (const gchar   *sysroot_path,
+                                                RpmOstreeDiffPrintFormat format,
+                                                guint          max_key_len,
+                                                GCancellable  *cancellable,
+                                                GError       **error)
 {
   g_autoptr(GFile) sysroot_file = g_file_new_for_path (sysroot_path);
   g_autoptr(OstreeSysroot) sysroot = ostree_sysroot_new (sysroot_file);
@@ -119,7 +121,8 @@ rpmostree_print_treepkg_diff_from_sysroot_path (const gchar *sysroot_path,
                            cancellable, error))
     return FALSE;
 
-  rpmostree_diff_print_formatted (removed, added, modified_old, modified_new);
+  rpmostree_diff_print_formatted (format, max_key_len,
+                                  removed, added, modified_old, modified_new);
   return TRUE;
 }
 

--- a/src/app/rpmostree-libbuiltin.c
+++ b/src/app/rpmostree-libbuiltin.c
@@ -94,17 +94,8 @@ rpmostree_print_treepkg_diff_from_sysroot_path (const gchar *sysroot_path,
   if (!ostree_sysroot_load (sysroot, cancellable, error))
     return FALSE;
 
-  return rpmostree_print_treepkg_diff (sysroot, cancellable, error);
-}
-
-/* Print the diff between the booted and pending deployments */
-gboolean
-rpmostree_print_treepkg_diff (OstreeSysroot    *sysroot,
-                              GCancellable     *cancellable,
-                              GError          **error)
-{
   g_autoptr(GPtrArray) deployments = ostree_sysroot_get_deployments (sysroot);
-  g_assert (deployments->len > 1);
+  g_assert_cmpuint (deployments->len, >, 1);
 
   OstreeDeployment *new_deployment = deployments->pdata[0];
   OstreeDeployment *booted_deployment = ostree_sysroot_get_booted_deployment (sysroot);

--- a/src/app/rpmostree-libbuiltin.h
+++ b/src/app/rpmostree-libbuiltin.h
@@ -24,6 +24,8 @@
 
 #include "libglnx.h"
 
+#include "rpmostree-util.h"
+
 #include "rpm-ostreed-generated.h"
 
 G_BEGIN_DECLS
@@ -62,9 +64,11 @@ rpmostree_has_new_default_deployment (RPMOSTreeOS *os_proxy,
                                       GVariant    *previous_deployment);
 
 gboolean
-rpmostree_print_treepkg_diff_from_sysroot_path (const gchar *sysroot_path,
-                                                GCancellable *cancellable,
-                                                GError **error);
+rpmostree_print_treepkg_diff_from_sysroot_path (const gchar   *sysroot_path,
+                                                RpmOstreeDiffPrintFormat format,
+                                                guint          max_key_len,
+                                                GCancellable  *cancellable,
+                                                GError       **error);
 
 void
 rpmostree_print_timestamp_version (const char  *version_string,

--- a/src/app/rpmostree-libbuiltin.h
+++ b/src/app/rpmostree-libbuiltin.h
@@ -62,11 +62,6 @@ rpmostree_has_new_default_deployment (RPMOSTreeOS *os_proxy,
                                       GVariant    *previous_deployment);
 
 gboolean
-rpmostree_print_treepkg_diff (OstreeSysroot    *sysroot,
-                              GCancellable     *cancellable,
-                              GError          **error);
-
-gboolean
 rpmostree_print_treepkg_diff_from_sysroot_path (const gchar *sysroot_path,
                                                 GCancellable *cancellable,
                                                 GError **error);

--- a/src/app/rpmostree-override-builtins.c
+++ b/src/app/rpmostree-override-builtins.c
@@ -119,8 +119,7 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
 
       const char *sysroot_path = rpmostree_sysroot_get_path (sysroot_proxy);
       if (!rpmostree_print_treepkg_diff_from_sysroot_path (sysroot_path,
-                                                           cancellable,
-                                                           error))
+            RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE, 0, cancellable, error))
         return FALSE;
 
       g_print ("Run \"systemctl reboot\" to start a reboot\n");

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -848,6 +848,27 @@ rpmostree_stdout_is_journal (void)
   return stdout_is_socket;
 }
 
+char*
+rpmostree_generate_diff_summary (guint upgraded,
+                                 guint downgraded,
+                                 guint removed,
+                                 guint added)
+{
+  guint args[] = { upgraded, downgraded, removed, added };
+  const char *arg_desc[] = { "upgraded", "downgraded", "removed", "added" };
+
+  g_autoptr(GString) summary = g_string_new (NULL);
+  for (guint i = 0; i < G_N_ELEMENTS (args); i++)
+    {
+      if (args[i] == 0)
+        continue;
+      if (summary->len > 0)
+        g_string_append (summary, ", ");
+      g_string_append_printf (summary, "%u %s", args[i], arg_desc[i]);
+    }
+  return g_string_free (g_steal_pointer (&summary), FALSE);
+}
+
 /* Given the result of rpm_ostree_db_diff(), print it in a nice formatted way for humans. */
 void
 rpmostree_diff_print_formatted (GPtrArray *removed,

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -113,8 +113,24 @@ rpmostree_generate_diff_summary (guint upgraded,
                                  guint removed,
                                  guint added);
 
+typedef enum {
+  RPMOSTREE_DIFF_PRINT_FORMAT_SUMMARY,       /* Diff: 1 upgraded, 2 downgraded, 3 removed, 4 added */
+  RPMOSTREE_DIFF_PRINT_FORMAT_FULL_ALIGNED,  /* Upgraded: ...
+                                                          ...
+                                                   Added: ...
+                                                          ...  */
+  RPMOSTREE_DIFF_PRINT_FORMAT_FULL_MULTILINE /* Upgraded:
+                                                   ...
+                                                   ...
+                                                 Added:
+                                                   ...
+                                                   ...  */
+} RpmOstreeDiffPrintFormat;
+
 void
-rpmostree_diff_print_formatted (GPtrArray *removed,
+rpmostree_diff_print_formatted (RpmOstreeDiffPrintFormat format,
+                                guint      max_key_len,
+                                GPtrArray *removed,
                                 GPtrArray *added,
                                 GPtrArray *modified_old,
                                 GPtrArray *modified_new);

--- a/src/libpriv/rpmostree-util.h
+++ b/src/libpriv/rpmostree-util.h
@@ -107,6 +107,12 @@ gs_file_get_path_cached (GFile *file)
 
 gboolean rpmostree_stdout_is_journal (void);
 
+char*
+rpmostree_generate_diff_summary (guint upgraded,
+                                 guint downgraded,
+                                 guint removed,
+                                 guint added);
+
 void
 rpmostree_diff_print_formatted (GPtrArray *removed,
                                 GPtrArray *added,

--- a/tests/vmcheck/test-db.sh
+++ b/tests/vmcheck/test-db.sh
@@ -55,6 +55,17 @@ vm_build_rpm pkg-to-replace
 vm_build_rpm pkg-to-replace-archtrans arch noarch
 vm_rpmostree install pkg-to-remove pkg-to-replace pkg-to-replace-archtrans
 
+# we should be able to see the diff in status now
+vm_rpmostree status > status.txt
+assert_file_has_content status.txt "Diff: 3 added"
+vm_rpmostree status -v > statusv.txt
+assert_file_has_content statusv.txt \
+  "Added:" \
+  "pkg-to-remove" \
+  "pkg-to-replace" \
+  "pkg-to-replace-archtrans"
+echo "ok db diff in status"
+
 booted_csum=$(vm_get_booted_csum)
 pending_csum=$(vm_get_pending_csum)
 check_diff $booted_csum $pending_csum \


### PR DESCRIPTION
Right now we only print a diff of the pending deployment if we have a
cached update (which only happens if user just did an `upgrade`
operation). But really, we can just always print this for the pending
deployment regardless of whether there's a cached update calculated.

This is prep for changing chained operations to only show the diff
between the previous pending deployment to the new pending deployment (#945).
With this patch, the full diff from booted to pending will always be
available through `status` (and `db diff` too though it's not as nice).