### PR TITLE
compose: Add --download-only-rpms

### DIFF
--- a/tests/compose
+++ b/tests/compose
@@ -47,8 +47,7 @@ if test -z "${RPMOSTREE_COMPOSE_CACHEONLY:-}"; then
     setup_rpmmd_repos ${dn}/composedata
     ostree --repo=${tmp_repo} init --mode=bare-user
     # Ensure all subsequent tests have the RPMs
-    mkdir -p ${test_compose_datadir}/fedora-local
-    mkdir ${test_compose_datadir}/cache
+    mkdir -p ${test_compose_datadir}/{fedora-local,cache}
     rpm-ostree compose --repo=${tmp_repo} tree --download-only-rpms --cachedir=${test_compose_datadir}/cache ${dn}/composedata/fedora-base.json
     find ${test_compose_datadir}/cache/ -name '*.rpm' | while read f; do
         mv $f ${test_compose_datadir}/fedora-local

--- a/tests/compose
+++ b/tests/compose
@@ -44,12 +44,16 @@ test ${uid} = ${datadir_owner}
 echo "Preparing compose tests... $(date)"
 tmp_repo=${test_compose_datadir}/tmp-repo
 if test -z "${RPMOSTREE_COMPOSE_CACHEONLY:-}"; then
-    mkdir -p ${test_compose_datadir}/cache
     setup_rpmmd_repos ${dn}/composedata
     ostree --repo=${tmp_repo} init --mode=bare-user
-    # We use rpm-ostree in dry-run --cachedir mode
-    rpm-ostree compose --repo=${tmp_repo} tree --download-only --cachedir=${test_compose_datadir}/cache ${dn}/composedata/fedora-base.json
-    (cd ${test_compose_datadir}/cache && createrepo_c .)
+    # Ensure all subsequent tests have the RPMs
+    mkdir -p ${test_compose_datadir}/fedora-local
+    mkdir ${test_compose_datadir}/cache
+    rpm-ostree compose --repo=${tmp_repo} tree --download-only-rpms --cachedir=${test_compose_datadir}/cache ${dn}/composedata/fedora-base.json
+    find ${test_compose_datadir}/cache/ -name '*.rpm' | while read f; do
+        mv $f ${test_compose_datadir}/fedora-local
+    done
+    (cd ${test_compose_datadir}/fedora-local && createrepo_c .)
 fi
 echo "Done preparing compose tests! $(date)"
 rm ${tmp_repo} -rf

--- a/tests/compose-tests/libcomposetest.sh
+++ b/tests/compose-tests/libcomposetest.sh
@@ -40,7 +40,7 @@ prepare_compose_test() {
     rm -f composedata/*.repo
     cat > composedata/fedora-local.repo <<EOF
 [fedora-local]
-baseurl=${test_compose_datadir}/cache
+baseurl=${test_compose_datadir}/fedora-local
 enabled=1
 gpgcheck=0
 EOF


### PR DESCRIPTION
Prep for making `--unified-core` the only path.  It turns
out our compose testsuite has a lot of hardcoded ideas about
how the two paths work.  The rojig tests in particular need
cached RPMs, so we can't just rely on caching the pkgcache repo.

Add a `--download-only-rpms` that always returns RPMs, and doesn't
import into the pkgcache repo.
