### PR TITLE
rebase: Support identical checksum rebases

### DIFF
--- a/src/daemon/rpmostreed-utils.c
+++ b/src/daemon/rpmostreed-utils.c
@@ -202,16 +202,6 @@ rpmostreed_refspec_parse_partial (const gchar *new_provided_refspec,
         }
     }
 
-  if (g_strcmp0 (origin_remote, remote) == 0 &&
-      g_strcmp0 (origin_ref, ref) == 0)
-    {
-      g_set_error (error, RPM_OSTREED_ERROR,
-                   RPM_OSTREED_ERROR_INVALID_REFSPEC,
-                   "Old and new refs are equal: %s:%s",
-                   remote, ref);
-      return FALSE;
-    }
-
   if (remote == NULL)
       *out_refspec = g_steal_pointer (&ref);
   else


### PR DESCRIPTION
Change things to only throw this error for non-checksum rebases; for
RHEL CoreOS + https://github.com/openshift/pivot/
we've had it happen that the same ostree commit can end up
in separate oscontainers.  We want to support changing
the custom origin that might point to the same commit.
