### PR TITLE
unpacker: Add support for zstd

### DIFF
--- a/src/libpriv/rpmostree-unpacker-core.c
+++ b/src/libpriv/rpmostree-unpacker-core.c
@@ -74,6 +74,7 @@ rpmostree_unpack_rpm2cpio (int fd, GError **error)
         archive_read_support_filter_gzip,
         archive_read_support_filter_xz,
         archive_read_support_filter_bzip2,
+        archive_read_support_filter_zstd,
         archive_read_support_format_cpio };
 
     for (i = 0; i < G_N_ELEMENTS (archive_setup_funcs); i++)


### PR DESCRIPTION
Fedora rawhide has switched its RPM payload compression to zstd:
https://fedoraproject.org/wiki/Changes/Switch_RPMs_to_zstd_compression

See also https://bugzilla.redhat.com/show_bug.cgi?id=1728346.