### PR TITLE
app/deploy: Add --disallow-downgrade switch

### DIFF
--- a/src/app/rpmostree-builtin-deploy.c
+++ b/src/app/rpmostree-builtin-deploy.c
@@ -33,6 +33,7 @@ static gboolean opt_preview;
 static gboolean opt_cache_only;
 static gboolean opt_download_only;
 static gboolean opt_lock_finalization;
+static gboolean opt_disallow_downgrade;
 
 static GOptionEntry option_entries[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
@@ -45,6 +46,7 @@ static GOptionEntry option_entries[] = {
   { "cache-only", 'C', 0, G_OPTION_ARG_NONE, &opt_cache_only, "Do not download latest ostree and RPM data", NULL },
   { "download-only", 0, 0, G_OPTION_ARG_NONE, &opt_download_only, "Just download latest ostree and RPM data, don't deploy", NULL },
   { "lock-finalization", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &opt_lock_finalization, "Prevent automatic deployment finalization on shutdown", NULL },
+  { "disallow-downgrade", 0, 0, G_OPTION_ARG_NONE, &opt_disallow_downgrade, "Forbid deployment of chronologically older trees", NULL },
   { NULL }
 };
 
@@ -116,7 +118,7 @@ rpmostree_builtin_deploy (int            argc,
       GVariantDict dict;
       g_variant_dict_init (&dict, NULL);
       g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
-      g_variant_dict_insert (&dict, "allow-downgrade", "b", TRUE);
+      g_variant_dict_insert (&dict, "allow-downgrade", "b", !opt_disallow_downgrade);
       g_variant_dict_insert (&dict, "cache-only", "b", opt_cache_only);
       g_variant_dict_insert (&dict, "download-only", "b", opt_download_only);
       g_variant_dict_insert (&dict, "lock-finalization", "b", opt_lock_finalization);

--- a/src/app/rpmostree-builtin-rebase.c
+++ b/src/app/rpmostree-builtin-rebase.c
@@ -41,6 +41,7 @@ static char * opt_custom_origin_description;
 static gboolean opt_cache_only;
 static gboolean opt_download_only;
 static gboolean opt_experimental;
+static gboolean opt_disallow_downgrade;
 
 static GOptionEntry option_entries[] = {
   { "os", 0, 0, G_OPTION_ARG_STRING, &opt_osname, "Operate on provided OSNAME", "OSNAME" },
@@ -53,6 +54,7 @@ static GOptionEntry option_entries[] = {
   { "custom-origin-description", 0, 0, G_OPTION_ARG_STRING, &opt_custom_origin_description, "Human-readable description of custom origin", NULL },
   { "custom-origin-url", 0, 0, G_OPTION_ARG_STRING, &opt_custom_origin_url, "Machine-readable description of custom origin", NULL },
   { "experimental", 0, 0, G_OPTION_ARG_NONE, &opt_experimental, "Enable experimental features", NULL },
+  { "disallow-downgrade", 0, 0, G_OPTION_ARG_NONE, &opt_disallow_downgrade, "Forbid deployment of chronologically older trees", NULL },
   { NULL }
 };
 
@@ -163,7 +165,7 @@ rpmostree_builtin_rebase (int             argc,
   GVariantDict dict;
   g_variant_dict_init (&dict, NULL);
   g_variant_dict_insert (&dict, "reboot", "b", opt_reboot);
-  g_variant_dict_insert (&dict, "allow-downgrade", "b", TRUE);
+  g_variant_dict_insert (&dict, "allow-downgrade", "b", !opt_disallow_downgrade);
   g_variant_dict_insert (&dict, "cache-only", "b", opt_cache_only);
   g_variant_dict_insert (&dict, "download-only", "b", opt_download_only);
   g_variant_dict_insert (&dict, "skip-purge", "b", opt_skip_purge);

--- a/src/daemon/rpmostreed-transaction-types.c
+++ b/src/daemon/rpmostreed-transaction-types.c
@@ -1580,7 +1580,7 @@ rpmostreed_transaction_new_deploy (GDBusMethodInvocation *invocation,
   self->override_remove_pkgs = vardict_lookup_strv_canonical (self->modifiers, "override-remove-packages");
   self->override_reset_pkgs = vardict_lookup_strv_canonical (self->modifiers, "override-reset-packages");
 
-  /* default to allowing downgrades for rebases & deploys */
+  /* default to allowing downgrades for rebases & deploys (without --disallow-downgrade) */
   if (vardict_lookup_bool (self->options, "allow-downgrade", refspec_or_revision))
     self->flags |= RPMOSTREE_TRANSACTION_DEPLOY_FLAG_ALLOW_DOWNGRADE;
 


### PR DESCRIPTION
In FCOS, we want to make sure that Zincati is always deploying a newer
tree to prevent downgrade attacks in certain threat models.

For completeness, also add the option to `rebase`.

Need to add tests for this.