### PR TITLE
Pass full command-line and use as transaction title

### DIFF
--- a/src/app/rpmostree-builtin-deploy.c
+++ b/src/app/rpmostree-builtin-deploy.c
@@ -117,6 +117,7 @@ rpmostree_builtin_deploy (int            argc,
       g_variant_dict_insert (&dict, "allow-downgrade", "b", TRUE);
       g_variant_dict_insert (&dict, "cache-only", "b", opt_cache_only);
       g_variant_dict_insert (&dict, "download-only", "b", opt_download_only);
+      g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
       g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
       /* Use newer D-Bus API only if we have to so we maintain coverage. */

--- a/src/app/rpmostree-builtin-finalize-deployment.c
+++ b/src/app/rpmostree-builtin-finalize-deployment.c
@@ -82,6 +82,7 @@ rpmostree_builtin_finalize_deployment (int             argc,
     g_variant_dict_insert (&dict, "checksum", "s", checksum);
   g_variant_dict_insert (&dict, "allow-missing-checksum", "b", opt_allow_missing);
   g_variant_dict_insert (&dict, "allow-unlocked", "b", opt_allow_unlocked);
+  g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
   g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
   g_autofree char *transaction_address = NULL;

--- a/src/app/rpmostree-builtin-initramfs.c
+++ b/src/app/rpmostree-builtin-initramfs.c
@@ -135,6 +135,7 @@ rpmostree_builtin_initramfs (int             argc,
       GVariantDict dict;
       g_variant_dict_init (&dict, NULL);
       g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
+      g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
       g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
       g_autofree char *transaction_address = NULL;

--- a/src/app/rpmostree-builtin-kargs.c
+++ b/src/app/rpmostree-builtin-kargs.c
@@ -272,6 +272,7 @@ rpmostree_builtin_kargs (int            argc,
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
   g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
+  g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
   g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
   if (opt_editor)

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -167,6 +167,7 @@ rpmostree_builtin_rebase (int             argc,
   g_variant_dict_insert (&dict, "cache-only", "b", opt_cache_only);
   g_variant_dict_insert (&dict, "download-only", "b", opt_download_only);
   g_variant_dict_insert (&dict, "skip-purge", "b", opt_skip_purge);
+  g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
   if (opt_custom_origin_url)
     {
       if (!opt_custom_origin_description)

--- a/src/app/rpmostree-builtin-reset.c
+++ b/src/app/rpmostree-builtin-reset.c
@@ -100,6 +100,7 @@ rpmostree_builtin_reset (int             argc,
   g_variant_dict_insert (&dict, "no-overrides", "b", opt_overrides);
   g_variant_dict_insert (&dict, "no-initramfs", "b", opt_initramfs);
   g_variant_dict_insert (&dict, "cache-only", "b", cache_only);
+  g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
   g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
   if (!rpmostree_update_deployment (os_proxy, NULL, NULL, install_pkgs, uninstall_pkgs,

--- a/src/app/rpmostree-builtin-types.h
+++ b/src/app/rpmostree-builtin-types.h
@@ -54,6 +54,7 @@ struct RpmOstreeCommand {
  */
 struct RpmOstreeCommandInvocation {
   RpmOstreeCommand *command;
+  const char *command_line;
   int exit_code;
 };
 G_END_DECLS

--- a/src/app/rpmostree-builtin-upgrade.c
+++ b/src/app/rpmostree-builtin-upgrade.c
@@ -134,6 +134,7 @@ rpmostree_builtin_upgrade (int             argc,
       GVariantDict dict;
       g_variant_dict_init (&dict, NULL);
       g_variant_dict_insert (&dict, "mode", "s", check_or_preview ? "check" : "auto");
+      g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
       /* override default of TRUE if we're handling --check/--preview for backcompat,
        * or we're *are* handling --trigger-automatic-update-policy, but on a tty */
       if (check_or_preview || glnx_stdout_is_tty ())
@@ -165,6 +166,7 @@ rpmostree_builtin_upgrade (int             argc,
       g_variant_dict_insert (&dict, "cache-only", "b", opt_cache_only);
       g_variant_dict_insert (&dict, "download-only", "b", opt_download_only);
       g_variant_dict_insert (&dict, "lock-finalization", "b", opt_lock_finalization);
+      g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
       g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
       /* Use newer D-Bus API only if we have to. */

--- a/src/app/rpmostree-override-builtins.c
+++ b/src/app/rpmostree-override-builtins.c
@@ -58,6 +58,7 @@ static GOptionEntry remove_option_entries[] = {
 
 static gboolean
 handle_override (RPMOSTreeSysroot  *sysroot_proxy,
+                 RpmOstreeCommandInvocation *invocation,
                  const char *const *override_remove,
                  const char *const *override_replace,
                  const char *const *override_reset,
@@ -81,6 +82,7 @@ handle_override (RPMOSTreeSysroot  *sysroot_proxy,
   g_variant_dict_insert (&dict, "no-pull-base", "b", TRUE);
   g_variant_dict_insert (&dict, "dry-run", "b", opt_dry_run);
   g_variant_dict_insert (&dict, "no-overrides", "b", opt_reset_all);
+  g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
   g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
   g_autoptr(GVariant) previous_deployment = rpmostree_os_dup_default_deployment (os_proxy);
@@ -166,7 +168,7 @@ rpmostree_override_builtin_replace (int argc, char **argv,
   argv++; argc--;
   argv[argc] = NULL;
 
-  return handle_override (sysroot_proxy,
+  return handle_override (sysroot_proxy, invocation,
                           opt_remove_pkgs, (const char *const*)argv, NULL,
                           cancellable, error);
 }
@@ -209,7 +211,7 @@ rpmostree_override_builtin_remove (int argc, char **argv,
   argv++; argc--;
   argv[argc] = NULL;
 
-  return handle_override (sysroot_proxy,
+  return handle_override (sysroot_proxy, invocation,
                           (const char *const*)argv, opt_replace_pkgs, NULL,
                           cancellable, error);
 }
@@ -258,7 +260,7 @@ rpmostree_override_builtin_reset (int argc, char **argv,
   argv++; argc--;
   argv[argc] = NULL;
 
-  return handle_override (sysroot_proxy,
+  return handle_override (sysroot_proxy, invocation,
                           NULL, NULL, (const char *const*)argv,
                           cancellable, error);
 }

--- a/src/app/rpmostree-pkg-builtins.c
+++ b/src/app/rpmostree-pkg-builtins.c
@@ -96,6 +96,7 @@ pkg_change (RpmOstreeCommandInvocation *invocation,
   g_variant_dict_insert (&dict, "allow-inactive", "b", opt_allow_inactive);
   g_variant_dict_insert (&dict, "no-layering", "b", opt_uninstall_all);
   g_variant_dict_insert (&dict, "idempotent-layering", "b", opt_idempotent);
+  g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
   g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 
   gboolean met_local_pkg = FALSE;

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -343,6 +343,9 @@
             Prevent automatic deployment finalization on shutdown.
             Clients must manually call FinalizeDeployment() when ready
             to apply the update and reboot.
+         "initiating-command-line" (type 's')
+            Mark the transaction as being initiated by the given command.
+            This is used for the transaction title and journal entries.
     -->
     <method name="UpdateDeployment">
       <arg type="a{sv}" name="modifiers" direction="in"/>

--- a/src/daemon/rpmostree-sysroot-upgrader.c
+++ b/src/daemon/rpmostree-sysroot-upgrader.c
@@ -59,6 +59,7 @@ struct RpmOstreeSysrootUpgrader {
   OstreeRepo *repo;
   char *osname;
   RpmOstreeSysrootUpgraderFlags flags;
+  char *command_line;
 
   OstreeDeployment *cfg_merge_deployment;
   OstreeDeployment *origin_merge_deployment;
@@ -204,6 +205,7 @@ rpmostree_sysroot_upgrader_finalize (GObject *object)
   g_clear_object (&self->sysroot);
   g_clear_object (&self->repo);
   g_free (self->osname);
+  g_free (self->command_line);
 
   g_clear_object (&self->cfg_merge_deployment);
   g_clear_object (&self->origin_merge_deployment);
@@ -1227,6 +1229,7 @@ rpmostree_sysroot_upgrader_set_kargs (RpmOstreeSysrootUpgrader *self,
 /**
  * rpmostree_sysroot_upgrader_deploy:
  * @self: Self
+ * @initiating_command_line (nullable): command-line that initiated the deployment
  * @out_deployment: (out) (optional): return location for new deployment
  * @cancellable: Cancellable
  * @error: Error
@@ -1236,6 +1239,7 @@ rpmostree_sysroot_upgrader_set_kargs (RpmOstreeSysrootUpgrader *self,
  */
 gboolean
 rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
+                                   const char               *initiating_command_line,
                                    OstreeDeployment        **out_deployment,
                                    GCancellable             *cancellable,
                                    GError                  **error)

--- a/src/daemon/rpmostree-sysroot-upgrader.h
+++ b/src/daemon/rpmostree-sysroot-upgrader.h
@@ -127,10 +127,11 @@ rpmostree_sysroot_upgrader_pull_repos (RpmOstreeSysrootUpgrader  *self,
 
 
 gboolean
-rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader  *self,
-                                   OstreeDeployment         **out_deployment,
-                                   GCancellable           *cancellable,
-                                   GError                **error);
+rpmostree_sysroot_upgrader_deploy (RpmOstreeSysrootUpgrader *self,
+                                   const char               *initiating_command_line,
+                                   OstreeDeployment        **out_deployment,
+                                   GCancellable             *cancellable,
+                                   GError                  **error);
 
 void
 rpmostree_sysroot_upgrader_set_kargs (RpmOstreeSysrootUpgrader *self,

--- a/src/libpriv/rpmostree-util.c
+++ b/src/libpriv/rpmostree-util.c
@@ -1240,7 +1240,7 @@ rpmostree_maybe_shell_quote (const char *s)
   static GRegex *safe_chars_regex;
   if (g_once_init_enter (&regex_initialized))
     {
-      safe_chars_regex = g_regex_new ("^[[:alnum:]-._]+$", 0, 0, NULL);
+      safe_chars_regex = g_regex_new ("^[[:alnum:]-._/=]+$", 0, 0, NULL);
       g_assert (safe_chars_regex);
       g_once_init_leave (&regex_initialized, 1);
     }

--- a/tests/vmcheck/test-initramfs.sh
+++ b/tests/vmcheck/test-initramfs.sh
@@ -46,7 +46,9 @@ fi
 assert_file_has_content err.txt "arg.*used with.*enable"
 echo "ok initramfs state"
 
+vm_status_watch_start
 vm_rpmostree initramfs --enable > initramfs.txt
+vm_status_watch_check "Transaction: initramfs --enable"
 assert_file_has_content initramfs.txt "Initramfs regeneration.*enabled"
 vm_rpmostree initramfs > initramfs.txt
 assert_file_has_content initramfs.txt "Initramfs regeneration.*enabled"

--- a/tests/vmcheck/test-kernel-args.sh
+++ b/tests/vmcheck/test-kernel-args.sh
@@ -67,7 +67,9 @@ assert_file_has_content tmp_conf.txt 'APPENDARG=2NDAPPEND'
 echo "ok delete a single key/value pair from multi valued key pairs"
 
 # Test for rpm-ostree kargs replace
+vm_status_watch_start
 vm_rpmostree kargs --append=REPLACE_TEST=TEST --append=REPLACE_MULTI_TEST=TEST --append=REPLACE_MULTI_TEST=NUMBERTWO
+vm_status_watch_check "Transaction: kargs --append=REPLACE_TEST=TEST --append=REPLACE_MULTI_TEST=TEST --append=REPLACE_MULTI_TEST=NUMBERTWO"
 
 # Test for replacing key/value pair with  only one value
 vm_rpmostree kargs --replace=REPLACE_TEST=HELLO

--- a/tests/vmcheck/test-layering-basic-1.sh
+++ b/tests/vmcheck/test-layering-basic-1.sh
@@ -122,7 +122,9 @@ vm_rpmostree install foo-1.0 --idempotent
 assert_streq $old_pending $(vm_get_pending_csum)
 echo "ok idempotent install"
 
+vm_status_watch_start
 vm_rpmostree uninstall foo-1.0
+vm_status_watch_check "Transaction: uninstall foo-1.0"
 
 # Test idempotent uninstall
 old_pending=$(vm_get_pending_csum)

--- a/tests/vmcheck/test-layering-unified.sh
+++ b/tests/vmcheck/test-layering-unified.sh
@@ -39,7 +39,9 @@ bar_rpm=/var/tmp/vmcheck/yumrepo/packages/x86_64/bar-1.0-1.x86_64.rpm
 # UPGRADE
 
 commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck)
+vm_status_watch_start
 vm_rpmostree upgrade --install bar --install $foo_rpm
+vm_status_watch_check "Transaction: upgrade --install bar --install $foo_rpm"
 vm_assert_status_jq \
     ".deployments[0][\"base-checksum\"] == \"${commit}\"" \
     '.deployments[0]["packages"]|length == 1' \
@@ -54,7 +56,9 @@ echo "ok upgrade with bar and local foo"
 
 commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck \
            --add-metadata-string=version=SUPADUPAVERSION)
+vm_status_watch_start
 vm_rpmostree deploy SUPADUPAVERSION --install foo --install $bar_rpm
+vm_status_watch_check "Transaction: deploy SUPADUPAVERSION --install foo --install $bar_rpm"
 vm_assert_status_jq \
     ".deployments[0][\"base-checksum\"] == \"${commit}\"" \
     '.deployments[0]["version"] == "SUPADUPAVERSION"' \
@@ -70,8 +74,10 @@ echo "ok deploy with foo and local bar"
 
 commit=$(vm_cmd ostree commit -b vmcheck_tmp/rebase \
            --tree=ref=vmcheck --add-metadata-string=version=SUPADUPAVERSION)
+vm_status_watch_start
 vm_rpmostree rebase vmcheck_tmp/rebase SUPADUPAVERSION \
     --install bar --install $foo_rpm
+vm_status_watch_check "Transaction: rebase vmcheck_tmp/rebase SUPADUPAVERSION --install bar --install $foo_rpm"
 vm_assert_status_jq \
     ".deployments[0][\"base-checksum\"] == \"${commit}\"" \
     '.deployments[0]["origin"] == "vmcheck_tmp/rebase"' \
@@ -86,12 +92,16 @@ echo "ok rebase with bar and local foo"
 
 # PKG CHANGES
 
+vm_status_watch_start
 vm_rpmostree install $foo_rpm
+vm_status_watch_check "Transaction: install $foo_rpm"
 vm_assert_status_jq \
     '.deployments[0]["packages"]|length == 0' \
     '.deployments[0]["requested-local-packages"]|length == 1' \
     '.deployments[0]["requested-local-packages"]|index("foo-1.0-1.x86_64") >= 0'
+vm_status_watch_start
 vm_rpmostree uninstall foo-1.0-1.x86_64 --install bar
+vm_status_watch_check "Transaction: uninstall foo-1.0-1.x86_64 --install bar"
 vm_assert_status_jq \
     '.deployments[0]["packages"]|length == 1' \
     '.deployments[0]["packages"]|index("bar") >= 0' \

--- a/tests/vmcheck/test-override-local-replace.sh
+++ b/tests/vmcheck/test-override-local-replace.sh
@@ -125,7 +125,9 @@ assert_replaced_local_pkg bar-1.0-1.x86_64 bar-0.9-1.x86_64
 echo "ok override replacements carried through upgrade"
 
 # try to reset pkgs using both name and nevra
+vm_status_watch_start
 vm_rpmostree override reset foo fooext-2.0-1.x86_64
+vm_status_watch_check "Transaction: override reset foo fooext-2.0-1.x86_64"
 vm_assert_status_jq \
   '.deployments[0]["base-local-replacements"]|length == 1' \
   '.deployments[0]["requested-base-local-replacements"]|length == 1'

--- a/tests/vmcheck/test-override-remove.sh
+++ b/tests/vmcheck/test-override-remove.sh
@@ -219,6 +219,8 @@ vm_rpmostree cleanup -p
 echo "ok override remove base dep to layered pkg fails"
 
 vm_build_rpm boo
+vm_status_watch_start
 vm_rpmostree override remove foo --install boo
+vm_status_watch_check "Transaction: override remove foo --install boo"
 vm_rpmostree cleanup -p
 echo "ok remove and --install at the same time"

--- a/tests/vmcheck/test-override-replace-2.sh
+++ b/tests/vmcheck/test-override-replace-2.sh
@@ -77,7 +77,10 @@ build_rpms() {
 }
 build_rpms
 
+vm_status_watch_start
 vm_rpmostree install {foo,bar}-ext-{1,2}
+vm_status_watch_check "Transaction: install foo-ext-1 foo-ext-2 bar-ext-1 bar-ext-2"
+
 vm_cmd ostree refs $(vm_get_deployment_info 0 checksum) \
   --create vmcheck_tmp/with_foo_and_bar
 vm_rpmostree cleanup -p

--- a/tests/vmcheck/test-reset.sh
+++ b/tests/vmcheck/test-reset.sh
@@ -97,7 +97,9 @@ echo "ok reset EVERYTHING"
 
 # reset everything and overlay at the same time
 vm_build_rpm a-new-package
+vm_status_watch_start
 vm_rpmostree reset --install a-new-package
+vm_status_watch_check "Transaction: reset --install a-new-package"
 vm_assert_status_jq \
   '.deployments[0]["packages"]|length == 1' \
   '.deployments[0]["packages"]|index("a-new-package") >= 0' \


### PR DESCRIPTION
In the app, rebuild the exact command-line that the client used and pass
that to the daemon to be used as the transaction title. Especially in
transactions like `UpdateDeployment()`, we can avoid reverse-engineering
what the original command used was.

This will be used by the upcoming history feature to record the
command-line used in the journal.

Split out of #1813.