### PR TITLE
vmcheck/overlay: Drop dependency on host Python

### DIFF
--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -20,15 +20,12 @@ if [ "$id" == fedora ] && [ "$version_id" == 29 ]; then
 fi
 
 pkg_upgrade
-pkg_install_if_os centos epel-release
 pkg_install_builddeps rpm-ostree
 # XXX: new libdnf deps until next release
 pkg_install json-c-devel cppunit{,-devel} swig sqlite-devel \
     libmodulemd1-devel libsmartcols-devel gpgme-devel
 # Mostly dependencies for tests
-pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq PyYAML \
-    libubsan libasan libtsan elfutils fuse sudo python-gobject-base \
-    selinux-policy-devel selinux-policy-targeted python2-createrepo_c \
-    rsync rpm-python # provided by python2-rpm on Fedora
-# For more CI testing
-pkg_install_if_os fedora parallel clang rustfmt-preview
+pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq python3-pyyaml \
+    libubsan libasan libtsan elfutils fuse sudo python3-gobject-base \
+    selinux-policy-devel selinux-policy-targeted python3-createrepo_c \
+    rsync python3-rpm parallel clang rustfmt-preview

--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -49,7 +49,7 @@ mkdir ${tmpd} && touch ${tmpd}/.tmp
                      systemd/libsystemd-sys/systemd \
                      libsystemd-sys/systemd; do
    rm -rf vendor/$crate_subdir
-   python -c '
+   python3 -c '
 import json, sys
 crate, subdir = sys.argv[1].split("/", 1)
 checksum_file = ("vendor/%s/.cargo-checksum.json" % crate)
@@ -59,7 +59,7 @@ open(checksum_file, "w").write(json.dumps(j))' $crate_subdir
  done
  # Also drop a couple of files that get mangled by %configure during hardening.
  for crate in backtrace-sys; do
-   python -c '
+   python3 -c '
 import json, sys, os
 checksum_file = ("vendor/%s/.cargo-checksum.json" % sys.argv[1])
 j = json.load(open(checksum_file))

--- a/scripts/rpmostree-group2json.py
+++ b/scripts/rpmostree-group2json.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python -tt
+#!/usr/bin/python3
 
 import os
 import sys
@@ -17,4 +17,4 @@ for fname in sys.argv[1:]:
         done = True
         out += '"%s": %s' % (group, gid)
 out += ' } },'
-print out
+print(out)

--- a/scripts/rpmostree-passwd2json.py
+++ b/scripts/rpmostree-passwd2json.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python -tt
+#!/usr/bin/python3
 
 import os
 import sys
@@ -20,4 +20,4 @@ for fname in sys.argv[1:]:
         else:
             out += '"%s": [%s, %s]' % (user, uid, gid)
 out += ' } },'
-print out
+print(out)

--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -1008,6 +1008,7 @@ rpmostree_builtin_status (int             argc,
 
       JsonNode *json_root = json_builder_get_root (builder);
       glnx_unref_object JsonGenerator *generator = json_generator_new ();
+      json_generator_set_pretty (generator, TRUE);
 
       if (opt_json)
         json_generator_set_root (generator, json_root);

--- a/tests/check/test-lib-introspection.sh
+++ b/tests/check/test-lib-introspection.sh
@@ -26,7 +26,7 @@ set -x
 
 if ! skip_one_with_asan; then
     cat >test-rpmostree-gi-arch <<EOF
-#!/usr/bin/python2
+#!/usr/bin/python3
 import gi
 gi.require_version("RpmOstree", "1.0")
 from gi.repository import RpmOstree
@@ -44,7 +44,7 @@ fi
 
 if ! skip_one_with_asan; then
     cat >test-rpmostree-gi <<EOF
-#!/usr/bin/python2
+#!/usr/bin/python3
 import gi
 gi.require_version("RpmOstree", "1.0")
 from gi.repository import RpmOstree

--- a/tests/common/libtest.sh
+++ b/tests/common/libtest.sh
@@ -145,10 +145,10 @@ setup_test_repository () {
 }
 
 run_temp_webserver() {
-    env PYTHONUNBUFFERED=1 setsid python -m SimpleHTTPServer 0 >${test_tmpdir}/httpd-output &
+    env PYTHONUNBUFFERED=1 setsid python3 -m http.server 0 >${test_tmpdir}/httpd-output &
     for x in $(seq 50); do
         if test -e ${test_tmpdir}/httpd-output; then
-            sed -e 's,Serving HTTP on 0.0.0.0 port \([0-9]*\) \.\.\.,\1,' < ${test_tmpdir}/httpd-output > ${test_tmpdir}/httpd-port
+            sed -e 's,Serving HTTP on 0.0.0.0 port \([0-9]*\) (http://.*) \.\.\.,\1,' < ${test_tmpdir}/httpd-output > ${test_tmpdir}/httpd-port
             if ! cmp ${test_tmpdir}/httpd-output ${test_tmpdir}/httpd-port 1>/dev/null; then
                 break
             fi

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -213,7 +213,7 @@ vm_get_deployment_info() {
   local idx=$1
   local key=$2
   vm_rpmostree status --json | \
-    python -c "
+    python3 -c "
 import sys, json
 deployments = json.load(sys.stdin)[\"deployments\"]
 idx = $idx
@@ -222,18 +222,18 @@ if idx < 0:
     if depl[\"booted\"]:
       idx = i
 if idx < 0:
-  print \"Failed to determine currently booted deployment\"
+  print(\"Failed to determine currently booted deployment\")
   exit(1)
 if idx >= len(deployments):
-  print \"Deployment index $idx is out of range\"
+  print(\"Deployment index $idx is out of range\")
   exit(1)
 depl = deployments[idx]
 if \"$key\" in depl:
   data = depl[\"$key\"]
   if type(data) is list:
-    print \" \".join(data)
+    print(\" \".join(data))
   else:
-    print data
+    print(data)
 "
 }
 
@@ -450,7 +450,7 @@ vm_start_httpd() {
 
   # CentOS systemd is too old for -p WorkingDirectory
   vm_cmd systemd-run --unit $name sh -c \
-    "'cd $dir && python -m SimpleHTTPServer $port'"
+    "'cd $dir && python3 -m http.server $port'"
 
   # NB: the EXIT trap is used by libtest, but not the ERR trap
   trap "vm_stop_httpd $name" ERR

--- a/tests/compose-tests/libcomposetest.sh
+++ b/tests/compose-tests/libcomposetest.sh
@@ -15,7 +15,7 @@ jd=json.load(sys.stdin)
 ${1}
 json.dump(jd,sys.stdout)
 EOF
-    python ./editjson.py && rm -f ./editjson.py
+    python3 ./editjson.py && rm -f ./editjson.py
 }
 
 pysetjsonmember() {
@@ -50,7 +50,7 @@ EOF
     pysetjsonmember "repos" '["fedora-local"]' ${treefile}
     # FIXME extract from json
     if [ "${filetype}" = "yaml" ]; then
-        python <<EOF
+        python3 <<EOF
 import json, yaml, sys
 ifn="${treefile}"
 ofn=ifn.replace('.json', '.yaml')

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -35,7 +35,7 @@ assert_file_has_content preset.txt '^enable ostree-remount.service$'
 assert_file_has_content preset.txt '^enable ostree-finalize-staged.path$'
 
 prepare_compose_test "from-yaml"
-python <<EOF
+python3 <<EOF
 import json, yaml
 jd=json.load(open("$treefile"))
 with open("$treefile.yaml", "w") as f:

--- a/tests/manual/test-dbquery.py
+++ b/tests/manual/test-dbquery.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 from gi.repository import Gio, OSTree, RpmOstree

--- a/tests/utils/updateinfo
+++ b/tests/utils/updateinfo
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (C) 2018 Jonathan Lebon <jlebon@redhat.com>
 #
@@ -292,12 +292,12 @@ def show_updates(uinfo, uid):
     for update in uinfo.updates:
         if uid is not None and update.id != uid:
             continue
-        print update.id, update.type, update.severity
+        print(update.id, update.type, update.severity)
         for col in update.collections:
             for pkg in col.packages:
-                print "  pkg:", pkg.filename
+                print("  pkg:", pkg.filename)
         for ref in update.references:
-            print "  ref:", ref.id, ref.href
+            print("  ref:", ref.id, ref.href)
 
 
 def shallow_clone_update(update):

--- a/tests/vmcheck/multitest.py
+++ b/tests/vmcheck/multitest.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 
 import os
 import sys
@@ -100,7 +100,7 @@ class Host:
                                    stdout=open("vmcheck/%s.log" % test, 'wb'),
                                    stderr=subprocess.STDOUT)
         self.test = test
-        print "INFO: scheduled", self.test, "on host", self.hostname
+        print("INFO: scheduled", self.test, "on host", self.hostname)
 
     def flush(self):
         if not self._p:

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -13,12 +13,12 @@ if test -z "${INSIDE_VM:-}"; then
 
     vm_rsync
 
-    vm_rpmostree status --json > out.json
-    commit=$(jq -r '.deployments[0]["checksum"]' < out.json)
-    origin=$(jq -r '.deployments[0]["origin"]' < out.json)
-    version=$(jq -r '.deployments[0]["version"]' < out.json)
-    timestamp=$(jq -r '.deployments[0]["timestamp"]' < out.json)
-    rm -f out.json
+    vm_rpmostree status --json > ${VM}-out.json
+    commit=$(jq -r    '.deployments[0]["checksum"]'  < ${VM}-out.json)
+    origin=$(jq -r    '.deployments[0]["origin"]'    < ${VM}-out.json)
+    version=$(jq -r   '.deployments[0]["version"]'   < ${VM}-out.json)
+    timestamp=$(jq -r '.deployments[0]["timestamp"]' < ${VM}-out.json)
+    rm -f ${VM}-out.json
 
     vm_cmd env \
       RPMOSTREE_TEST_NO_OVERLAY="${RPMOSTREE_TEST_NO_OVERLAY:-}" \

--- a/tests/vmcheck/overlay.sh
+++ b/tests/vmcheck/overlay.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -xeuo pipefail
 
 # Execute this code path on the host
 if test -z "${INSIDE_VM:-}"; then
@@ -27,8 +27,6 @@ if test -z "${INSIDE_VM:-}"; then
     vm_reboot
     exit 0
 fi
-
-set -x
 
 # And then this code path in the VM
 

--- a/tests/vmcheck/test-cached-rpm-diffs.sh
+++ b/tests/vmcheck/test-cached-rpm-diffs.sh
@@ -63,12 +63,6 @@ call_dbus() {
     -m org.projectatomic.rpmostree1.OS.$method "$@"
 }
 
-if vm_cmd test -x /usr/bin/python3; then
-  py=python3
-else
-  py=python
-fi
-
 run_transaction() {
   method=$1; shift
   sig=$1; shift
@@ -76,7 +70,7 @@ run_transaction() {
   cur=$(vm_get_journal_cursor)
   # use ansible for this so we don't have to think about hungry quote-eating ssh
   vm_shell_inline <<EOF
-$py -c '
+python3 -c '
 import dbus
 addr = dbus.SystemBus().call_blocking(
   "org.projectatomic.rpmostree1", "$ospath", "org.projectatomic.rpmostree1.OS",

--- a/tests/vmcheck/test-layering-scripts.sh
+++ b/tests/vmcheck/test-layering-scripts.sh
@@ -35,7 +35,7 @@ vm_build_rpm scriptpkg1 \
   pretrans "# http://lists.rpm.org/pipermail/rpm-ecosystem/2016-August/000391.html
             echo pretrans should've been ignored && exit 1" \
   verifyscript "echo verifyscript should've been ignored && exit 1" \
-  post_args "-p /usr/bin/python" \
+  post_args "-p /usr/bin/python3" \
   post 'open("/usr/lib/rpmostreetestinterp", "w").close();
 open("/var/lib/rpm-state/scriptpkg1-stamp", "w").close()' \
   posttrans "# Firewalld; https://github.com/projectatomic/rpm-ostree/issues/638

--- a/tests/vmcheck/test-misc-1.sh
+++ b/tests/vmcheck/test-misc-1.sh
@@ -58,7 +58,7 @@ if test -z "${RPMOSTREE_TEST_NO_OVERLAY:-}"; then
 fi
 
 vm_rpmostree status --jsonpath '$.deployments[0].booted' > jsonpath.txt
-assert_file_has_content_literal jsonpath.txt '[true]'
+assert_file_has_content_literal jsonpath.txt 'true'
 echo "ok jsonpath"
 
 vm_rpmostree --version > version.yaml

--- a/tests/vmcheck/test-misc-1.sh
+++ b/tests/vmcheck/test-misc-1.sh
@@ -62,7 +62,7 @@ assert_file_has_content_literal jsonpath.txt '[true]'
 echo "ok jsonpath"
 
 vm_rpmostree --version > version.yaml
-python -c 'import yaml; v=yaml.safe_load(open("version.yaml")); assert("Version" in v["rpm-ostree"])'
+python3 -c 'import yaml; v=yaml.safe_load(open("version.yaml")); assert("Version" in v["rpm-ostree"])'
 echo "ok yaml version"
 
 # Ensure we return an error when passing a wrong option.


### PR DESCRIPTION
Also switch to using `jq` on the controlling host instead of Python.

This is also prep for switching CI to FCOS which is likely to not ship
Python at all.