### PR TITLE
compose: Add --parent option

### DIFF
--- a/src/app/rpmostree-compose-builtin-rojig.c
+++ b/src/app/rpmostree-compose-builtin-rojig.c
@@ -568,7 +568,7 @@ impl_write_rojig (RpmOstreeRojigCompose *self,
   if (!rpmostree_composeutil_write_composejson (self->repo,
                                                 opt_write_composejson_to, &stats,
                                                 new_revision, new_commit, &composemeta_builder,
-                                                error))
+                                                cancellable, error))
     return FALSE;
 
   return TRUE;

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -1130,7 +1130,7 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
                                                 opt_write_composejson_to, statsp,
                                                 new_revision, new_commit,
                                                 &composemeta_builder,
-                                                error))
+                                                cancellable, error))
     return FALSE;
 
   if (opt_write_commitid_to)

--- a/src/app/rpmostree-compose-builtin-tree.c
+++ b/src/app/rpmostree-compose-builtin-tree.c
@@ -79,6 +79,7 @@ static char *opt_write_composejson_to;
 static gboolean opt_no_parent;
 static char *opt_write_lockfile;
 static char **opt_read_lockfiles;
+static char *opt_parent;
 
 /* shared by both install & commit */
 static GOptionEntry common_option_entries[] = {
@@ -116,6 +117,7 @@ static GOptionEntry commit_option_entries[] = {
   { "write-commitid-to", 0, 0, G_OPTION_ARG_STRING, &opt_write_commitid_to, "File to write the composed commitid to instead of updating the ref", "FILE" },
   { "write-composejson-to", 0, 0, G_OPTION_ARG_STRING, &opt_write_composejson_to, "Write JSON to FILE containing information about the compose run", "FILE" },
   { "no-parent", 0, 0, G_OPTION_ARG_NONE, &opt_no_parent, "Always commit without a parent", NULL },
+  { "parent", 0, 0, G_OPTION_ARG_STRING, &opt_parent, "Commit with specific parent", "REV" },
   { NULL }
 };
 
@@ -1068,7 +1070,12 @@ impl_commit_tree (RpmOstreeTreeComposeContext *self,
     }
 
   g_autofree char *parent_revision = NULL;
-  if (self->ref && !opt_no_parent)
+  if (opt_parent)
+    {
+      if (!ostree_repo_resolve_rev (self->repo, opt_parent, FALSE, &parent_revision, error))
+        return FALSE;
+    }
+  else if (self->ref && !opt_no_parent)
     {
       if (!ostree_repo_resolve_rev (self->repo, self->ref, TRUE, &parent_revision, error))
         return FALSE;

--- a/src/app/rpmostree-composeutil.c
+++ b/src/app/rpmostree-composeutil.c
@@ -374,6 +374,7 @@ rpmostree_composeutil_write_composejson (OstreeRepo  *repo,
                                          const char *new_revision,
                                          GVariant   *new_commit,
                                          GVariantBuilder *builder,
+                                         GCancellable *cancellable,
                                          GError    **error)
 {
   g_autoptr(GVariant) new_commit_inline_meta = g_variant_get_child_value (new_commit, 0);
@@ -432,14 +433,14 @@ rpmostree_composeutil_write_composejson (OstreeRepo  *repo,
       /* don't error if the parent doesn't exist */
       gboolean parent_exists;
       if (!ostree_repo_has_object (repo, OSTREE_OBJECT_TYPE_COMMIT, parent_revision,
-                                   &parent_exists, NULL, error))
+                                   &parent_exists, cancellable, error))
         return FALSE;
 
       if (parent_exists)
         {
           g_autoptr(GVariant) diffv = NULL;
           if (!rpm_ostree_db_diff_variant (repo, parent_revision, new_revision,
-                                           TRUE, &diffv, NULL, error))
+                                           TRUE, &diffv, cancellable, error))
             return FALSE;
           g_variant_builder_add (builder, "{sv}", "pkgdiff", diffv);
         }
@@ -460,7 +461,7 @@ rpmostree_composeutil_write_composejson (OstreeRepo  *repo,
         return FALSE;
       g_autoptr(GOutputStream) out = g_unix_output_stream_new (tmpf.fd, FALSE);
       /* See also similar code in status.c */
-      if (json_generator_to_stream (generator, out, NULL, error) <= 0
+      if (json_generator_to_stream (generator, out, cancellable, error) <= 0
           || (error != NULL && *error != NULL))
         return FALSE;
 

--- a/src/app/rpmostree-composeutil.h
+++ b/src/app/rpmostree-composeutil.h
@@ -71,6 +71,7 @@ rpmostree_composeutil_write_composejson (OstreeRepo  *repo,
                                          const char *new_revision,
                                          GVariant   *new_commit,
                                          GVariantBuilder *builder,
+                                         GCancellable *cancellable,
                                          GError    **error);
 
 G_END_DECLS

--- a/tests/compose-tests/libbasic-test.sh
+++ b/tests/compose-tests/libbasic-test.sh
@@ -108,4 +108,9 @@ echo "ok compose pkglist"
 ostree --repo=${repobuild} cat ${treeref} /usr/share/rpm-ostree/treefile.json > treefile.json
 assert_jq treefile.json '.basearch == "x86_64"'
 echo "ok basearch"
+
+ostree --repo=${repobuild} rev-parse ${treeref}^ > parent.txt
+assert_file_has_content parent.txt 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+echo "ok --parent"
 }
+

--- a/tests/compose-tests/test-basic-unified.sh
+++ b/tests/compose-tests/test-basic-unified.sh
@@ -25,7 +25,9 @@ cat > metadata.json <<EOF
   "overrideme": "new val"
 }
 EOF
-runcompose --ex-unified-core --add-metadata-from-json metadata.json
+# Test --parent at the same time (hash is `echo | sha256sum`)
+runcompose --ex-unified-core --add-metadata-from-json metadata.json \
+  --parent 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 
 # Run it again, but without RPMOSTREE_PRESERVE_TMPDIR. Should be a no-op. This
 # exercises fd handling in the tree context.

--- a/tests/compose-tests/test-basic.sh
+++ b/tests/compose-tests/test-basic.sh
@@ -17,7 +17,9 @@ cat > metadata.json <<EOF
   "overrideme": "new val"
 }
 EOF
-runcompose --add-metadata-from-json metadata.json
+# Test --parent at the same time (hash is `echo | sha256sum`)
+runcompose --add-metadata-from-json metadata.json \
+  --parent 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
 
 . ${dn}/libbasic-test.sh
 basic_test


### PR DESCRIPTION
This may seem like a backflip on #1829, but there's a common theme here:
in a promotion workflow, the parent (or lack of parent) of a commit is
an important parameter, so we need full flexibility in configuring it.

But again, like #1829, we still want e.g. change detection, versioning,
and various optimizations to happen on whatever the latest commit on
that ref is in the build repo.