### PR TITLE
rust/treefile: Add basearch key

### DIFF
--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -101,7 +101,8 @@ fn treefile_parse_stream<R: io::Read>(
             if treearch != arch {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    format!("Invalid basearch: cross-composes are not supported"),
+                    format!("Invalid basearch {} on {}: cross-composes are not supported",
+                            treearch, arch),
                 ).into())
             } else {
                 Some(treearch)

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -96,6 +96,22 @@ fn treefile_parse_stream<R: io::Read>(
         }
     };
 
+    treefile.basearch = match (treefile.basearch, basearch) {
+        (Some(treearch), Some(arch)) => {
+            if treearch != arch {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("Invalid basearch: cross-composes are not supported"),
+                ).into())
+            } else {
+                Some(treearch)
+            }
+        }
+        (None, Some(arch)) => Some(arch.into()),
+        // really, only for tests do we not specify a basearch. let's just canonicalize to None
+        (_, None) => None,
+    };
+
     // Substitute ${basearch}
     treefile.treeref = match (basearch, treefile.treeref.take()) {
         (Some(basearch), Some(treeref)) => {
@@ -501,6 +517,8 @@ struct TreeComposeConfig {
     #[serde(rename = "ref")]
     #[serde(skip_serializing_if = "Option::is_none")]
     treeref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    basearch: Option<String>,
     // Optional rojig data
     #[serde(skip_serializing_if = "Option::is_none")]
     rojig: Option<Rojig>,

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -562,3 +562,16 @@ assert_files_hardlinked() {
         fatal "Files '$1' and '$2' are not hardlinked"
     fi
 }
+
+# $1  - json file
+# $2+ - assertions
+assert_jq() {
+    f=$1; shift
+    for expression in "$@"; do
+        if ! jq -e "${expression}" >/dev/null < $f; then
+            jq . < $f | sed -e 's/^/# /' >&2
+            echo 1>&2 "${expression} failed to match $f"
+            exit 1
+        fi
+    done
+}

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -354,15 +354,7 @@ vm_assert_layered_pkg() {
 # and asserts that they are true.
 vm_assert_status_jq() {
     vm_rpmostree status --json > status.json
-    vm_rpmostree status > status.txt
-    for expression in "$@"; do
-        if ! jq -e "${expression}" >/dev/null < status.json; then
-            jq . < status.json | sed -e 's/^/# /' >&2
-            echo 1>&2 "${expression} failed to match status.json"
-            cat status.txt
-            exit 1
-        fi
-    done
+    assert_jq status.json "$@"
 }
 
 vm_pending_is_staged() {

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -101,3 +101,7 @@ assert_file_has_content pkglist.txt 'systemd'
 assert_file_has_content pkglist.txt 'systemd-bootchart'
 echo "ok compose pkglist"
 }
+
+ostree --repo=${repobuild} cat ${treeref} /usr/share/rpm-ostree/treefile.json > treefile.json
+assert_jq treefile.json '.basearch == "x86_64"'
+echo "ok basearch"


### PR DESCRIPTION
Add a `basearch` key to the manifest. This can be used at compose time
to assert the architecture the compose is running on. Though my
motivation is for the common case where it gets omitted from the input
manifest and gets automatically added by rpm-ostree into
`/usr/share/rpm-ostree/treefile.json` for introspection on the client.

(The crucial part here is that the treefile created by rpm-ostree
remains deserializable into a `TreeComposeConfig`).

Closes: coreos/fedora-coreos-tracker#154