### PR TITLE
treefile: Support `arch-include`

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -29,7 +29,7 @@ host:
 tests:
   - ./ci/f29-cosa-build.sh
 
-timeout: 60m
+timeout: 120m
 
 ---
 

--- a/docs/manual/treefile.md
+++ b/docs/manual/treefile.md
@@ -224,6 +224,22 @@ It supports the following parameters:
    also be an array of strings.  Including the same file multiple times
    is an error.
 
+ * `arch-include`: object (`Map<String,include>`), optional: Each member of this
+   object should be the name of a base architecture (`$basearch`), and the `include` value
+   functions the same as the `include` key above - it can be either
+   a single string, or an array of strings - and it has the same semantics.
+   Entries which match `arch-include` are processed after `include`.
+
+   Example (in YAML):
+
+   ```yaml
+   arch-include:
+     x86_64: bootloader-x86_64.yaml
+     s390x:
+       - bootloader-s390x.yaml
+       - tweaks-s390x.yaml
+    ```
+
  * `container`: boolean, optional: Defaults to `false`.  If `true`, then
    rpm-ostree will not do any special handling of kernel, initrd or the
    /boot directory. This is useful if the target for the tree is some kind

--- a/rust/src/treefile.rs
+++ b/rust/src/treefile.rs
@@ -1104,6 +1104,24 @@ rojig:
     }
 
     #[test]
+    fn test_treefile_includes() -> Fallible<()> {
+        let workdir = tempfile::tempdir()?;
+        utils::write_file(workdir.path().join("foo.yaml"), |b| {
+            let foo = r#"
+packages:
+  - fooinclude
+"#;
+            b.write_all(foo.as_bytes())?; Ok(()) })?;
+        let mut buf = VALID_PRELUDE.to_string();
+        buf.push_str(r#"
+include: foo.yaml
+"#);
+        let tf = new_test_treefile(workdir.path(), buf.as_str(), None)?;
+        assert!(tf.parsed.packages.unwrap().len() == 4);
+        Ok(())
+    }
+
+    #[test]
     fn test_treefile_merge() {
         let basearch = Some(ARCH_X86_64);
         let mut base = append_and_parse(


### PR DESCRIPTION
A long time ago we added architecture-specific package lists
via e.g. `packages-ppc64le`.  Much more recently we added
support for having the `include` key be a list - multiple includes.

By combining these two and supporting architecture-conditional includes,
we've effectively added architecture-conditionals to *all* keys.

Notably we want this for Fedora CoreOS today which is using
`remove-from-packages` on `grub2-tools` which isn't present on
s390x.
