### PR TITLE
compose: Add --no-parent option

### DIFF
--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -69,6 +69,7 @@ static gboolean opt_dry_run;
 static gboolean opt_print_only;
 static char *opt_write_commitid_to;
 static char *opt_write_composejson_to;
+static gboolean opt_no_parent;
 
 /* shared by both install & commit */
 static GOptionEntry common_option_entries[] = {
@@ -103,6 +104,7 @@ static GOptionEntry commit_option_entries[] = {
   { "add-metadata-from-json", 0, 0, G_OPTION_ARG_STRING, &opt_metadata_json, "Parse the given JSON file as object, convert to GVariant, append to OSTree commit", "JSON" },
   { "write-commitid-to", 0, 0, G_OPTION_ARG_STRING, &opt_write_commitid_to, "File to write the composed commitid to instead of updating the ref", "FILE" },
   { "write-composejson-to", 0, 0, G_OPTION_ARG_STRING, &opt_write_composejson_to, "Write JSON to FILE containing information about the compose run", "FILE" },
+  { "no-parent", 0, 0, G_OPTION_ARG_NONE, &opt_no_parent, "Always commit without a parent", NULL },
   { NULL }
 };
 
@@ -1002,7 +1004,7 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
     }
 
   g_autofree char *parent_revision = NULL;
-  if (self->ref)
+  if (self->ref && !opt_no_parent)
     {
       if (!ostree_repo_resolve_rev (self->repo, self->ref, TRUE, &parent_revision, error))
         return FALSE;

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -100,8 +100,8 @@ assert_file_has_content pkglist.txt 'systemd'
 # also change the corresponding test in misc-tweaks.sh.
 assert_file_has_content pkglist.txt 'systemd-bootchart'
 echo "ok compose pkglist"
-}
 
 ostree --repo=${repobuild} cat ${treeref} /usr/share/rpm-ostree/treefile.json > treefile.json
 assert_jq treefile.json '.basearch == "x86_64"'
 echo "ok basearch"
+}

--- a/tests/compose-tests/libcomposetest.sh
+++ b/tests/compose-tests/libcomposetest.sh
@@ -1,5 +1,5 @@
 dn=$(cd $(dirname $0) && pwd)
-test_tmpdir=$(mktemp -d /var/tmp/rpm-ostree-compose-test.XXXXXX)
+test_tmpdir=$(mktemp -d ${RPMOSTREE_TMPDIR_LOCATION:-/var/tmp}/rpm-ostree-compose-test.XXXXXX)
 touch ${test_tmpdir}/.test
 trap _cleanup_tmpdir EXIT
 cd ${test_tmpdir}

--- a/tests/compose-tests/test-basic-unified.sh
+++ b/tests/compose-tests/test-basic-unified.sh
@@ -63,10 +63,15 @@ fi
 rm ${co} -rf
 echo "ok no cachedir zero-sized hardlinks"
 
-# And redo it to trigger relabeling
+# And redo it to trigger relabeling. Also test --no-parent at the same time.
 origrev=$(ostree --repo=${repobuild} rev-parse ${treeref})
-runcompose  --force-nocache --ex-unified-core
+runcompose  --force-nocache --ex-unified-core --no-parent
 newrev=$(ostree --repo=${repobuild} rev-parse ${treeref})
 assert_not_streq "${origrev}" "${newrev}"
-
 echo "ok rerun"
+
+# And check that --no-parent worked.
+if ostree rev-parse ${newrev}^; then
+  assert_not_reached "New revision has a parent even with --no-parent?"
+fi
+echo "ok --no-parent"

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -44,3 +44,8 @@ EOF
 export treefile=$treefile.yaml
 runcompose
 echo "ok yaml"
+
+# also check that --no-parent doesn't invalidate change detection
+runcompose --no-parent |& tee out.txt
+assert_file_has_content_literal out.txt "No apparent changes since previous commit"
+echo "ok --no-parent"


### PR DESCRIPTION
There are cases where we do want all the things that specifying a ref
provides (e.g. change detection, version incrementing, SELinux labeling
optimizations, and of course writing the ref) but we *don't* want the
new commit to have a parent. Add a new `--no-parent` option to
accommodate this.

This will be used by coreos-assembler. See discussions at
coreos/coreos-assembler#159.