### PR TITLE
daemon/sysroot: Fix ActiveTransaction property

### DIFF
--- a/src/daemon/rpmostreed-sysroot.c
+++ b/src/daemon/rpmostreed-sysroot.c
@@ -898,8 +898,8 @@ rpmostreed_sysroot_set_txn (RpmostreedSysroot     *self,
       GDBusMethodInvocation *invocation = rpmostreed_transaction_get_invocation (self->transaction);
       g_autoptr(GVariant) v = g_variant_ref_sink (g_variant_new ("(sss)",
                                                                  g_dbus_method_invocation_get_method_name (invocation),
-                                                                 g_dbus_method_invocation_get_object_path (invocation),
-                                                                 g_dbus_method_invocation_get_sender (invocation)));
+                                                                 g_dbus_method_invocation_get_sender (invocation),
+                                                                 g_dbus_method_invocation_get_object_path (invocation)));
       rpmostree_sysroot_set_active_transaction ((RPMOSTreeSysroot*)self, v);
       rpmostree_sysroot_set_active_transaction_path ((RPMOSTreeSysroot*)self,
                                                      rpmostreed_transaction_get_client_address (self->transaction));


### PR DESCRIPTION
Minor regression from #1755. Noticed this after seeing the following in
the journal:

```
Mar 01 02:41:03 f29-ros rpm-ostree[3931]: Failed to GetConnectionUnixUser for client /org/projectatomic/rpmostree1/fedora_atomic: GDBus.Error:org.freedesktop.DBus.Error.NameHasNoOwner: Could not get UID of name '/org/projectatomic/rpmostree1/fedora_atomic': no such name
Mar 01 02:41:03 f29-ros rpm-ostree[3931]: Failed to GetConnectionUnixProcessID for client /org/projectatomic/rpmostree1/fedora_atomic: GDBus.Error:org.freedesktop.DBus.Error.NameHasNoOwner: Could not get PID of name '/org/projectatomic/rpmostree1/fedora_atomic': no such name
```