### PR TITLE
kargs: Just print args, don't add additional text

### DIFF
--- a/src/app/rpmostree-builtin-kargs.c
+++ b/src/app/rpmostree-builtin-kargs.c
@@ -261,8 +261,7 @@ rpmostree_builtin_kargs (int            argc,
 
   if (display_kernel_args)
     {
-      g_print ("The kernel arguments are:\n%s\n",
-               old_kernel_arg_string);
+      g_print ("%s\n", old_kernel_arg_string);
       return TRUE;
     }
 


### PR DESCRIPTION
The Unix tradition is generally not to add English text unless
necessary.

This makes the output of this command more obviously parsable,
although I'm not entirely sure we should do this versus adding
`--json` or so, but eh, it's also not wrong.
