### PR TITLE
app/db-diff: Add --format=json output

### DIFF
--- a/src/daemon/rpmostree-package-variants.c
+++ b/src/daemon/rpmostree-package-variants.c
@@ -115,11 +115,12 @@ rpm_ostree_db_diff_variant_compare_by_type (const void *v1,
 /**
  * rpm_ostree_db_build_diff_variant
  * @repo: A OstreeRepo
- * @old_ref: old ref to use
- * @new_ref: New ref to use
+ * @from_rev: First ref to diff
+ * @to_rev: Second ref to diff
+ * @allow_noent: Don't error out if rpmdb information is missing
  * @out_variant: GVariant that represents the differences between the rpm
  *   databases on the given refs.
- * GCancellable: *cancellable
+ * GCancellable: A GCancellable
  * GError: **error
  *
  * Returns: %TRUE on success, %FALSE on failure

--- a/tests/vmcheck/test-db.sh
+++ b/tests/vmcheck/test-db.sh
@@ -73,6 +73,15 @@ check_diff $booted_csum $pending_csum \
   +pkg-to-replace \
   +pkg-to-replace-archtrans
 
+# also check the diff using json
+vm_rpmostree db diff --format=json $booted_csum $pending_csum > diff.json
+# See assert_replaced_local_pkg() for some syntax explanation. The .[1] == 0 bit
+# is what filters by "pkgs added".
+assert_jq diff.json \
+  '[.pkgdiff|map(select(.[1] == 0))[][0]]|index("pkg-to-remove") >= 0' \
+  '[.pkgdiff|map(select(.[1] == 0))[][0]]|index("pkg-to-replace") >= 0' \
+  '[.pkgdiff|map(select(.[1] == 0))[][0]]|index("pkg-to-replace-archtrans") >= 0'
+
 # check that it's the default behaviour without both args
 check_diff "" "" \
   +pkg-to-remove \


### PR DESCRIPTION
Add a new "json" output format. The "diff" format is also a mostly
machine-compatible one. But JSON is much more ubiquitous and easier to
consume.