### PR TITLE
core: Also suggest `upgrade` for base/layered split

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1633,7 +1633,8 @@ check_goal_solution (RpmOstreeContext *self,
           }
         rpmostree_output_message ("This likely means that some of your layered packages "
                                   "have requirements on newer or older versions of some "
-                                  "base packages. `rpm-ostree cleanup -m` may help. For "
+                                  "base packages. Doing `rpm-ostree cleanup -m` and "
+                                  "`rpm-ostree upgrade` first may help. For "
                                   "more details, see: "
                                   "https://github.com/projectatomic/rpm-ostree/issues/415");
 


### PR DESCRIPTION
In the case of Fedora Silverblue which has daily composes, doing
`rpm-ostree cleanup -m && rpm-ostree upgrade` would work around the
majority of incidences here.

It doesn't apply if one is pinning to a specific version for whatever
reason, but that's not the common case.