### PR TITLE
Jenkins prep and cleanup patches

### DIFF
--- a/ci/ci-commitmessage-submodules.sh
+++ b/ci/ci-commitmessage-submodules.sh
@@ -16,9 +16,9 @@ dn=$(dirname $0)
 # It's very common for people to accidentally change submodules, and having this
 # requirement is a small hurdle to pass.
 
-# if running under PAPR, use the branch/PR HEAD actually
-# being tested rather than the merge sha
-HEAD=${PAPR_COMMIT:-HEAD}
+# If passed the commit, use that. Otherwise, if running under PAPR, use the
+# branch/PR HEAD actually being tested rather than the merge sha
+HEAD=${1:-${PAPR_COMMIT:-HEAD}}
 
 tmpd=$(mktemp -d)
 touch ${tmpd}/.tmpdir

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -22,6 +22,8 @@ fi
 
 pkg_upgrade
 pkg_install_builddeps rpm-ostree
+# and we have the canonical spec file handy so just builddep from that too
+dnf builddep --spec -y packaging/rpm-ostree.spec.in
 # Mostly dependencies for tests
 pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq python3-pyyaml \
     libubsan libasan libtsan elfutils fuse sudo python3-gobject-base \

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -21,9 +21,6 @@ fi
 
 pkg_upgrade
 pkg_install_builddeps rpm-ostree
-# XXX: new libdnf deps until next release
-pkg_install json-c-devel cppunit{,-devel} swig sqlite-devel \
-    libmodulemd1-devel libsmartcols-devel gpgme-devel
 # Mostly dependencies for tests
 pkg_install ostree{,-devel,-grub2} createrepo_c /usr/bin/jq python3-pyyaml \
     libubsan libasan libtsan elfutils fuse sudo python3-gobject-base \

--- a/ci/installdeps.sh
+++ b/ci/installdeps.sh
@@ -6,10 +6,11 @@ set -xeuo pipefail
 dn=$(dirname $0)
 . ${dn}/libbuild.sh
 
-# Use the latest ostree by default
+# Use the latest ostree by default (XXX: currently pulling in f29 ostree, need
+# to bump rdgo to f30 or wait for packit)
 id=$(. /etc/os-release && echo $ID)
 version_id=$(. /etc/os-release && echo $VERSION_ID)
-if [ "$id" == fedora ] && [ "$version_id" == 29 ]; then
+if [ "$id" == fedora ] && [ "$version_id" -ge 29 ]; then
     echo -e '[fahc]\nmetadata_expire=1m\nbaseurl=https://ci.centos.org/artifacts/sig-atomic/fahc/rdgo/build/\ngpgcheck=0\n' > /etc/yum.repos.d/fahc.repo
     # Until we fix https://github.com/rpm-software-management/libdnf/pull/149
     excludes='exclude=ostree ostree-libs ostree-grub2 rpm-ostree'

--- a/ci/libbuild.sh
+++ b/ci/libbuild.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/bash
 
 pkg_upgrade() {
-    echo "Running yum -y distro-sync... $(date)"
-    yum -y distro-sync
-    echo "Done yum -y distro-sync! $(date)"
+    echo "Running dnf -y distro-sync... $(date)"
+    dnf -y distro-sync
+    echo "Done dnf -y distro-sync! $(date)"
 }
 
 make() {
@@ -17,21 +17,9 @@ build() {
 }
 
 pkg_install() {
-    echo "Running yum -y install... $(date)"
-    yum -y install "$@"
-    echo "Done running yum -y install! $(date)"
-}
-
-pkg_install_if_os() {
-    os=$1
-    shift
-    (. /etc/os-release;
-         if test "${os}" = "${ID}"; then
-            pkg_install "$@"
-         else
-             echo "Skipping installation on OS ${ID}: $@"
-         fi
-    )
+    echo "Running dnf -y install... $(date)"
+    dnf -y install "$@"
+    echo "Done running dnf -y install! $(date)"
 }
 
 pkg_builddep() {
@@ -46,16 +34,11 @@ pkg_builddep() {
 }
 
 pkg_install_builddeps() {
-    pkg=$1
-    if test -x /usr/bin/dnf; then
-        pkg_install dnf-plugins-core 'dnf-command(builddep)'
-        # Base buildroot
-        pkg_install @buildsys-build
-    else
-        pkg_install yum-utils
-        # Base buildroot, copied from the mock config sadly
-        pkg_install bash bzip2 coreutils cpio diffutils system-release findutils gawk gcc gcc-c++ grep gzip info make patch redhat-rpm-config rpm-build sed shadow-utils tar unzip util-linux which xz
-    fi
+    local pkg=$1
+    pkg_install dnf-plugins-core 'dnf-command(builddep)'
+    # Base buildroot (but exclude fedora-release, conflicts with -container:
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1649921)
+    pkg_install @buildsys-build --excludepkg fedora-release
     # builddeps+runtime deps
     pkg_builddep $pkg
     pkg_install $pkg

--- a/packaging/Makefile.dist-packaging
+++ b/packaging/Makefile.dist-packaging
@@ -12,17 +12,7 @@ PKG_CLIENT_VER = $(PACKAGE)-client-$(GITREV_FOR_PKG)
 dist-snapshot:
 	./make-git-snapshot.sh "$(srcdir)" "$(PKG_VER)" "$(GITREV)"
 	rm -f $(PKG_VER).tar.xz
-	xz $(PKG_VER).tar 
-
-dist-snapshot-without-compose-tooling:
-	./make-git-snapshot.sh "$(srcdir)" "$(PKG_CLIENT_VER)" "$(GITREV)"; \
-	rm tmp -rf; \
-	mkdir tmp; \
-	tar -C tmp -x "--exclude=$(PKG_CLIENT_VER)/src/*compose*" -f $(PKG_CLIENT_VER).tar; \
-	(cd tmp && tar -cf ../$(PKG_CLIENT_VER).tar.filtered *); \
-	mv $(PKG_CLIENT_VER).tar{.filtered,}; \
-	rm -f $(PKG_CLIENT_VER).tar.xz; \
-	xz $(PKG_CLIENT_VER).tar 
+	xz -T0 $(PKG_VER).tar
 
 srpm: dist-snapshot
 	 sed -e "s,^Version:.*,Version: $(GITREV_FOR_PKG)," $(PACKAGE).spec.in > $(PACKAGE).spec; \

--- a/packaging/Makefile.dist-packaging
+++ b/packaging/Makefile.dist-packaging
@@ -20,5 +20,7 @@ srpm: dist-snapshot
 
 rpm: srpm
 	./rpmbuild-cwd --rebuild $(PKG_VER)*.src.rpm
-	repomanage -o | xargs -r rm
+
+yumrepo: rpm
+	repomanage -o . | xargs -r rm
 	createrepo_c .

--- a/packaging/make-git-snapshot.sh
+++ b/packaging/make-git-snapshot.sh
@@ -40,7 +40,7 @@ mkdir ${tmpd} && touch ${tmpd}/.tmp
 
 (cd ${tmpd}
  mkdir -p .cargo vendor
- cargo vendor -q --sync ${TOP}/rust/Cargo.toml vendor
+ (cd ${TOP}/rust && cargo vendor ${tmpd}/vendor)
  cp ${TOP}/rust/Cargo.lock .
  cp ${TOP}/rust/cargo-vendor-config .cargo/config
  # Filter out bundled libcurl and systemd; we always want the pkgconfig ones

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -172,7 +172,7 @@ $PYTHON autofiles.py > files.devel \
   '%{_datadir}/gir-1.0/*-1.0.gir'
 
 %files -f files
-%doc COPYING README.md
+%doc COPYING.GPL COPYING.LGPL LICENSE README.md
 
 %files libs -f files.lib
 

--- a/packaging/rpm-ostree.spec.in
+++ b/packaging/rpm-ostree.spec.in
@@ -1,12 +1,29 @@
+# The canonical copy of this spec file is upstream at:
+# https://github.com/projectatomic/rpm-ostree/blob/master/packaging/rpm-ostree.spec.in
+
 Summary: Hybrid image/package system
 Name: rpm-ostree
-Version: 2017.3
+Version: 2019.5
 Release: 1%{?dist}
 #VCS: https://github.com/cgwalters/rpm-ostree
-# This tarball is generated via "make -f Makefile.dist-packaging dist-snapshot"
+# This tarball is generated via "cd packaging && make -f Makefile.dist-packaging dist-snapshot"
+# in the upstream git.  If rust is enabled, it contains vendored sources.
 Source0: rpm-ostree-%{version}.tar.xz
 License: LGPLv2+
 URL: https://github.com/projectatomic/rpm-ostree
+
+ExclusiveArch: %{rust_arches}
+
+%if 0%{?fedora}
+BuildRequires: cargo
+BuildRequires: rust
+%else
+# assume el8
+BuildRequires: rust-toolset
+%endif
+
+# For the autofiles bits below
+BuildRequires: /usr/bin/python3
 # We always run autogen.sh
 BuildRequires: autoconf automake libtool git
 # For docs
@@ -14,39 +31,52 @@ BuildRequires: chrpath
 BuildRequires: gtk-doc
 BuildRequires: gperf
 BuildRequires: gnome-common
-BuildRequires: gobject-introspection
+BuildRequires: /usr/bin/g-ir-scanner
 # Core requirements
-BuildRequires: pkgconfig(ostree-1) >= 2017.2
+# One way to check this: `objdump -p /path/to/rpm-ostree | grep LIBOSTREE` and pick the highest (though that might miss e.g. new struct members)
+BuildRequires: pkgconfig(ostree-1) >= 2019.2
+BuildRequires: pkgconfig(polkit-gobject-1)
 BuildRequires: pkgconfig(json-glib-1.0)
 BuildRequires: pkgconfig(rpm)
 BuildRequires: pkgconfig(libarchive)
 BuildRequires: pkgconfig(libsystemd)
-BuildRequires: pkgconfig(polkit-gobject-1)
 BuildRequires: libcap-devel
 BuildRequires: libattr-devel
 
 # We currently interact directly with librepo
 BuildRequires: pkgconfig(librepo)
 
+# Needed by curl-rust
+BuildRequires: pkgconfig(libcurl)
+
 # libdnf bundling
 # We're using RPATH to pick up our bundled version
 %global __requires_exclude ^libdnf[.]so[.].*$
 
+# Our bundled libdnf.so.2 is for us only
+%global __provides_exclude_from ^%{_libdir}/%{name}/.*$
+
 BuildRequires: cmake
 BuildRequires: pkgconfig(expat)
 BuildRequires: pkgconfig(check)
-BuildRequires: python-devel
-BuildRequires: python-sphinx
-%if (0%{?rhel} != 0 && 0%{?rhel} <= 7)
-BuildRequires: libsolv-devel
-%else
 BuildRequires: pkgconfig(libsolv)
-%endif
 
-# In CentOS7/RHEL the package is client-only right now, but we can do both
-%if 0%{?rhel} != 0 && 0%{?rhel} <= 7
-Provides: rpm-ostree-client
-%endif
+# We need g++ for libdnf
+BuildRequires: gcc-c++
+
+
+# more libdnf build deps (see libdnf's spec for versions)
+%global swig_version 3.0.12
+%global libmodulemd_version 1.6.1
+BuildRequires:  swig >= %{swig_version}
+BuildRequires:  pkgconfig(modulemd) >= %{libmodulemd_version}
+BuildRequires:  pkgconfig(json-c)
+BuildRequires:  pkgconfig(cppunit)
+BuildRequires:  pkgconfig(sqlite3)
+BuildRequires:  pkgconfig(smartcols)
+BuildRequires:  gpgme-devel
+
+Requires:       libmodulemd1%{?_isa} >= %{libmodulemd_version}
 
 # For now...see https://github.com/projectatomic/rpm-ostree/pull/637
 # and https://github.com/fedora-infra/fedmsg-atomic-composer/pull/17
@@ -56,6 +86,8 @@ Requires: ostree
 Requires: bubblewrap
 Requires: fuse
 
+Requires: %{name}-libs%{?_isa} = %{version}-%{release}
+
 %description
 rpm-ostree is a hybrid image/package system.  It supports
 "composing" packages on a build server into an OSTree repository,
@@ -64,13 +96,18 @@ Additionally, unlike many "pure" image systems, with rpm-ostree
 each client system can layer on additional packages, providing
 a "best of both worlds" approach.
 
+%package libs
+Summary: Shared library for rpm-ostree
+
+%description libs
+The %{name}-libs package includes the shared library for %{name}.
+
 %package devel
 Summary: Development headers for %{name}
-Group: Development/Libraries
-Requires: %{name} = %{version}-%{release}
+Requires: %{name}-libs%{?_isa} = %{version}-%{release}
 
 %description devel
-The %{name}-devel package includes the header files for the %{name} library.
+The %{name}-devel package includes the header files for %{name}-libs.
 
 %prep
 %autosetup -Sgit -n %{name}-%{version}
@@ -91,7 +128,6 @@ find $RPM_BUILD_ROOT -name '*.la' -delete
 # way the same spec file works more easily across multiple versions where e.g. an
 # older version might not have a systemd unit file.
 cat > autofiles.py <<EOF
-#!/usr/bin/python
 import os,sys,glob
 os.chdir(os.environ['RPM_BUILD_ROOT'])
 for line in sys.argv[1:]:
@@ -107,20 +143,30 @@ for line in sys.argv[1:]:
         else:
             sys.stderr.write('{0} did not match any files\n'.format(line))
 EOF
-python autofiles.py > files \
+PYTHON=python3
+if ! test -x /usr/bin/python3; then
+    PYTHON=python2
+fi
+$PYTHON autofiles.py > files \
   '%{_bindir}/*' \
   '%{_libdir}/%{name}' \
-  '%{_libdir}/*.so.*' \
   '%{_mandir}/man*/*' \
-  '%{_libdir}/girepository-1.0/*.typelib' \
   '%{_sysconfdir}/dbus-1/system.d/*' \
+  '%{_sysconfdir}/rpm-ostreed.conf' \
   '%{_prefix}/lib/systemd/system/*' \
   '%{_libexecdir}/rpm-ostree*' \
+  '%{_datadir}/polkit-1/actions/*.policy' \
   '%{_datadir}/dbus-1/system-services' \
-  '%{_datadir}/polkit-1/actions/org.projectatomic.rpmostree1.policy'
-python autofiles.py > files.devel \
+  '%{_datadir}/bash-completion/completions/*'
+
+$PYTHON autofiles.py > files.lib \
+  '%{_libdir}/*.so.*' \
+  '%{_libdir}/girepository-1.0/*.typelib'
+
+$PYTHON autofiles.py > files.devel \
   '%{_libdir}/lib*.so' \
   '%{_includedir}/*' \
+  '%{_datadir}/dbus-1/interfaces/org.projectatomic.rpmostree1.xml' \
   '%{_libdir}/pkgconfig/*' \
   '%{_datadir}/gtk-doc/html/*' \
   '%{_datadir}/gir-1.0/*-1.0.gir'
@@ -128,5 +174,6 @@ python autofiles.py > files.devel \
 %files -f files
 %doc COPYING README.md
 
-%files devel -f files.devel
+%files libs -f files.lib
 
+%files devel -f files.devel


### PR DESCRIPTION
These are prep patches for hooking up to Jenkins pipelines. Most are pretty straight-forward but there is one commit I'd like to call out specifically:

---

packaging: Move canonical spec file here

So this is a somewhat significant change, but I'd like to try having the
canonical spec file upstream. A few reasons for this:

1. We integrate tightly with the distros we're destined for, and so
   we're in a pretty good position for knowing how the software should
   be packaged.
2. We can atomically change packaging along with the rest of the code.
   This has important ramifications, including that it'll be easier to
   integrate with continuous build services like Packit, but releases
   will also be less fraught with last-minute packaging fixes.
3. I'm playing with Jenkins pipelines and there I'd like to make RPMs
   the "artifact" that gets moved down the pipeline into later stages
   (e.g. `cosa build`). We could even eventually make it an actual
   external artifact so that anyone can easily download RPMs from any
   random PR for testing. (And in fact, with a thin yumrepo layer on
   top, it could be used to replace Packit/rdgo entirely).

Not that this approach doesn't have issues as well (e.g. on the dist-git
side, we'll need some minimal tooling to merge in the changelog), though
I think it's worth trying out.