### PR TITLE
treefile: Support multiple includes

### DIFF
--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -216,11 +216,13 @@ It supports the following parameters:
    are provided, then `postprocess-script` will be executed after all
    other `postprocess`.
 
- * `include`: string, optional: Path to another treefile which will be
+ * `include`: string or array of string, optional: Path(s) to treefiles which will be
    used as an inheritance base.  The semantics for inheritance are:
    Non-array values in child values override parent values.  Array
    values are concatenated.  Filenames will be resolved relative to
-   the including treefile.
+   the including treefile.  Since rpm-ostree 2019.5, this value may
+   also be an array of strings.  Including the same file multiple times
+   is an error.
 
  * `container`: boolean, optional: Defaults to `false`.  If `true`, then
    rpm-ostree will not do any special handling of kernel, initrd or the

--- a/tests/compose-tests/test-misc-tweaks.sh
+++ b/tests/compose-tests/test-misc-tweaks.sh
@@ -6,15 +6,20 @@ dn=$(cd $(dirname $0) && pwd)
 . ${dn}/libcomposetest.sh
 
 prepare_compose_test "misc-tweaks"
-# No docs
-pysetjsonmember "documentation" "False"
+# No docs, also test multi includes
+cat >composedata/documentation.yaml <<'EOF'
+documentation: false
+EOF
+cat > composedata/recommends.yaml <<'EOF'
+recommends: false
+EOF
+pysetjsonmember "include" '["documentation.yaml", "recommends.yaml"]'
 # Note this overrides:
 # $ rpm -q systemd
 # systemd-238-8.git0e0aa59.fc28.x86_64
 # $ rpm -qlv systemd|grep -F 'system/default.target '
 # lrwxrwxrwx    1 root    root                       16 May 11 06:59 /usr/lib/systemd/system/default.target -> graphical.target
 pysetjsonmember "default_target" '"multi-user.target"'
-pysetjsonmember "recommends" 'False'
 pysetjsonmember "units" '["tuned.service"]'
 # And test adding/removing files
 pysetjsonmember "add-files" '[["foo.txt", "/usr/etc/foo.txt"],


### PR DESCRIPTION
I'm working on having Silverblue inherit from Fedora CoreOS.  But
conceptually it also inherits from (parts of) Workstation.
It is just easier if we support multiple inheritance, then I don't
need to think too hard about how to make it a single inheritance chain.
