### PR TITLE
compose: Add `boot-location: modules` 

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -26,13 +26,9 @@ It supports the following parameters:
  * `selinux`: boolean, optional: Defaults to `true`.  If `false`, then
    no SELinux labeling will be performed on the server side.
 
- * `boot-location` (or `boot_location`): string, optional: Historically, ostree
-    put bootloader data in /boot.  However, this has a few flaws; it gets
-    shadowed at boot time, and also makes dealing with Anaconda installation
-    harder.  There are 3 possible values:
-    * "both": the default, kernel data goes in /boot and /usr/lib/ostree-boot
-    * "legacy": Now an alias for "both"; historically meant just "boot"
-    * "new": kernel data goes in /usr/lib/ostree-boot and /usr/lib/modules
+ * `boot-location` (or `boot_location`): string, optional: If specified, this value
+    must be "new".  Historically rpm-ostree supported multiple kernel locations;
+    this is no longer the case.
 
  * `etc-group-members`: Array of strings, optional: Unix groups in this
    list will be stored in `/etc/group` instead of `/usr/lib/group`.  Use

--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -26,9 +26,15 @@ It supports the following parameters:
  * `selinux`: boolean, optional: Defaults to `true`.  If `false`, then
    no SELinux labeling will be performed on the server side.
 
- * `boot-location` (or `boot_location`): string, optional: If specified, this value
-    must be "new".  Historically rpm-ostree supported multiple kernel locations;
-    this is no longer the case.
+ * `boot-location` (or `boot_location`): string, optional:
+    There are 2 possible values:
+    * "new": A misnomer, this value is no longer "new".  Kernel data
+      goes in `/usr/lib/ostree-boot` in addition to `/usr/lib/modules`.
+      This is the default; use it if you have a need to care about
+      upgrading from very old versions of libostree.
+    * "modules": Kernel data goes just in `/usr/lib/modules`.  Use
+      this for new systems, and systems that don't need to be upgraded
+      from very old libostree versions.
 
  * `etc-group-members`: Array of strings, optional: Unix groups in this
    list will be stored in `/etc/group` instead of `/usr/lib/group`.  Use

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -520,6 +520,8 @@ fn whitespace_split_packages(pkgs: &[String]) -> Vec<String> {
 enum BootLocation {
     #[serde(rename = "new")]
     New,
+    #[serde(rename = "modules")]
+    Modules,
 }
 
 impl Default for BootLocation {

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -518,17 +518,13 @@ fn whitespace_split_packages(pkgs: &[String]) -> Vec<String> {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 enum BootLocation {
-    #[serde(rename = "both")]
-    Both,
-    #[serde(rename = "legacy")]
-    Legacy,
     #[serde(rename = "new")]
     New,
 }
 
 impl Default for BootLocation {
     fn default() -> Self {
-        BootLocation::Both
+        BootLocation::New
     }
 }
 
@@ -820,13 +816,13 @@ remove-files:
         let treefile = append_and_parse(
             "
 gpg_key: foo
-boot_location: both
+boot_location: new
 default_target: bar
 automatic_version_prefix: baz
         ",
         );
         assert!(treefile.gpg_key.unwrap() == "foo");
-        assert!(treefile.boot_location.unwrap() == BootLocation::Both);
+        assert!(treefile.boot_location.unwrap() == BootLocation::New);
         assert!(treefile.default_target.unwrap() == "bar");
         assert!(treefile.automatic_version_prefix.unwrap() == "baz");
     }
@@ -836,13 +832,13 @@ automatic_version_prefix: baz
         let treefile = append_and_parse(
             "
 gpg-key: foo
-boot-location: both
+boot-location: new
 default-target: bar
 automatic-version-prefix: baz
         ",
         );
         assert!(treefile.gpg_key.unwrap() == "foo");
-        assert!(treefile.boot_location.unwrap() == BootLocation::Both);
+        assert!(treefile.boot_location.unwrap() == BootLocation::New);
         assert!(treefile.default_target.unwrap() == "bar");
         assert!(treefile.automatic_version_prefix.unwrap() == "baz");
     }

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -48,12 +48,10 @@ ostree --repo=${repobuild} show --print-metadata-key rpmostree.rpmmd-repos ${tre
 assert_file_has_content meta.txt 'id.*fedora.*timestamp'
 echo "ok metadata"
 
-for path in /boot /usr/lib/ostree-boot; do
-    ostree --repo=${repobuild} ls -R ${treeref} ${path} > bootls.txt
-    assert_file_has_content bootls.txt vmlinuz-
-    assert_file_has_content bootls.txt initramfs-
-    echo "ok boot files"
-done
+ostree --repo=${repobuild} ls -R ${treeref} /usr/lib/ostree-boot > bootls.txt
+assert_file_has_content bootls.txt vmlinuz-
+assert_file_has_content bootls.txt initramfs-
+echo "ok boot files"
 vmlinuz_line=$(grep -o '/vmlinuz.*$' bootls.txt)
 kver=$(echo ${vmlinuz_line} | sed -e 's,^/vmlinuz-,,' -e 's,-[0-9a-f]*$,,')
 ostree --repo=${repobuild} ls ${treeref} /usr/lib/modules/${kver}/vmlinuz >/dev/null

--- a/tests/compose-tests/test-boot-location-modules.sh
+++ b/tests/compose-tests/test-boot-location-modules.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -xeuo pipefail
+
+dn=$(cd $(dirname $0) && pwd)
+. ${dn}/libcomposetest.sh
+
+prepare_compose_test "bootlocation-modules"
+pysetjsonmember "boot_location" '"modules"'
+runcompose
+echo "ok compose"
+
+# Nothing in /boot (but it should exist)
+ostree --repo=${repobuild} ls -R ${treeref} /boot > bootls.txt
+cat >bootls-expected.txt <<EOF
+d00755 0 0      0 /boot
+EOF
+diff -u bootls{-expected,}.txt
+# Verify /usr/lib/ostree-boot
+ostree --repo=${repobuild} ls -R ${treeref} /usr/lib/ostree-boot > bootls.txt
+assert_not_file_has_content bootls.txt vmlinuz-
+assert_not_file_has_content bootls.txt initramfs-
+# And use the kver to find the kernel in /usr/lib/modules
+ostree --repo=${repobuild} ls -R ${treeref} /usr/lib/modules > modules-lsr.txt
+assert_file_has_content modules-lsr.txt '/vmlinuz$'
+assert_file_has_content modules-lsr.txt '/initramfs.img$'
+echo "ok boot location modules"

--- a/tests/compose-tests/test-installroot.sh
+++ b/tests/compose-tests/test-installroot.sh
@@ -26,10 +26,6 @@ integrationconf=usr/lib/tmpfiles.d/rpm-ostree-0-integration.conf
 assert_not_has_file ${instroot}-postprocess/${integrationconf}
 rpm-ostree compose postprocess ${instroot}-postprocess
 assert_has_file ${instroot}-postprocess/${integrationconf}
-# Without treefile, kernels end up in "both" mode
-ls ${instroot}-postprocess/boot > ls.txt
-assert_file_has_content ls.txt '^vmlinuz-'
-rm -f ls.txt
 ostree --repo=${repobuild} commit -b test-directcommit --selinux-policy ${instroot}-postprocess --tree=dir=${instroot}-postprocess
 echo "ok postprocess + direct commit"
 


### PR DESCRIPTION
The libostree support for handling `/usr/lib/ostree-boot` has
existed for over 4 years:

```
commit 37a059925f6b96d30190b65bee6bdde0ae1c6915
Commit:     Colin Walters <walters@verbum.org>
CommitDate: Sun Nov 30 23:14:05 2014 -0500

    deploy: Ensure that we can deploy using only /usr/lib/ostree-boot

```

I think we assume now that no one is now making *new* treecomposes and needs
a newer rpm-ostree and that they expect people to be able to use as an
upgrade target from a libostree that predates that.
