### PR TITLE
tests/vmcheck: Fully drop python 3 requirement

### DIFF
--- a/ci/vmcheck-provision.sh
+++ b/ci/vmcheck-provision.sh
@@ -5,4 +5,4 @@ set -xeuo pipefail
 
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
-pkg_install openssh-clients ansible
+pkg_install openssh-clients

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -444,7 +444,8 @@ vm_run_container() {
   done
   [ $# -ne 0 ] || fatal "No container args provided"
   # just automatically always share dnf cache so we don't redownload each time
-  vm_cmd mkdir -p /var/cache/dnf
+  # (use -n so this ssh invocation doesn't consume stdin)
+  vm_cmd -n mkdir -p /var/cache/dnf
   vm_cmd podman run --rm -v /var/cache/dnf:/var/cache/dnf:z $podman_args \
     registry.fedoraproject.org/fedora:30 "$@"
 }

--- a/tests/common/libvm.sh
+++ b/tests/common/libvm.sh
@@ -458,11 +458,7 @@ vm_start_httpd() {
   local dir=$1; shift
   local port=$1; shift
 
-  # just nuke the service of the same name if it exists and is also transient
-  if vm_cmd systemctl show $name | grep -q UnitFileState=transient; then
-    vm_cmd systemctl stop $name
-  fi
-
+  vm_cmd podman rm -f $name || true
   vm_run_container --net=host -d --name $name --privileged \
     -v $dir:/srv --workdir /srv -- \
     python3 -m http.server $port

--- a/tests/vmcheck/test-cached-rpm-diffs.sh
+++ b/tests/vmcheck/test-cached-rpm-diffs.sh
@@ -68,8 +68,9 @@ run_transaction() {
   sig=$1; shift
   args=$1; shift
   cur=$(vm_get_journal_cursor)
-  # use ansible for this so we don't have to think about hungry quote-eating ssh
-  vm_shell_inline <<EOF
+  vm_run_container --privileged -i -v /var/run/dbus:/var/run/dbus --net=host -- \
+    /bin/bash << EOF
+dnf install -y python3-dbus
 python3 -c '
 import dbus
 addr = dbus.SystemBus().call_blocking(

--- a/tests/vmcheck/test-cached-rpm-diffs.sh
+++ b/tests/vmcheck/test-cached-rpm-diffs.sh
@@ -70,6 +70,7 @@ run_transaction() {
   cur=$(vm_get_journal_cursor)
   vm_run_container --privileged -i -v /var/run/dbus:/var/run/dbus --net=host -- \
     /bin/bash << EOF
+set -xeuo pipefail
 dnf install -y python3-dbus
 python3 -c '
 import dbus

--- a/tests/vmcheck/test-download-only.sh
+++ b/tests/vmcheck/test-download-only.sh
@@ -35,14 +35,11 @@ set -x
 vm_build_rpm_repo_mode skip foobar
 vm_start_httpd vmcheck /var/tmp 8888
 vm_rpmostree cleanup -m
-vm_ansible_inline <<EOF
-- copy:
-    content: |
-      [vmcheck-http]
-      name=vmcheck-http
-      baseurl=http://localhost:8888/vmcheck/yumrepo
-      gpgcheck=0
-    dest: /etc/yum.repos.d/vmcheck-http.repo
+vm_send_inline /etc/yum.repos.d/vmcheck-http.repo <<EOF
+[vmcheck-http]
+name=vmcheck-http
+baseurl=http://localhost:8888/vmcheck/yumrepo
+gpgcheck=0
 EOF
 
 osname=$(vm_get_booted_deployment_info osname)

--- a/tests/vmcheck/test-livefs.sh
+++ b/tests/vmcheck/test-livefs.sh
@@ -150,9 +150,7 @@ fi
 vm_cmd test -f /${dummy_file_to_modify}
 generate_upgrade() {
     # Create a modified vmcheck commit
-    vm_ansible_inline <<EOF
-- shell: |
-    set -xeuo pipefail
+    vm_shell_inline <<EOF
       cd /ostree/repo/tmp
       rm vmcheck -rf
       ostree checkout vmcheck vmcheck --fsync=0

--- a/tests/vmcheck/test-misc-1.sh
+++ b/tests/vmcheck/test-misc-1.sh
@@ -83,11 +83,8 @@ echo "ok error on unknown command"
 # Be sure an unprivileged user exists and that we can SSH into it. This is a bit
 # underhanded, but we need a bona fide user session to verify non-priv status,
 # and logging in through SSH is an easy way to achieve that.
-vm_ansible_inline <<EOF
-- user:
-    name: testuser
-- shell: |
-    set -euo pipefail
+vm_shell_inline <<EOF
+    getent passwd testuser >/dev/null || useradd testuser
     mkdir -pm 0700 /home/testuser/.ssh
     cp -a /root/.ssh/authorized_keys /home/testuser/.ssh
     chown -R testuser:testuser /home/testuser/.ssh
@@ -139,9 +136,7 @@ vm_rpmostree usroverlay
 vm_cmd test -w /usr/bin
 echo "ok usroverlay"
 
-vm_ansible_inline <<EOF
-- shell: |
-    set -xeuo pipefail
+vm_shell_inline <<EOF
     rpm-ostree cleanup -p
     originpath=\$(ostree admin --print-current-dir).origin
     cp -a \${originpath}{,.orig}

--- a/tests/vmcheck/test-misc-2.sh
+++ b/tests/vmcheck/test-misc-2.sh
@@ -229,14 +229,11 @@ echo "ok /run/ostree-booted in scriptlet container"
 # local repos are always cached, so let's start up an http server for the same
 # vmcheck repo
 vm_start_httpd vmcheck /var/tmp 8888
-vm_ansible_inline <<EOF
-- copy:
-    content: |
-      [vmcheck-http]
-      name=vmcheck-http
-      baseurl=http://localhost:8888/vmcheck/yumrepo
-      gpgcheck=0
-    dest: /etc/yum.repos.d/vmcheck-http.repo
+vm_send_inline /etc/yum.repos.d/vmcheck-http.repo <<EOF
+[vmcheck-http]
+name=vmcheck-http
+baseurl=http://localhost:8888/vmcheck/yumrepo
+gpgcheck=0
 EOF
 
 vm_rpmostree cleanup -rpmb


### PR DESCRIPTION
Drop the use of Ansible everywhere. And for now, just disable the one
test that directly uses Python on the host.

This is required to be able to hack on Fedora CoreOS.