### PR TITLE
postprocess: Quote OSTREE_VERSION value

### DIFF
--- a/src/libpriv/rpmostree-postprocess.c
+++ b/src/libpriv/rpmostree-postprocess.c
@@ -1476,8 +1476,9 @@ mutate_os_release (const char    *contents,
       g_string_append_printf (new_contents, "%s\n", line);
     }
 
-  /* add a bona fide ostree entry */
-  g_string_append_printf (new_contents, "OSTREE_VERSION=%s\n", next_version);
+  /* Add a bona fide ostree entry. Quote it as a precaution */
+  g_autofree char *quoted_version = g_shell_quote (next_version);
+  g_string_append_printf (new_contents, "OSTREE_VERSION=%s\n", quoted_version);
 
   return g_string_free (new_contents, FALSE);
 }

--- a/tests/compose-tests/test-mutate-os-release.sh
+++ b/tests/compose-tests/test-mutate-os-release.sh
@@ -37,7 +37,7 @@ ostree --repo=${repobuild} cat ${treeref} \
 # VERSION_ID *shouldn't* change
 # (https://github.com/projectatomic/rpm-ostree/pull/433)
 assert_file_has_content os-release.prop VERSION_ID=${releasever}
-assert_file_has_content os-release.prop OSTREE_VERSION=${releasever}.444
+assert_file_has_content os-release.prop OSTREE_VERSION=\'${releasever}.444\'
 assert_file_has_content os-release.prop 'VERSION="'${releasever}'\.444 (Atomic '
 echo "ok mutate-os-release-cli"
 
@@ -55,6 +55,6 @@ ostree --repo=${repobuild} cat ${treeref} \
 # VERSION_ID *shouldn't* change
 # (https://github.com/projectatomic/rpm-ostree/pull/433)
 assert_file_has_content os-release.prop VERSION_ID=${releasever}
-assert_file_has_content os-release.prop OSTREE_VERSION=${releasever}.555
+assert_file_has_content os-release.prop OSTREE_VERSION=\'${releasever}.555\'
 assert_file_has_content os-release.prop 'VERSION="'${releasever}'\.555 (Atomic '
 echo "ok mutate-os-release (auto)"


### PR DESCRIPTION
Quote the value set for OSTREE_VERSION in /etc/os-release as this is an
arbitrary string set at compose time that may contain whitespace.

This edge case was found in [0] as the compose are built with the
following command:

  $ rpm-ostree compose tree \
      --repo="repo" \
      --cachedir="cache" \
      --add-metadata-string="version=Kinoite 30.23" \
      "fedora-kinoite.yaml"

[0] https://discussion.fedoraproject.org/t/kinoite-a-kde-and-now-xfce-version-of-fedora-silverblue/147/95

Signed-off-by: Timothée Ravier <tim@siosm.fr>

Note: I have not fully tested this (minor) change yet.