### PR TITLE
daemon: Add new ModifyYumRepo DBus API

### DIFF
--- a/src/daemon/org.projectatomic.rpmostree1.policy
+++ b/src/daemon/org.projectatomic.rpmostree1.policy
@@ -138,6 +138,17 @@
     </defaults>
   </action>
 
+  <action id="org.projectatomic.rpmostree1.repo-modify">
+    <description>Modify repository settings</description>
+    <message>Authentication is required to modify repository settings</message>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
   <action id="org.projectatomic.rpmostree1.client-management">
     <description>Register and unregister as a sysroot client</description>
     <message>Authentication is required to register as a sysroot client</message>

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -281,6 +281,13 @@
       <arg type="s" name="transaction_address" direction="out"/>
     </method>
 
+    <!-- Set options in yum .repo files -->
+    <method name="ModifyYumRepo">
+      <arg type="s" name="repo_id" direction="in"/>
+      <arg type="a{ss}" name="settings" direction="in"/>
+      <arg type="s" name="transaction_address" direction="out"/>
+    </method>
+
     <!-- Available modifiers:
          "set-refspec" (type 's')
          "set-revision" (type 's')

--- a/src/daemon/rpmostreed-transaction-types.h
+++ b/src/daemon/rpmostreed-transaction-types.h
@@ -117,6 +117,16 @@ rpmostreed_transaction_new_refresh_md (GDBusMethodInvocation *invocation,
                                        const char            *osname,
                                        GCancellable          *cancellable,
                                        GError               **error);
+
+RpmostreedTransaction *
+rpmostreed_transaction_new_modify_yum_repo (GDBusMethodInvocation *invocation,
+                                            OstreeSysroot         *sysroot,
+                                            const char            *osname,
+                                            const char            *repo_id,
+                                            GVariant              *settings,
+                                            GCancellable          *cancellable,
+                                            GError               **error);
+
 typedef enum {
   RPMOSTREE_TRANSACTION_KERNEL_ARG_FLAG_REBOOT = (1 << 0),
 } RpmOstreeTransactionKernelArgFlags;


### PR DESCRIPTION
This allows clients such as gnome-software to enable and disable
yum repositories.

Closes: #1771 

(Note that this is completely untested, ran out of time today and going to be offline the whole weekend. I'll just put it up in case someone wants to have an early look. Will test it and fix things up on Monday.)