### PR TITLE
app/deploy: Add --lock-finalization switch

### DIFF
--- a/src/app/rpmostree-builtin-deploy.c
+++ b/src/app/rpmostree-builtin-deploy.c
@@ -32,6 +32,7 @@ static gboolean opt_reboot;
 static gboolean opt_preview;
 static gboolean opt_cache_only;
 static gboolean opt_download_only;
+static gboolean opt_lock_finalization;
 
 static GOptionEntry option_entries[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
@@ -43,6 +44,7 @@ static GOptionEntry option_entries[] = {
   { "preview", 0, 0, G_OPTION_ARG_NONE, &opt_preview, "Just preview package differences", NULL },
   { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Do not download latest ostree and RPM data", NULL },
   { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only, "Just download latest ostree and RPM data, don't deploy", NULL },
+  { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization, "Prevent automatic deployment finalization on shutdown", NULL },
   { NULL }
 };
 
@@ -117,6 +119,7 @@ rpmostree_builtin_deploy (int            argc,
       g_variant_dict_insert (&dict, "allow-downgrade", "b", TRUE);
       g_variant_dict_insert (&dict, "cache-only", "b", opt_cache_only);
       g_variant_dict_insert (&dict, "download-only", "b", opt_download_only);
+      g_variant_dict_insert (&dict, "lock-finalization", "b", opt_lock_finalization);
       g_variant_dict_insert (&dict, "initiating-command-line", "s", invocation->command_line);
       g_autoptr(GVariant) options = g_variant_ref_sink (g_variant_dict_end (&dict));
 

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -29,7 +29,7 @@ set -x
 # Locked finalization
 booted_csum=$(vm_get_booted_csum)
 commit=$(vm_cmd ostree commit -b vmcheck --tree=ref=vmcheck)
-vm_rpmostree upgrade --lock-finalization
+vm_rpmostree deploy revision="${commit}" --lock-finalization
 vm_cmd test -f /run/ostree/staged-deployment-locked
 cursor=$(vm_get_journal_cursor)
 vm_reboot
@@ -37,7 +37,7 @@ assert_streq "$(vm_get_booted_csum)" "${booted_csum}"
 vm_assert_journal_has_content $cursor 'Not finalizing; found /run/ostree/staged-deployment-locked'
 echo "ok locked staging"
 
-vm_rpmostree upgrade --lock-finalization
+vm_rpmostree deploy revision="${commit}" --lock-finalization
 vm_cmd test -f /run/ostree/staged-deployment-locked
 if vm_rpmostree finalize-deployment; then
   assert_not_reached "finalized without expected checksum"


### PR DESCRIPTION
Of course, update agents driving rpm-ostree know exactly to which commit
they want the system to upgrade, so `upgrade --lock-finalization` is not
helpful. Teach `deploy` the `--lock-finalization` switch too.