### PR TITLE
daemon: Remove unused pkgcache method

### DIFF
--- a/src/daemon/rpmostree-sysroot-core.c
+++ b/src/daemon/rpmostree-sysroot-core.c
@@ -134,31 +134,6 @@ add_package_refs_to_set (RpmOstreeRefSack *rsack,
   return TRUE;
 }
 
-/* The pkgcache is in extensions/; see also
- * https://github.com/projectatomic/rpm-ostree/pull/1055
- */
-gboolean
-rpmostree_syscore_get_pkgcache_repo (OstreeRepo   *parent,
-                                     OstreeRepo  **out_pkgcache,
-                                     GCancellable *cancellable,
-                                     GError      **error)
-{
-  if (!glnx_shutil_mkdir_p_at (ostree_repo_get_dfd (parent),
-                               "extensions/rpmostree", 0755,
-                               cancellable, error))
-    return FALSE;
-  g_autoptr(OstreeRepo) pkgcache =
-    ostree_repo_create_at (ostree_repo_get_dfd (parent),
-                           "extensions/rpmostree/pkgcache",
-                           OSTREE_REPO_MODE_BARE, NULL,
-                           cancellable, error);
-  if (!pkgcache)
-    return FALSE;
-
-  *out_pkgcache = g_steal_pointer (&pkgcache);
-  return TRUE;
-}
-
 /* Loop over all deployments, gathering all referenced NEVRAs for
  * layered packages.  Then delete any cached pkg refs that aren't in
  * that set.

--- a/src/daemon/rpmostree-sysroot-core.h
+++ b/src/daemon/rpmostree-sysroot-core.h
@@ -45,12 +45,6 @@ OstreeDeployment *rpmostree_syscore_get_origin_merge_deployment (OstreeSysroot *
 
 gboolean rpmostree_syscore_bump_mtime (OstreeSysroot *self, GError **error);
 
-gboolean
-rpmostree_syscore_get_pkgcache_repo (OstreeRepo   *parent,
-                                     OstreeRepo  **out_pkgcache,
-                                     GCancellable *cancellable,
-                                     GError      **error);
-
 #define RPMOSTREE_LIVE_INPROGRESS_XATTR "user.rpmostree-live-inprogress"
 #define RPMOSTREE_LIVE_REPLACED_XATTR "user.rpmostree-live-replaced"
 


### PR DESCRIPTION
This has been dead code since we merged the pkgcache into the main
repo.  I noticed that the daemon is holding open two instances
of the system repo and came across this while trying to figure out
why.
