### PR TITLE
Add ostree-layers and ostree-overrride-layers

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -61,6 +61,14 @@ It supports the following parameters:
  * `packages-$basearch`: Array of strings, optional: Set of installed packages, used
     only if $basearch matches the target architecture name.
 
+ * `ostree-layers`: Array of strings, optional: After all packages are unpacked,
+    check out these OSTree refs, which must already be in the destination repository.
+    Any conflicts with packages will be an error.
+
+ * `ostree-override-layers`: Array of strings, optional: Like above, but any
+    files present in packages and prior layers will be silently overriden.
+    This is useful for development builds to replace parts of the base tree.
+
  * `bootstrap_packages`: Array of strings, optional: Deprecated; you should
     now just include this set in the main `packages` array.
 

--- a/src/app/rpmostree-compose-builtin-rojig.c
+++ b/src/app/rpmostree-compose-builtin-rojig.c
@@ -166,6 +166,7 @@ install_packages (RpmOstreeRojigCompose  *self,
 
   g_autofree char *ret_new_inputhash = NULL;
   if (!rpmostree_composeutil_checksum (dnf_context_get_goal (dnfctx),
+                                       self->repo,
                                        self->treefile_rs, self->treefile,
                                        &ret_new_inputhash, error))
     return FALSE;

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -714,9 +714,12 @@ rpm_ostree_compose_context_new (const char    *treefile_pathstr,
                                error))
     return FALSE;
 
+  g_auto(GStrv) layers = ror_treefile_get_all_ostree_layers (self->treefile_rs);
+  if (layers && *layers && !opt_unified_core)
+    return glnx_throw (error, "ostree-layers requires unified-core mode");
+
   if (self->build_repo != self->repo)
     {
-      g_auto(GStrv) layers = ror_treefile_get_all_ostree_layers (self->treefile_rs);
       for (char **iter = layers; iter && *iter; iter++)
         {
           const char *layer = *iter;

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -29,6 +29,7 @@ G_BEGIN_DECLS
 
 gboolean
 rpmostree_composeutil_checksum (HyGoal             goal,
+                                OstreeRepo        *repo,
                                 RORTreefile       *tf,
                                 JsonObject        *treefile,
                                 char             **out_checksum,

--- a/tests/compose-tests/test-misc-tweaks.sh
+++ b/tests/compose-tests/test-misc-tweaks.sh
@@ -69,7 +69,7 @@ for x in $(seq 3); do
 done
 rm tmp/usr -rf
 mkdir -p tmp/usr/share/info
-echo some info | gzip > tmp/usr/share/info/bash.info.gz
+echo sweet new ls binary > tmp/usr/bin/ls
 ostree --repo="${repobuild}" commit --consume --no-xattrs --owner-uid=0 --owner-gid=0 -b testoverride-1 --tree=dir=tmp
 cat >> ${new_treefile} <<EOF
 ostree-layers:
@@ -145,8 +145,8 @@ for x in $(seq 3); do
   ostree --repo=${repobuild} cat ${treeref} /usr/share/testsubdir-${x}/test > t
   assert_file_has_content t sometestdata-subdir-${x}
 done
-ostree --repo=${repobuild} cat ${treeref} /usr/share/info/bash.info.gz | gunzip > bash.info
-assert_file_has_content bash.info 'some info'
+ostree --repo=${repobuild} cat ${treeref} /usr/bin/ls > ls.txt
+assert_file_has_content ls.txt '^sweet new ls binary$'
 echo "ok layers"
 
 # Check that add-files with bad paths are rejected

--- a/tests/compose-tests/test-misc-tweaks.sh
+++ b/tests/compose-tests/test-misc-tweaks.sh
@@ -68,7 +68,7 @@ for x in $(seq 3); do
   ostree --repo="${repobuild}" commit --consume --no-xattrs --owner-uid=0 --owner-gid=0 -b testlayer-${x} --tree=dir=tmp
 done
 rm tmp/usr -rf
-mkdir -p tmp/usr/share/info
+mkdir -p tmp/usr/{share/info,bin}
 echo sweet new ls binary > tmp/usr/bin/ls
 ostree --repo="${repobuild}" commit --consume --no-xattrs --owner-uid=0 --owner-gid=0 -b testoverride-1 --tree=dir=tmp
 cat >> ${new_treefile} <<EOF


### PR DESCRIPTION

The use case for `ostree-layers` is to support injecting non-RPM
content in a more flexible way than can be done with `add-files`,
and also without dropping all the way to split composes.

This starts with support on the `compose tree` side but down the
line I'd like to make it more convenient to do *client* side too.

For `ostree-override-layers` this is mainly a development thing
for tools like coreos-assembler.  Rather than building an RPM
we just `make install DESTDIR` then commit and add to
`ostree-override-layers`.
