### PR TITLE
importer: Add some error prefixing

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -27,7 +27,7 @@ host:
   distro: fedora/29/atomic
 
 tests:
-  - ./ci/f29-cosa-build.sh
+  - ./ci/cosa-build.sh
 
 timeout: 120m
 

--- a/ci/cosa-build.sh
+++ b/ci/cosa-build.sh
@@ -7,10 +7,11 @@ cosaimg=quay.io/coreos-assembler/coreos-assembler:latest
 podman pull "${cosaimg}"
 
 # Build rpm-ostree using cosa as a buildroot, and extract the result
-podman run --privileged --rm \
+podman run --security-opt label=disable --rm \
        -v $(pwd):/srv/code -w /srv/code \
+       --entrypoint bash --user root \
        "${cosaimg}" \
-       /bin/sh -c './ci/build.sh && make install DESTDIR=$(pwd)/installroot'
+       -c 'yum -y swap fedora-release-container fedora-release && ./ci/build.sh && make install DESTDIR=$(pwd)/installroot'
 
 codedir=$(pwd)
 mkdir fcos

--- a/src/libpriv/rpmostree-importer.c
+++ b/src/libpriv/rpmostree-importer.c
@@ -884,7 +884,7 @@ import_rpm_to_repo (RpmOstreeImporter *self,
   g_autoptr(OstreeMutableTree) mtree = ostree_mutable_tree_new ();
   if (!ostree_repo_import_archive_to_mtree (repo, &opts, self->archive, mtree,
                                             modifier, cancellable, error))
-    return FALSE;
+    return glnx_prefix_error (error, "Importing archive");
 
   /* check if any of the cbs set an error */
   if (cb_error != NULL)
@@ -921,7 +921,7 @@ import_rpm_to_repo (RpmOstreeImporter *self,
 
       if (!ostree_repo_write_dfd_to_mtree (repo, tmpdir.fd, ".", mtree, modifier,
                                            cancellable, error))
-        return FALSE;
+        return glnx_prefix_error (error, "Writing tmpfiles mtree");
 
       /* check if any of the cbs set an error */
       if (cb_error != NULL)
@@ -933,7 +933,7 @@ import_rpm_to_repo (RpmOstreeImporter *self,
 
   g_autoptr(GFile) root = NULL;
   if (!ostree_repo_write_mtree (repo, mtree, &root, cancellable, error))
-    return FALSE;
+    return glnx_prefix_error (error, "Writing mtree");
 
   g_autoptr(GVariant) metadata = NULL;
   if (!build_metadata_variant (self, &metadata, cancellable, error))
@@ -949,7 +949,7 @@ import_rpm_to_repo (RpmOstreeImporter *self,
   if (!ostree_repo_write_commit_with_time (repo, NULL, "", "", metadata,
                                            OSTREE_REPO_FILE (root), buildtime,
                                            out_csum, cancellable, error))
-    return FALSE;
+    return glnx_prefix_error (error, "Writing commit");
 
   return TRUE;
 }
@@ -967,8 +967,7 @@ rpmostree_importer_run (RpmOstreeImporter *self,
   if (!import_rpm_to_repo (self, &csum, cancellable, error))
     {
       g_autofree char *name = headerGetAsString (self->hdr, RPMTAG_NAME);
-      g_prefix_error (error, "Importing package %s: ", name);
-      return FALSE;
+      return glnx_prefix_error (error, "Importing package '%s'", name);
     }
 
   const char *branch = rpmostree_importer_get_ostree_branch (self);


### PR DESCRIPTION
I was debugging a failure in cosa when running in unprivleged podman,
with this patch the error is:
`error: Importing package 'alternatives': Writing tmpfiles mtree: llistxattr: Is a directory`

And that finally made it obvious to me that the problem is not using
tmpfs for `/tmp` (well, this is a bug in fuse-overlayfs).

Anyways, let's prefix errors some more on general principle.
