### PR TITLE
core: Strengthen how we enforce lockfiles

### DIFF
--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1855,21 +1855,21 @@ check_locked_pkgs (RpmOstreeContext *self,
     dnf_goal_get_packages (goal, DNF_PACKAGE_INFO_INSTALL, -1);
 
   for (guint i = 0; i < packages->len; i++)
-  {
-    DnfPackage *pkg = packages->pdata[i];
-    const char *nevra = dnf_package_get_nevra (pkg);
-    const char *chksum = g_hash_table_lookup (self->vlockmap, nevra);
-    if (!chksum)
-      continue;
+    {
+      DnfPackage *pkg = packages->pdata[i];
+      const char *nevra = dnf_package_get_nevra (pkg);
+      const char *chksum = g_hash_table_lookup (self->vlockmap, nevra);
+      if (!chksum)
+        continue;
 
-    g_autofree char *repodata_chksum = NULL;
-    if (!rpmostree_get_repodata_chksum_repr (pkg, &repodata_chksum, error))
-      return FALSE;
+      g_autofree char *repodata_chksum = NULL;
+      if (!rpmostree_get_repodata_chksum_repr (pkg, &repodata_chksum, error))
+        return FALSE;
 
-    if (chksum && !g_str_equal (chksum, repodata_chksum))
-      return glnx_throw (error, "Locked package %s checksum  mismatch: expected %s, got %s",
-                         nevra, chksum, repodata_chksum);
-  }
+      if (chksum && !g_str_equal (chksum, repodata_chksum))
+        return glnx_throw (error, "Locked package %s checksum mismatch: expected %s, got %s",
+                           nevra, chksum, repodata_chksum);
+    }
 
   return TRUE;
 }

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1886,7 +1886,7 @@ rpmostree_context_prepare (RpmOstreeContext *self,
   g_autoptr(GHashTable) local_pkgs_to_install =
     g_hash_table_new_full (g_str_hash, g_str_equal, NULL, g_object_unref);
 
-  /* Handle packages to replace */
+  /* Handle packages to replace; only add them to the sack for now */
   g_autoptr(GPtrArray) replaced_nevras = g_ptr_array_new ();
   for (char **it = cached_replace_pkgs; it && *it; it++)
     {
@@ -1905,7 +1905,7 @@ rpmostree_context_prepare (RpmOstreeContext *self,
       g_hash_table_insert (local_pkgs_to_install, (gpointer)nevra, g_steal_pointer (&pkg));
     }
 
-  /* For each new local package, tell libdnf to add it to the goal */
+  /* Now handle local package; only add them to the sack for now */
   for (char **it = cached_pkgnames; it && *it; it++)
     {
       const char *nevra = *it;

--- a/src/libpriv/rpmostree-core.c
+++ b/src/libpriv/rpmostree-core.c
@@ -1866,12 +1866,13 @@ rpmostree_context_prepare (RpmOstreeContext *self,
         return FALSE;
       journal_rpmmd_info (self);
     }
+  DnfSack *sack = dnf_context_get_sack (dnfctx);
 
   /* Don't try to keep multiple kernels per root; that's a traditional thing,
    * ostree binds kernel + userspace.
    */
-  dnf_sack_set_installonly (dnf_context_get_sack (self->dnfctx), NULL);
-  dnf_sack_set_installonly_limit (dnf_context_get_sack (self->dnfctx), 0);
+  dnf_sack_set_installonly (sack, NULL);
+  dnf_sack_set_installonly_limit (sack, 0);
 
   if (self->rojig_pure)
     {
@@ -1954,7 +1955,6 @@ rpmostree_context_prepare (RpmOstreeContext *self,
 
   /* And finally, handle repo packages to install */
   g_autoptr(GPtrArray) missing_pkgs = NULL;
-  DnfSack *sack = dnf_context_get_sack (dnfctx);
   for (char **it = pkgnames; it && *it; it++)
     {
       const char *pkgname = *it;

--- a/src/libpriv/rpmostree-rpm-util.c
+++ b/src/libpriv/rpmostree-rpm-util.c
@@ -1285,32 +1285,6 @@ rpmostree_create_pkglist_variant (GPtrArray     *pkglist,
   return TRUE;
 }
 
-DnfPackage *
-rpmostree_get_locked_package (DnfSack    *sack,
-                              GHashTable *lockmap,
-                              const char *name)
-{
-  if (!lockmap || !name)
-    return NULL;
-
-  /* The manifest might specify not only package names (foo-1.x) but also
-   * something-that-foo-provides */
-  g_autoptr(GPtrArray) alts = rpmostree_get_matching_packages (sack, name);
-
-  for (gsize i = 0; i < alts->len; i++)
-  {
-    DnfPackage *pkg = alts->pdata[i];
-    g_autofree gchar *repodata_chksum = NULL;
-    if (!rpmostree_get_repodata_chksum_repr (pkg, &repodata_chksum, NULL))
-      continue;
-
-    const char *chksum = g_hash_table_lookup (lockmap, dnf_package_get_nevra (pkg));
-    if (chksum && !g_strcmp0 (chksum, repodata_chksum))
-      return g_object_ref (pkg);
-  }
-  return NULL;
-}
-
 /* Simple wrapper around hy_split_nevra() that adds allow-none and GError convention */
 gboolean
 rpmostree_decompose_nevra (const char  *nevra,

--- a/src/libpriv/rpmostree-rpm-util.h
+++ b/src/libpriv/rpmostree-rpm-util.h
@@ -216,9 +216,6 @@ rpmostree_create_pkglist_variant (GPtrArray     *pkglist,
                                   GCancellable  *cancellable,
                                   GError       **error);
 
-DnfPackage *
-rpmostree_get_locked_package (DnfSack *sack, GHashTable *lockmap, const char *name);
-
 char * rpmostree_get_cache_branch_for_n_evr_a (const char *name, const char *evr, const char *arch);
 char *rpmostree_get_cache_branch_header (Header hdr);
 char *rpmostree_get_rojig_branch_header (Header hdr);

--- a/tests/compose-tests/test-lockfile.sh
+++ b/tests/compose-tests/test-lockfile.sh
@@ -35,7 +35,7 @@ build_rpm test-pkg version 2.0 requires test-pkg-common
 runcompose --ex-lockfile=$PWD/versions.lock --cachedir $(pwd)/cache
 echo "ok compose with lockfile"
 
-rpm-ostree --repo=${repobuild} db list ${treeref} test-pkg >test-pkg-list.txt
+rpm-ostree --repo=${repobuild} db list ${treeref} > test-pkg-list.txt
 assert_file_has_content test-pkg-list.txt 'test-pkg-1.0-1.x86_64'
 assert_file_has_content test-pkg-list.txt 'test-pkg-common-1.0-1.x86_64'
 echo "lockfile read"


### PR DESCRIPTION
One problem with how we use lockfiles right now is that we don't enforce
them for dependencies. That is, if `foo` requires `bar`, but only `foo`
is in the manifest, then while `foo` will be locked, `bar` will never
be checked against the lockfile because it was never explicitly
requested.

Higher-level though, I don't like how indirect the locking here feels.
See some comments about that in:

https://github.com/projectatomic/rpm-ostree/pull/1745#discussion_r288772527
https://github.com/projectatomic/rpm-ostree/pull/1745#discussion_r289419017

Essentially, the manifest is an input file of patterns, and all we
really know from the lockfile output is that the set of packages in
there satisfies this input in some way. But:

1. there are multiple ways to satisfy the same input (hence why hints
   like `SOLVER_FAVOR` exist)
2. the solution is dependent on how the solver is implemented (i.e.
   different libsolv versions might yield different solutions)
3. the solution is dependent on flags fed to the solver (i.e. different
   libdnf versions might yield different solutions)

So any attempt at cross-checking between the input file and the lockfile
is going to be very hard. Using a stricter mode as I suggested in #1745
of only allowing pure pkgnames or NEVRAs would help, but it wouldn't
address the dependency issue. (Though I'm still thinking about possibly
doing this anyway.)

The solution I propose here is instead to take the nuclear approach: we
completely exclude from the sack all packages of the same name as
packages in our lockfiles, but which do not match the NEVRA. Therefore,
any possible solution has to also satisfy our lockfile (or error out).