### PR TITLE
Support layering rpms with files in /opt

### DIFF
--- a/src/libpriv/rpmostree-bwrap.c
+++ b/src/libpriv/rpmostree-bwrap.c
@@ -86,7 +86,7 @@ rpmostree_bwrap_set_inherit_stdin (RpmOstreeBwrap *bwrap)
   g_subprocess_launcher_set_flags (bwrap->launcher, G_SUBPROCESS_FLAGS_STDIN_INHERIT);
 }
 
-static void
+void
 rpmostree_bwrap_append_bwrap_argv (RpmOstreeBwrap *bwrap, ...)
 {
   va_list args;

--- a/src/libpriv/rpmostree-bwrap.h
+++ b/src/libpriv/rpmostree-bwrap.h
@@ -48,6 +48,7 @@ void rpmostree_bwrap_set_inherit_stdin (RpmOstreeBwrap *bwrap);
 void rpmostree_bwrap_var_tmp_tmpfs (RpmOstreeBwrap *bwrap);
 void rpmostree_bwrap_bind_read (RpmOstreeBwrap *bwrap, const char *src, const char *dest);
 void rpmostree_bwrap_bind_readwrite (RpmOstreeBwrap *bwrap, const char *src, const char *dest);
+void rpmostree_bwrap_append_bwrap_argv (RpmOstreeBwrap *bwrap, ...) G_GNUC_NULL_TERMINATED;
 void rpmostree_bwrap_append_child_argv (RpmOstreeBwrap *bwrap, ...) G_GNUC_NULL_TERMINATED;
 void rpmostree_bwrap_append_child_argva (RpmOstreeBwrap *bwrap, int argc, char **argv);
 

--- a/src/libpriv/rpmostree-scripts.c
+++ b/src/libpriv/rpmostree-scripts.c
@@ -337,6 +337,7 @@ run_script_in_bwrap_container (int rootfs_fd,
   gboolean created_run_ostree_booted = FALSE;
   glnx_autofd int stdout_fd = -1;
   glnx_autofd int stderr_fd = -1;
+  struct stat stbuf;
 
   /* TODO - Create a pipe and send this to bwrap so it's inside the
    * tmpfs.  Note the +1 on the path to skip the leading /.
@@ -387,6 +388,9 @@ run_script_in_bwrap_container (int rootfs_fd,
     goto out;
   /* Scripts can see a /var with compat links like alternatives */
   rpmostree_bwrap_var_tmp_tmpfs (bwrap);
+
+  if (glnx_fstatat (rootfs_fd, "usr/lib/opt", &stbuf, AT_SYMLINK_NOFOLLOW, NULL) && S_ISDIR(stbuf.st_mode))
+    rpmostree_bwrap_append_bwrap_argv (bwrap, "--symlink", "usr/lib/opt", "/opt", NULL);
 
   /* Add ostree-booted API; some scriptlets may work differently on OSTree systems; e.g.
    * akmods. Just create it manually; /run is usually tmpfs, but scriptlets shouldn't be

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -222,6 +222,8 @@ rpmostree_translate_path_for_ostree (const char *path)
    */
   else if (g_str_has_prefix (path, VAR_SELINUX_TARGETED_PATH))
     return g_strconcat ("usr/etc/selinux/targeted/", path + strlen (VAR_SELINUX_TARGETED_PATH), NULL);
+  else if (g_str_has_prefix (path, "opt/"))
+    return g_strconcat ("usr/lib/", path, NULL);
 
   return NULL;
 }


### PR DESCRIPTION
This adds support for layering rpms with files in /opt. The way we
do this is that when importing the rpms we rewrite any files in /opt
into /usr/lib/opt, and then we add back a symlink from the toplevels
of /opt into /usr/lib/opt via the per-package tmpfiles.d.

Also, in order for this to work with the %post script we bind /opt
to usr/lib/opt during the script execution.

This is enough to make layering chrome work.

This fixes https://github.com/projectatomic/rpm-ostree/issues/233