### PR TITLE
build: Move completions to /usr/share

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,7 @@ m4_define_default(
      AS_IF([test -n "$$1"], [$4], [$5])])
 
 PKG_CHECK_VAR(BASH_COMPLETIONSDIR, [bash-completion], [completionsdir],,
-  BASH_COMPLETIONSDIR="${sysconfdir}/bash_completion.d")
+  BASH_COMPLETIONSDIR="${datadir}/bash-completion/completions")
 AC_SUBST(BASH_COMPLETIONSDIR)
 
 AC_PATH_PROG([cargo], [cargo])


### PR DESCRIPTION
rdgo is choking on this right now because, even though we added
`/usr/share/bash-completion` to the list of dirs to check in the spec
file[1], we don't have `bash-completion` installed in the buildroot, so
the `completionsdir` pkgconfig var isn't defined and we end up
defaulting to `/etc/bash_completion.d`.

el7's bash (not that it matters much now after #1785) is indeed new
enough to know that location. See also
https://github.com/ostreedev/ostree/pull/1083.

[1] https://src.fedoraproject.org/rpms/rpm-ostree/pull-request/30