### PR TITLE
Release 2019.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ dnl Then git push origin v201X.XX.
 dnl Then create the xz tarball from `make -f Makefile.dist-packaging dist-snapshot`.
 dnl Then create a GitHub release for the new release tag and attach the tarball.
 m4_define([year_version], [2019])
-m4_define([release_version], [4])
+m4_define([release_version], [5])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([rpm-ostree], [package_version], [atomic-devel@projectatomic.io])
 AC_CONFIG_HEADER([config.h])


### PR DESCRIPTION
I think we're in a good position now for FCOS enablement, and there are
a bunch of fixes we should get out, such as the zstd one.