### PR TITLE
daemon: Bump sysroot mtime to force reload

### DIFF
--- a/src/daemon/rpmostreed-os.c
+++ b/src/daemon/rpmostreed-os.c
@@ -978,23 +978,11 @@ out:
   return TRUE;
 }
 
-static void
-on_finalize_done (RpmostreedTransaction *transaction, RpmostreedOS *self)
-{
-  g_autoptr(GError) local_error = NULL;
-  if (!rpmostreed_os_load_internals (self, &local_error))
-    {
-      sd_journal_print (LOG_WARNING, "Failed to reload internals: %s",
-                        local_error->message);
-    }
-}
-
 static gboolean
 os_handle_finalize_deployment (RPMOSTreeOS *interface,
                                GDBusMethodInvocation *invocation,
                                GVariant *arg_options)
 {
-  RpmostreedOS *self = RPMOSTREED_OS (interface);
   g_autoptr(GCancellable) cancellable = g_cancellable_new ();
   glnx_unref_object RpmostreedTransaction *transaction = NULL;
   g_autoptr(OstreeSysroot) sysroot = NULL;
@@ -1021,9 +1009,6 @@ os_handle_finalize_deployment (RPMOSTreeOS *interface,
     goto out;
 
   rpmostreed_sysroot_set_txn (rsysroot, transaction);
-
-  /* Really, we just want to refresh `DefaultDeployment`, but meh... */
-  g_signal_connect (transaction, "closed", G_CALLBACK (on_finalize_done), self);
 
 out:
   if (local_error != NULL)

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -2308,6 +2308,11 @@ finalize_deployment_transaction_execute (RpmostreedTransaction *transaction,
         return glnx_throw (error, "Staged deployment already unlocked");
     }
 
+  /* And bump sysroot mtime so we reload... a bit awkward, though this is similar to
+   * libostree itself doing this for `ostree admin unlock` (and possibly an `ostree admin`
+   * version of `rpm-ostree finalize-deployment`). */
+  (void) rpmostree_syscore_bump_mtime (sysroot, NULL);
+
   sd_journal_print (LOG_INFO, "Finalized deployment; rebooting into %s", checksum);
   rpmostreed_reboot (cancellable, error);
   return TRUE;


### PR DESCRIPTION
Right now, after calling `rpm-ostree finalize-deployment`, we update the
`DefaultDeployment` property so that its `finalization-locked` key is
updated. This allows update agents like zincati to correctly understand
the current state if the reboot is locking/inhibited.

The issue though is that this property is accessible through D-Bus only,
and current plans for zincati is to just use the CLI for now.
Unfortunately, the output of `status --json` doesn't correctly get
updated since the deployments array comes from the sysroot interface.

Just use the nuclear mtime bump instead to force a reload. Another
approach long term is to formalize the set of paths/attributes libostree
clients should be monitoring, though having a single API is nice too.