### PR TITLE
libpriv/kargs: Copy libostree patch to support KEYWORD kargs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,7 +40,7 @@ AM_CPPFLAGS += -DDATADIR='"$(datadir)"' \
 	-DSYSCONFDIR='"$(sysconfdir)"' \
 	-DRPM_OSTREE_FEATURES='"$(RPM_OSTREE_FEATURES)"' \
 	-DRPM_OSTREE_GITREV='"$(RPM_OSTREE_GITREV)"' \
-	-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_50 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_50
+	-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_56 -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_56
 # Keep this in sync with the AM_CFLAGS in libostree; see
 # that project for more information about e.g. -fno-strict-aliasing
 AM_CFLAGS += -std=gnu11 -fno-strict-aliasing $(WARN_CFLAGS)

--- a/src/libpriv/rpmostree-kargs-process.c
+++ b/src/libpriv/rpmostree-kargs-process.c
@@ -373,7 +373,7 @@ _ostree_kernel_args_delete (OstreeKernelArgs *kargs,
  **/
 gboolean
 _ostree_kernel_args_delete_key_entry (OstreeKernelArgs *kargs,
-                                      char             *key,
+                                      const char       *key,
                                       GError          **error)
 {
   if (!g_hash_table_remove (kargs->table, key))

--- a/src/libpriv/rpmostree-kargs-process.c
+++ b/src/libpriv/rpmostree-kargs-process.c
@@ -17,6 +17,9 @@
  * Boston, MA 02111-1307, USA.
  */
 
+/* XXX: This file is lifted from src/libostree/ostree-kernel-args.c, though there are some
+ * new APIs. Should upstream those and dedupe. */
+
 #include "config.h"
 
 #include "rpmostree-kargs-process.h"
@@ -35,21 +38,12 @@ split_keyeq (char *arg)
   char *eq;
 
   eq = strchr (arg, '=');
-  if (eq)
-    {
-      /* Note key/val are in one malloc block,
-       * so we don't free val...
-       */
-      *eq = '\0';
-      return eq+1;
-    }
-  else
-    {
-      /* ...and this allows us to insert a constant
-       * string.
-       */
-      return "";
-    }
+  if (eq == NULL)
+    return NULL;
+
+  // Note: key/val are in a single allocation block, so we don't free val.
+  *eq = '\0';
+  return eq+1;
 }
 
 static gboolean
@@ -573,7 +567,10 @@ _ostree_kernel_args_to_strv (OstreeKernelArgs *kargs)
         {
           const char *value = values->pdata[j];
 
-          g_ptr_array_add (strv, g_strconcat (key, "=", value, NULL));
+          if (value == NULL)
+            g_ptr_array_add (strv, g_strconcat (key, NULL));
+          else
+            g_ptr_array_add (strv, g_strconcat (key, "=", value, NULL));
         }
     }
   g_ptr_array_add (strv, NULL);
@@ -605,14 +602,12 @@ _ostree_kernel_args_to_string (OstreeKernelArgs *kargs)
           else
             g_string_append_c (buf, ' ');
 
-          if (value && *value)
+          g_string_append (buf, key);
+          if (value != NULL)
             {
-              g_string_append (buf, key);
               g_string_append_c (buf, '=');
               g_string_append (buf, value);
             }
-          else
-            g_string_append (buf, key);
         }
     }
 

--- a/src/libpriv/rpmostree-kargs-process.h
+++ b/src/libpriv/rpmostree-kargs-process.h
@@ -72,7 +72,7 @@ gboolean _ostree_kernel_args_delete (OstreeKernelArgs *kargs,
 
 
 gboolean _ostree_kernel_args_delete_key_entry (OstreeKernelArgs *kargs,
-                                               char             *key,
+                                               const char       *key,
                                                GError          **error);
 
 

--- a/src/libpriv/rpmostree-kargs-process.h
+++ b/src/libpriv/rpmostree-kargs-process.h
@@ -25,21 +25,6 @@ G_BEGIN_DECLS
 
 typedef struct _OstreeKernelArgs OstreeKernelArgs;
 
-/*
- * Note: this is newly added to the API:
- * This flag is used to track the 'validity' and status of the arguments
- *
- * OSTREE_KERNEL_ARG_KEY_ONE_VALUE: means there is only one value associated with the key
- * OSTREE_KERNEL_ARG_REPLACE_NO_SECOND_SPLIT: means to tell 'replace function', the arg only need to be split once
- * OSTREE_KERNEL_ARG_FOUND_KEY_MULTI_VALUE: means the key found has multiple values associated with it
- *
- **/
-typedef enum {
-  OSTREE_KERNEL_ARG_KEY_ONE_VALUE = (1 << 0),
-  OSTREE_KERNEL_ARG_FOUND_KEY_MULTI_VALUE = (1 << 1),
-  OSTREE_KERNEL_ARG_REPLACE_NO_SECOND_SPLIT = (1 << 2),
-} OstreeKernelArgQueryFlag;
-
 GHashTable* _ostree_kernel_arg_get_kargs_table (OstreeKernelArgs *kargs);
 GPtrArray* _ostree_kernel_arg_get_key_array (OstreeKernelArgs *kargs);
 

--- a/tests/check/test-kargs.c
+++ b/tests/check/test-kargs.c
@@ -16,12 +16,13 @@ test_kargs_delete (void)
 {
   g_autoptr(GError) error = NULL;
   gboolean ret;
-  int key_index = 0;
   __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *karg = _ostree_kernel_args_new ();
 
   _ostree_kernel_args_append (karg, "single_key=test");
   _ostree_kernel_args_append (karg, "test=firstval");
   _ostree_kernel_args_append (karg, "test=secondval");
+  _ostree_kernel_args_append (karg, "test=");
+  _ostree_kernel_args_append (karg, "test");
 
   /* Delete a non-existant key should fail */
   ret = _ostree_kernel_args_delete (karg, "non_existant_key", &error);
@@ -41,21 +42,43 @@ test_kargs_delete (void)
   g_assert_error (error, G_IO_ERROR, G_IO_ERROR_FAILED);
   g_clear_error (&error);
 
+  /* Delete a key with only one value should fail if the value doesn't match */
+  ret = _ostree_kernel_args_delete (karg, "single_key=non_existent_value", &error);
+  g_assert (!ret);
+  g_assert_error (error, G_IO_ERROR, G_IO_ERROR_FAILED);
+  g_clear_error (&error);
+
   /* Delete a key with only one value should succeed by only specifying key */
   ret = _ostree_kernel_args_delete (karg, "single_key", &error);
   g_assert_no_error (error);
   g_assert (ret);
   /* verify the value array is properly updated */
   GPtrArray *kargs_array = _ostree_kernel_arg_get_key_array (karg);
-  g_assert (!_ostree_ptr_array_find (kargs_array, "single_key", &key_index));
+  g_assert (!g_ptr_array_find_with_equal_func (kargs_array, "single_key", g_str_equal, NULL));
   g_assert (!check_string_existance (karg, "single_key"));
 
-  /* Delete a key/value pair by specifying correct key=value should succeed */
+  /* Delete specific key/value pair */
   ret = _ostree_kernel_args_delete (karg, "test=secondval", &error);
   g_assert_no_error (error);
   g_assert (ret);
   g_assert (!check_string_existance (karg, "test=secondval"));
 
+  /* Delete key/value pair with empty string value */
+  ret = _ostree_kernel_args_delete (karg, "test=", &error);
+  g_assert_no_error (error);
+  g_assert (ret);
+  g_assert (!check_string_existance (karg, "test="));
+
+  ret = _ostree_kernel_args_delete (karg, "test=firstval", &error);
+  g_assert_no_error (error);
+  g_assert (ret);
+  g_assert (!check_string_existance (karg, "test=firstval"));
+
+  /* And now we should be able to delete the last key */
+  ret = _ostree_kernel_args_delete (karg, "test", &error);
+  g_assert_no_error (error);
+  g_assert (ret);
+  g_assert (!check_string_existance (karg, "test"));
 }
 
 static void
@@ -93,6 +116,7 @@ test_kargs_replace (void)
   ret = _ostree_kernel_args_new_replace (karg, "single_key=newvalue", &error);
   g_assert_no_error (error);
   g_assert (ret);
+  g_assert (!check_string_existance (karg, "single_key"));
   g_assert (check_string_existance (karg, "single_key=newvalue"));
 
   /* Replace with input key=value=newvalue if key and value both
@@ -101,9 +125,16 @@ test_kargs_replace (void)
   ret = _ostree_kernel_args_new_replace (karg, "test=firstval=newval", &error);
   g_assert_no_error (error);
   g_assert (ret);
+  g_assert (!check_string_existance (karg, "test=firstval"));
   g_assert (check_string_existance (karg, "test=newval"));
 }
 
+static gboolean
+strcmp0_equal (gconstpointer v1,
+               gconstpointer v2)
+{
+  return g_strcmp0 (v1, v2) == 0;
+}
 
 /* In this function, we want to verify that _ostree_kernel_args_append
  * and _ostree_kernel_args_to_string is correct. After that
@@ -113,16 +144,12 @@ static void
 test_kargs_append (void)
 
 {
-  /* Note, here we assume the _ostree_ptr_array_find has
-   * a working functionality, as it shares a similar logic
-   * as the GLib function, and easy to tell the correctness of it
-   */
-  int test_num = 0;
   __attribute__((cleanup(_ostree_kernel_args_cleanup))) OstreeKernelArgs *append_arg = _ostree_kernel_args_new ();
   /* Some valid cases (key=value) pair */
   _ostree_kernel_args_append (append_arg, "test=valid");
   _ostree_kernel_args_append (append_arg, "test=secondvalid");
-  /* Add some 'invalid cases' */
+  _ostree_kernel_args_append (append_arg, "test=");
+  _ostree_kernel_args_append (append_arg, "test");
   _ostree_kernel_args_append (append_arg, "second_test");
 
   /* We loops through the kargs inside table to verify
@@ -132,18 +159,24 @@ test_kargs_append (void)
   GHashTable *kargs_table = _ostree_kernel_arg_get_kargs_table (append_arg);
   GLNX_HASH_TABLE_FOREACH_KV (kargs_table, const char*, key, GPtrArray*, value_array)
     {
-      if ( g_strcmp0 (key, "test") == 0)
+      if (g_str_equal (key, "test"))
         {
-          g_assert (_ostree_ptr_array_find (value_array, "valid", &test_num));
-          g_assert (_ostree_ptr_array_find (value_array, "secondvalid", &test_num));
+          g_assert (g_ptr_array_find_with_equal_func (value_array, "valid", strcmp0_equal, NULL));
+          g_assert (g_ptr_array_find_with_equal_func (value_array, "secondvalid", strcmp0_equal, NULL));
+          g_assert (g_ptr_array_find_with_equal_func (value_array, "", strcmp0_equal, NULL));
+          g_assert (g_ptr_array_find_with_equal_func (value_array, NULL, strcmp0_equal, NULL));
         }
       else
-        g_assert (_ostree_ptr_array_find (value_array, "", &test_num));
+        {
+          g_assert_cmpstr (key, ==, "second_test");
+          g_assert (g_ptr_array_find_with_equal_func (value_array, NULL, strcmp0_equal, NULL));
+        }
     }
+
   /* verify the value array is properly updated */
   GPtrArray *kargs_array = _ostree_kernel_arg_get_key_array (append_arg);
-  g_assert (_ostree_ptr_array_find (kargs_array, "test", &test_num));
-  g_assert (_ostree_ptr_array_find (kargs_array, "second_test", &test_num));
+  g_assert (g_ptr_array_find_with_equal_func (kargs_array, "test", g_str_equal, NULL));
+  g_assert (g_ptr_array_find_with_equal_func (kargs_array, "second_test", g_str_equal, NULL));
 
   /* Up till this point, we verified that the above was all correct, we then
    * check _ostree_kernel_args_to_string has the right result
@@ -151,9 +184,11 @@ test_kargs_append (void)
   g_autofree gchar* kargs_str = _ostree_kernel_args_to_string (append_arg);
   g_auto(GStrv) kargs_list = g_strsplit(kargs_str, " ", -1);
   g_assert (g_strv_contains ((const char* const *)kargs_list, "test=valid"));
-  g_assert (g_strv_contains ((const char* const *)kargs_list, "second_test"));
   g_assert (g_strv_contains ((const char* const *)kargs_list, "test=secondvalid"));
-  g_assert_cmpint (3, ==, g_strv_length (kargs_list));
+  g_assert (g_strv_contains ((const char* const *)kargs_list, "test="));
+  g_assert (g_strv_contains ((const char* const *)kargs_list, "test"));
+  g_assert (g_strv_contains ((const char* const *)kargs_list, "second_test"));
+  g_assert_cmpint (5, ==, g_strv_length (kargs_list));
 
 }
 

--- a/tests/check/test-kargs.c
+++ b/tests/check/test-kargs.c
@@ -43,8 +43,8 @@ test_kargs_delete (void)
 
   /* Delete a key with only one value should succeed by only specifying key */
   ret = _ostree_kernel_args_delete (karg, "single_key", &error);
-  g_assert (ret);
   g_assert_no_error (error);
+  g_assert (ret);
   /* verify the value array is properly updated */
   GPtrArray *kargs_array = _ostree_kernel_arg_get_key_array (karg);
   g_assert (!_ostree_ptr_array_find (kargs_array, "single_key", &key_index));
@@ -52,8 +52,8 @@ test_kargs_delete (void)
 
   /* Delete a key/value pair by specifying correct key=value should succeed */
   ret = _ostree_kernel_args_delete (karg, "test=secondval", &error);
-  g_assert (ret);
   g_assert_no_error (error);
+  g_assert (ret);
   g_assert (!check_string_existance (karg, "test=secondval"));
 
 }
@@ -91,16 +91,16 @@ test_kargs_replace (void)
    * Also note, we also allow ''(empty string) valid to be a value
    */
   ret = _ostree_kernel_args_new_replace (karg, "single_key=newvalue", &error);
-  g_assert (ret);
   g_assert_no_error (error);
+  g_assert (ret);
   g_assert (check_string_existance (karg, "single_key=newvalue"));
 
   /* Replace with input key=value=newvalue if key and value both
    * exist, the action should succeed
    */
   ret = _ostree_kernel_args_new_replace (karg, "test=firstval=newval", &error);
-  g_assert (ret);
   g_assert_no_error (error);
+  g_assert (ret);
   g_assert (check_string_existance (karg, "test=newval"));
 }
 

--- a/tests/vmcheck/test-kernel-args.sh
+++ b/tests/vmcheck/test-kernel-args.sh
@@ -57,7 +57,7 @@ echo "ok delete a single key/value pair"
 if vm_rpmostree kargs --delete APPENDARG 2>err.txt; then
     assert_not_reached "Delete A key with multiple values unexpectedly succeeded"
 fi
-assert_file_has_content err.txt "Unable to delete argument 'APPENDARG' with multiple values"
+assert_file_has_content err.txt "Multiple values for key 'APPENDARG' found"
 echo "ok failed to delete key with multiple values"
 
 vm_kargs_now --delete APPENDARG=VALAPPEND
@@ -82,7 +82,7 @@ echo "ok replacing one key/value pair"
 if vm_rpmostree kargs --replace=REPLACE_MULTI_TEST=ERR 2>err.txt; then
     assert_not_reached "Replace a key with multiple values unexpectedly succeeded"
 fi
-assert_file_has_content err.txt "Unable to replace argument 'REPLACE_MULTI_TEST' with multiple values"
+assert_file_has_content err.txt "Multiple values for key 'REPLACE_MULTI_TEST' found"
 echo "ok failed to replace key with multiple values"
 
 # Test for replacing  one of the values for multi value keys


### PR DESCRIPTION
This is essentially a copy of
https://github.com/ostreedev/ostree/pull/1785 to our private copy of the
kargs API. Should really dedupe those...

The really confusing part though was that that patch was intended to fix
the `rpm-ostree kargs --append EMPTYKEY=` case (#1706), yet the
`rpmostree kargs --append KEYWORD` case (#1779) wasn't also fixed, even
though that same ostree patch clearly fixes and tests for that too.

To make a long story short, we were passing buggy kargs to ostree, which
before that patch, had itself buggy kargs parsing which conveniently
fixed back the kargs we passed for the `KEYWORD` case.

Closes: #1779