### PR TITLE
compose: Make initramfs.img world-readable

### DIFF
--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -435,6 +435,12 @@ process_kernel_and_initramfs (int            rootfs_dfd,
                                NULL, &dracut_host_tmpd,
                                &initramfs_tmpf, cancellable, error))
       return FALSE;
+    /* No reason to have the initramfs not be world-readable since
+     * it's server-side generated and shouldn't contain any secrets.
+     * https://github.com/coreos/coreos-assembler/pull/372#issuecomment-467620937
+     */
+    if (!glnx_fchmod (initramfs_tmpf.fd, 0644, error))
+      return FALSE;
   }
 
   /* We always tell rpmostree_finalize_kernel() to skip /boot, since we'll do a

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -56,7 +56,9 @@ for path in /boot /usr/lib/ostree-boot; do
 done
 vmlinuz_line=$(grep -o '/vmlinuz.*$' bootls.txt)
 kver=$(echo ${vmlinuz_line} | sed -e 's,^/vmlinuz-,,' -e 's,-[0-9a-f]*$,,')
-ostree --repo=${repobuild} ls ${treeref} /usr/lib/modules/${kver}/{vmlinuz,initramfs.img} >/dev/null
+ostree --repo=${repobuild} ls ${treeref} /usr/lib/modules/${kver}/vmlinuz >/dev/null
+ostree --repo=${repobuild} ls ${treeref} /usr/lib/modules/${kver}/initramfs.img >ls.txt
+assert_file_has_content ls.txt '^-00644'
 
 ostree --repo=${repobuild} ls -R ${treeref} /usr/share/man > manpages.txt
 assert_file_has_content manpages.txt man5/ostree.repo.5


### PR DESCRIPTION
There's nothing secret there, it's server side generated.
Ref: https://github.com/coreos/coreos-assembler/pull/372#issuecomment-467620937
