### PR TITLE
Add InitiatingClientDescription property to transactions

### DIFF
--- a/src/app/rpmostree-builtin-status.c
+++ b/src/app/rpmostree-builtin-status.c
@@ -362,6 +362,11 @@ print_daemon_state (RPMOSTreeSysroot *sysroot_proxy,
     {
       const char *title = rpmostree_transaction_get_title (txn_proxy);
       g_print ("Transaction: %s\n", title);
+      const char *client = rpmostree_transaction_get_initiating_client_description (txn_proxy);
+      if (client && *client)
+        {
+          g_print ("  Initiator: %s\n", client);
+        }
     }
 
   return TRUE;

--- a/src/daemon/org.projectatomic.rpmostree1.xml
+++ b/src/daemon/org.projectatomic.rpmostree1.xml
@@ -390,6 +390,9 @@
     <!-- A single-line human-readable string -->
     <property name="Title" type="s" access="read"/>
 
+    <!-- Description of client that started the txn -->
+    <property name="InitiatingClientDescription" type="s" access="read"/>
+
     <!-- Yes, we can. -->
     <method name="Cancel"/>
 

--- a/src/daemon/rpmostreed-transaction.h
+++ b/src/daemon/rpmostreed-transaction.h
@@ -45,6 +45,7 @@ struct _RpmostreedTransactionClass {
 GType           rpmostreed_transaction_get_type            (void) G_GNUC_CONST;
 gboolean        rpmostreed_transaction_get_active          (RpmostreedTransaction *transaction);
 OstreeSysroot * rpmostreed_transaction_get_sysroot         (RpmostreedTransaction *transaction);
+const char *    rpmostreed_transaction_get_client          (RpmostreedTransaction *transaction);
 GDBusMethodInvocation *
                 rpmostreed_transaction_get_invocation      (RpmostreedTransaction *transaction);
 const char *    rpmostreed_transaction_get_client_address  (RpmostreedTransaction *transaction);


### PR DESCRIPTION
And render it in status, so if the daemon is doing something
we know who started it.  I'm doing this specifically because
gnome-software defaults to running `RefreshMd` but it's not
obvious that is happening.
