### PR TITLE
libvm: Use shared memory for SSH control socket instead of /var/tmp

### DIFF
--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -23,7 +23,7 @@ vm_setup() {
   export VM=${VM:-vmcheck}
   export SSH_CONFIG=${SSH_CONFIG:-${topsrcdir}/ssh-config}
   SSHOPTS="-o User=root -o ControlMaster=auto \
-           -o ControlPath=/var/tmp/ssh-$VM-$(date +%s%N).sock \
+           -o ControlPath=/dev/shm/ssh-$VM-$(date +%s%N).sock \
            -o ControlPersist=yes"
 
   # If we're provided with an ssh-config, make sure we tell


### PR DESCRIPTION
In Fedora 29, and Fedora 30 Silverblue, I have come across the
following error when executing `make vmsync` from my build container
(also on Fedora 29 and Fedora 30 images respectively):

```
...
Failed to connect to new control master
...
Control socket connect(/var/tmp/ssh-vmcheck-1556768111752693879.sock): Connection refused
Failed to connect to new control master
...
```

Previously this worked with Fedora 28 as the host.

After changing the socket to be in /dev/shm, the SSH connection to
the `vmcheck` VM is successful and the sources sync over.

The cause of this seems to be a problem with overlayfs and unix
sockets: https://github.com/moby/moby/issues/12080

Since overlayfs is the default graph driver in Fedora now, work
around this by switching the socket to be in /dev/shm.
